### PR TITLE
Fixing incorrect compiler allocations

### DIFF
--- a/BrendanCUDA.vcxproj
+++ b/BrendanCUDA.vcxproj
@@ -139,11 +139,7 @@
     <ClInclude Include="rand_bits.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="copyblock.cpp" />
     <CudaCompile Include="ai.cu" />
-    <CudaCompile Include="ai_evol_evolver.cpp">
-      <FileType>CppCode</FileType>
-    </CudaCompile>
     <CudaCompile Include="binary_basic.cu" />
     <CudaCompile Include="details_fillwith.cu" />
     <CudaCompile Include="dcopy.cu" />
@@ -152,6 +148,8 @@
     <CudaCompile Include="rand_randomizer.cu" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="copyblock.cpp" />
+    <ClCompile Include="ai_evol_evolver.cpp" />
     <ClCompile Include="ai_evol_eval_output_impl_proliferation.cpp" />
     <ClCompile Include="ai_evol_eval_output_impl_uniquevalues.cpp" />
   </ItemGroup>

--- a/BrendanCUDA.vcxproj.filters
+++ b/BrendanCUDA.vcxproj.filters
@@ -134,7 +134,7 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="allheaders.cuh">
-      <Filter>Source Files</Filter>
+      <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/BrendanCUDA.vcxproj.filters
+++ b/BrendanCUDA.vcxproj.filters
@@ -141,9 +141,6 @@
     <CudaCompile Include="ai.cu">
       <Filter>Source Files</Filter>
     </CudaCompile>
-    <CudaCompile Include="ai_evol_evolver.cpp">
-      <Filter>Source Files</Filter>
-    </CudaCompile>
     <CudaCompile Include="binary_basic.cu">
       <Filter>Source Files</Filter>
     </CudaCompile>
@@ -171,6 +168,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="copyblock.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ai_evol_evolver.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
Some .cpp files are being compiled with the nvcc compiler instead of the standard C++ compiler. This will not be resolved.

Additionally, some corrections have been made to the placement of the files in the "Source Files" and "Header Files" filters, which were incorrect in #8.