### PR TITLE
Add neglected features to `BrendanCUDA::CopyPtr`

### DIFF
--- a/copyptr.h
+++ b/copyptr.h
@@ -19,7 +19,7 @@ namespace BrendanCUDA {
             : ptr(std::move(Other.ptr)) { }
         __forceinline explicit CopyPtr(element_t* Val)
             : ptr(Val) { }
-        __forceinline explicit CopyPtr(std::nullptr_t)
+        __forceinline explicit CopyPtr(std::nullptr_t = nullptr)
             : ptr(nullptr) { }
 
         __forceinline CopyPtr<_T>& operator=(CopyPtr<_T> Other) {
@@ -47,6 +47,10 @@ namespace BrendanCUDA {
         }
     };
 
+    template <typename _T>
+    CopyPtr<_T> MakeCopyPtr() requires std::is_default_constructible_v<_T> {
+        return CopyPtr<_T>(new _T());
+    }
     template <typename _T>
     CopyPtr<_T> MakeCopyPtr(_T Val) {
         return CopyPtr<_T>(new _T(Val));

--- a/copyptr.h
+++ b/copyptr.h
@@ -34,6 +34,9 @@ namespace BrendanCUDA {
         __forceinline operator _T*() const {
             return Get();
         }
+        __forceinline _T* operator->() const {
+            return Get();
+        }
 
         __forceinline _T* Release() {
             return (_T*)ptr.release();


### PR DESCRIPTION
Adding features that probably should have been already included with `BrendanCUDA::CopyPtr`, as well as some new ones. These (thus far) include:
* adding the arrow (`->`) operator to `BrendanCUDA::CopyPtr`&mdash;for some reason, this is the only operator that the implicit cast could not handle;
* adding a default constructor to `BrendanCUDA::CopyPtr`, that inits the encapusulated pointer to null; and
* an overload of the function `BrendanCUDA::MakeCopyPtr` with no parameters, which constructs a new `BrendanCUDA::CopyPtr` that points to a value that is the result of the default constructor of the type pointed to.