### PR TITLE
Fixed constness in arrays.h

### DIFF
--- a/arrays.h
+++ b/arrays.h
@@ -68,21 +68,23 @@ namespace BrendanCUDA {
 
     template <typename _T>
     struct Span {
-    private:
-        using arrref_t = std::conditional_t<std::is_const_v<_T>, const std::array<std::remove_const_t<_T>, _Size>&, std::array<_T, _Size>&>;
-        using vecref_t = std::conditional_t<std::is_const_v<_T>, const std::vector<std::remove_const_t<_T>>&, std::vector<_T>&>;
-    public:
         using element_t = _T;
 
         _T* ptr;
         size_t size;
+
         __host__ __device__ __forceinline Span(_T* Ptr, size_t Size)
             : ptr(Ptr), size(Size) { }
 
         template <size_t _Size>
-        __host__ __device__ __forceinline Span(arrref_t Array)
+        __host__ __device__ __forceinline Span(std::array<std::remove_const_t<_T>, _Size>& Array)
             : ptr(Array.data()), size(Array.size()) { }
-        __host__ __device__ __forceinline Span(vecref_t Vector)
+        template <size_t _Size>
+        __host__ __device__ __forceinline Span(const std::array<std::remove_const_t<_T>, _Size>& Array) requires (std::is_const_v<_T>)
+            : ptr(Array.data()), size(Array.size()) { }
+        __host__ __device__ __forceinline Span(std::vector<std::remove_const_t<_T>>& Vector)
+            : ptr(Vector.data()), size(Vector.size()) { }
+        __host__ __device__ __forceinline Span(const std::vector<std::remove_const_t<_T>>& Vector) requires (std::is_const_v<_T>)
             : ptr(Vector.data()), size(Vector.size()) { }
         __host__ __device__ __forceinline Span(const ArrayV<_T>& Array)
             : ptr(Array.Data()), size(Array.Size()) { }

--- a/arrays.h
+++ b/arrays.h
@@ -84,9 +84,9 @@ namespace BrendanCUDA {
             : ptr(Array.data()), size(Array.size()) { }
         __host__ __device__ __forceinline Span(vecref_t Vector)
             : ptr(Vector.data()), size(Vector.size()) { }
-        __host__ __device__ __forceinline Span(const ArrayV<_T>& Array) requires (std::is_const_v<_T>)
+        __host__ __device__ __forceinline Span(const ArrayV<_T>& Array)
             : ptr(Array.Data()), size(Array.Size()) { }
-        __host__ __device__ __forceinline Span(const ArrayV<std::remove_const_t<_T>>& Array)
+        __host__ __device__ __forceinline Span(const ArrayV<std::remove_const_t<_T>>& Array) requires (std::is_const_v<_T>)
             : ptr(Array.Data()), size(Array.Size()) { }
         __host__ __device__ __forceinline Span(const Span<std::remove_const_t<_T>>& Span) requires std::is_const_v<_T>
             : ptr(Span.ptr), size(Span.size) { }

--- a/arrays.h
+++ b/arrays.h
@@ -70,7 +70,7 @@ namespace BrendanCUDA {
     struct Span {
     private:
         using arrref_t = std::conditional_t<std::is_const_v<_T>, const std::array<std::remove_const_t<_T>, _Size>&, std::array<_T, _Size>&>;
-        using vecref_t = const std::vector<std::remove_const_t<_T>>&;
+        using vecref_t = std::conditional_t<std::is_const_v<_T>, const std::vector<std::remove_const_t<_T>>&, std::vector<_T>&>;
     public:
         using element_t = _T;
 

--- a/arrays.h
+++ b/arrays.h
@@ -34,14 +34,9 @@ namespace BrendanCUDA {
             delete[] ptr;
         }
 
-        __host__ __device__ __forceinline ArrayV<_T>& operator=(const ArrayV<_T>& Array) {
-            this->~ArrayV();
-            new (this) ArrayV<_T>(Array);
-            return *this;
-        }
-        __host__ __device__ __forceinline ArrayV<_T>& operator=(ArrayV<_T>&& Array) {
-            this->~ArrayV();
-            new (this) ArrayV<_T>(Array);
+        __host__ __device__ __forceinline ArrayV<_T>& operator=(ArrayV<_T> Array) {
+            std::swap(ptr, Array.ptr);
+            std::swap(size, Array.size);
             return *this;
         }
 

--- a/arrays.h
+++ b/arrays.h
@@ -9,6 +9,7 @@ namespace BrendanCUDA {
     struct Span;
 
     template <typename _T>
+        requires (!std::is_const_v<_T>)
     class ArrayV {
         _T* ptr;
         size_t size;
@@ -22,7 +23,7 @@ namespace BrendanCUDA {
             : ptr(new _T[Size]), size(Size) { }
         __host__ __device__ __forceinline ArrayV(const ArrayV<_T>& Array)
             : ArrayV(Array.size) {
-            std::copy(Array.ptr, Array.ptr + Array.size, ptr);
+            std::copy_n(Array.ptr, Array.size, ptr);
         }
         __host__ __device__ __forceinline ArrayV(ArrayV<_T>&& Array)
             : ArrayV(Array.ptr, Array.size) {
@@ -44,7 +45,7 @@ namespace BrendanCUDA {
             return *this;
         }
 
-        __host__ __device__ _T* Data() requires (!std::is_const_v<_T>) {
+        __host__ __device__ _T* Data() {
             return ptr;
         }
         __host__ __device__ const _T* Data() const {
@@ -54,19 +55,19 @@ namespace BrendanCUDA {
             return size;
         }
 
-        __host__ __device__ __forceinline _T& operator[](size_t Idx) requires (!std::is_const_v<_T>) {
+        __host__ __device__ __forceinline _T& operator[](size_t Idx) {
             return ptr[Idx];
         }
         __host__ __device__ __forceinline const _T& operator[](size_t Idx) const {
             return ptr[Idx];
         }
 
-        __host__ __device__ __forceinline Span<_T> Split(size_t Start, size_t NewSize) requires (!std::is_const_v<_T>) {
-            return Span<_T>(*this);
+        __host__ __device__ __forceinline Span<_T> Split(size_t Start, size_t NewSize) {
+            return Span<_T>(*this).Split(Start, NewSize);
         }
 
         __host__ __device__ __forceinline Span<const _T> Split(size_t Start, size_t NewSize) const {
-            return Span<const _T>(*this);
+            return Span<const _T>(*this).Split(Start, NewSize);
         }
     };
 


### PR DESCRIPTION
Fixed constness in arrays.h. Specifically, edited `BrendanCUDA::ArrayV` and `BrendanCUDA::Span`, and removed `BrendanCUDA::SpanConst`.