### PR TITLE
Added new class: `BrendanCUDA::CopyPtr`

### DIFF
--- a/BrendanCUDA.vcxproj
+++ b/BrendanCUDA.vcxproj
@@ -103,6 +103,7 @@
     <ClInclude Include="allheaders.h" />
     <ClInclude Include="arrays.h" />
     <ClInclude Include="copyblock.h" />
+    <ClInclude Include="copyptr.h" />
     <ClInclude Include="copytype.h" />
     <ClInclude Include="crossassigns.h" />
     <ClInclude Include="cudaconstexpr.h" />

--- a/BrendanCUDA.vcxproj.filters
+++ b/BrendanCUDA.vcxproj.filters
@@ -44,6 +44,7 @@
     <ClInclude Include="details_mfieldbase.h" />
     <ClInclude Include="fields_mfield.h" />
     <ClInclude Include="fields_mdfield.h" />
+    <ClInclude Include="copyptr.h" />
   </ItemGroup>
   <ItemGroup>
     <CudaCompile Include="binary_basic.cu" />

--- a/copyptr.h
+++ b/copyptr.h
@@ -11,35 +11,27 @@ namespace BrendanCUDA {
         using element_t = _T;
         static constexpr bool copyable = std::copy_constructible<_T>;
 
-        explicit CopyPtr(std::unique_ptr<_T> UniPtr)
+        __forceinline explicit CopyPtr(std::unique_ptr<_T> UniPtr)
             : ptr(std::move(UniPtr)) { }
-        CopyPtr(const CopyPtr<_T>& Other) requires copyable
-            : ptr(Other.ptr ? std::make_unique<_T>(*Other.ptr) : std::unique_ptr<_T>(0)) { }
-        CopyPtr(CopyPtr<_T>&& Other)
+        __forceinline CopyPtr(const CopyPtr<_T>& Other) requires copyable
+            : ptr(Other.ptr ? std::make_unique<_T>(*Other.ptr) : std::unique_ptr<_T>(nullptr)) { }
+        __forceinline CopyPtr(CopyPtr<_T>&& Other)
             : ptr(std::move(Other.ptr)) { }
-        CopyPtr(_T Val)
-            : ptr(std::make_unique<_T>(Val)) { }
+        __forceinline explicit CopyPtr(element_t* Val)
+            : ptr(Val) { }
+        __forceinline explicit CopyPtr(std::nullptr_t)
+            : ptr(nullptr) { }
 
-        CopyPtr<_T>& operator=(CopyPtr<_T> Other) {
+        __forceinline CopyPtr<_T>& operator=(CopyPtr<_T> Other) {
             std::swap(ptr, Other.ptr);
         }
 
-        _T* Get() const {
+        __forceinline _T* Get() const {
             return (_T*)ptr.get();
         }
 
-        _T* operator->() const {
+        __forceinline operator _T*() const {
             return ptr.get();
-        }
-        _T& operator*() const {
-            return *ptr;
-        }
-        _T& operator[](size_t Idx) {
-            return ptr[Idx];
-        }
-
-        operator _T*() const {
-            return ptr;
         }
     };
 }

--- a/copyptr.h
+++ b/copyptr.h
@@ -34,4 +34,9 @@ namespace BrendanCUDA {
             return ptr.get();
         }
     };
+
+    template <typename _T>
+    CopyPtr<_T> MakeCopyPtr(_T Val) {
+        return CopyPtr<_T>(new _T(Val));
+    }
 }

--- a/copyptr.h
+++ b/copyptr.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <memory>
+#include <type_traits>
+
+namespace BrendanCUDA {
+    template <typename _T>
+    class CopyPtr {
+        std::unique_ptr<_T> ptr;
+    public:
+        using element_t = _T;
+        constexpr bool copyable = std::copy_constructible<_T>;
+
+        explicit CopyPtr(std::unique_ptr<_T> UniPtr)
+            : ptr(std::move(UniPtr)) { }
+        CopyPtr(const CopyPtr<_T>& Other) requires copyable
+            : ptr(Other.ptr ? std::make_unique<_T>(*Other.ptr) : std::unique_ptr<_T>(0)) { }
+        CopyPtr(CopyPtr<_T>&& Other)
+            : ptr(std::move(Other.ptr)) { }
+        CopyPtr(_T Val)
+            : ptr(std::make_unique<_T>(Val)) { }
+
+        CopyPtr<_T>& operator=(CopyPtr<_T> Other) {
+            std::swap(ptr, Other.ptr);
+        }
+
+        _T* Get() const {
+            return (_T*)ptr.get();
+        }
+
+        _T* operator->() const {
+            return ptr.get();
+        }
+        _T& operator*() const {
+            return *ptr;
+        }
+        _T& operator[](size_t Idx) {
+            return ptr[Idx];
+        }
+
+        operator _T*() const {
+            return ptr;
+        }
+    };
+}

--- a/copyptr.h
+++ b/copyptr.h
@@ -9,7 +9,7 @@ namespace BrendanCUDA {
         std::unique_ptr<_T> ptr;
     public:
         using element_t = _T;
-        constexpr bool copyable = std::copy_constructible<_T>;
+        static constexpr bool copyable = std::copy_constructible<_T>;
 
         explicit CopyPtr(std::unique_ptr<_T> UniPtr)
             : ptr(std::move(UniPtr)) { }

--- a/copyptr.h
+++ b/copyptr.h
@@ -34,6 +34,14 @@ namespace BrendanCUDA {
         __forceinline operator _T*() const {
             return Get();
         }
+
+        __forceinline _T* Release() {
+            return (_T*)ptr.release();
+        }
+
+        __forceinline void Reset(_T* newPtr = 0) {
+            ptr.reset(newPtr);
+        }
     };
 
     template <typename _T>

--- a/copyptr.h
+++ b/copyptr.h
@@ -31,7 +31,7 @@ namespace BrendanCUDA {
         }
 
         __forceinline operator _T*() const {
-            return ptr.get();
+            return Get();
         }
     };
 

--- a/copyptr.h
+++ b/copyptr.h
@@ -24,6 +24,7 @@ namespace BrendanCUDA {
 
         __forceinline CopyPtr<_T>& operator=(CopyPtr<_T> Other) {
             std::swap(ptr, Other.ptr);
+            return *this;
         }
 
         __forceinline _T* Get() const {


### PR DESCRIPTION
Added a new class (`BrendanCUDA::CopyPtr`) in a new file named `copyptr.h`. The class acts like a `std::unique_ptr`, but instead of deleting its copy constructors and copy assignment operators, it instead configures them such that if the type pointed to has a copy constructor, it will have copy functionality as well.