### PR TITLE
Fixed `BrendanCUDA::Fields::Field` and related objects

### DIFF
--- a/details_mfieldbase.h
+++ b/details_mfieldbase.h
@@ -75,7 +75,7 @@ namespace BrendanCUDA {
         template <size_t _DimensionCount, typename... _Ts>
         class MFieldBase : public DimensionedBase<_DimensionCount> {
             static_assert(sizeof...(_Ts), "The parameter pack _Ts must contain at least one element.");
-            
+
             using this_t = MFieldBase<_DimensionCount, _Ts...>;
             using basedb_t = DimensionedBase<_DimensionCount>;
         public:
@@ -123,7 +123,7 @@ namespace BrendanCUDA {
             }
             template <size_t _Idx>
             __host__ __device__ element_t<_Idx>* FData() const {
-                return darrs[_Idx];
+                return (element_t<_Idx>*)darrs[_Idx];
             }
 #pragma endregion
 

--- a/fields_dfield.h
+++ b/fields_dfield.h
@@ -7,6 +7,10 @@
 #include <string>
 
 namespace BrendanCUDA {
+    namespace details {
+        template <typename _T, size_t _DimensionCount>
+        using dfieldIK_t = void(*)(FixedVector<uint32_t, _DimensionCount> Pos, Fields::FieldProxyConst<_T, _DimensionCount> Previous, _T& NextVal);
+    }
     namespace Fields {
         template <typename _T, size_t _DimensionCount>
         class DField;
@@ -22,6 +26,7 @@ namespace BrendanCUDA {
             using basedb_t = DimensionedBase<_DimensionCount>;
         public:
             using vector_t = basefb_t::vector_t;
+            using kernelFunc_t = details::dfieldIK_t<_T, _DimensionCount>;
 
 #pragma region Wrapper
             __host__ __device__ __forceinline DField(const vector_t& Dimensions)
@@ -252,6 +257,7 @@ namespace BrendanCUDA {
             using basedb_t = DimensionedBase<_DimensionCount>;
         public:
             using vector_t = basefb_t::vector_t;
+            using kernelFunc_t = details::dfieldIK_t<_T, _DimensionCount>;
 
 #pragma region Wrapper
             __host__ __device__ DFieldProxy(const vector_t& Dimensions, _T* ArrF, _T* ArrB)
@@ -564,8 +570,5 @@ namespace BrendanCUDA {
             __host__ __device__ DFieldProxyConst(const DFieldProxy<_T, _DimensionCount>& Partner)
                 : basefb_t(Partner.Dimensions(), Partner.FData(), Partner.BData()) { }
         };
-
-        template <typename _T, size_t _DimensionCount>
-        using dfieldIteratorKernel_t = void(*)(FixedVector<uint32_t, _DimensionCount> Pos, FieldProxyConst<_T, _DimensionCount> Previous, _T& NextVal);
     }
 }

--- a/fields_mdfield.h
+++ b/fields_mdfield.h
@@ -37,6 +37,9 @@ namespace BrendanCUDA {
 
         template <size_t _DimensionCount, typename _TTypes, typename _TPublics>
         using mdfppik_t = typename MDFPPIK<_DimensionCount, _TTypes, _TPublics>::type_t;
+
+        template <size_t _DimensionCount, typename... _Ts>
+        using mdfkf_t = void(*)(const FixedVector<uint32_t, _DimensionCount>& Pos, const Fields::FieldProxyConst<_Ts, _DimensionCount>&... Prevs, _Ts&... Next);
     }
 
     namespace Fields {
@@ -57,9 +60,10 @@ namespace BrendanCUDA {
             using tuple_t = std::tuple<_Ts...>;
             template <size_t _Idx>
             using element_t = std::tuple_element_t<_Idx, tuple_t>;
+            using kernelFunc_t = details::mdfkf_t<_DimensionCount, _Ts...>;
             template <bool... _Publics>
                 requires (sizeof...(_Publics) == sizeof...(_Ts))
-            using publicPrivateIterator_t = details::mdfppik_t<_DimensionCount, std::tuple<_Ts...>, std::integer_sequence<bool, _Publics...>>;
+            using publicPrivateKernelFunc_t = details::mdfppik_t<_DimensionCount, std::tuple<_Ts...>, std::integer_sequence<bool, _Publics...>>;
 
 #pragma region Wrapper
             __host__ __device__ __forceinline MDField(const vector_t& Dimensions)
@@ -201,9 +205,10 @@ namespace BrendanCUDA {
             using tuple_t = std::tuple<_Ts...>;
             template <size_t _Idx>
             using element_t = std::tuple_element_t<_Idx, tuple_t>;
+            using kernelFunc_t = details::mdfkf_t<_DimensionCount, _Ts...>;
             template <bool... _Publics>
                 requires (sizeof...(_Publics) == sizeof...(_Ts))
-            using publicPrivateIterator_t = details::mdfppik_t<_DimensionCount, std::tuple<_Ts...>, std::integer_sequence<bool, _Publics...>>;
+            using publicPrivateKernelFunc_t = details::mdfppik_t<_DimensionCount, std::tuple<_Ts...>, std::integer_sequence<bool, _Publics...>>;
 
 #pragma region Wrapper
             __host__ __device__ __forceinline uint32_t LengthX() const requires (_DimensionCount <= 4) {

--- a/fields_mdfield.h
+++ b/fields_mdfield.h
@@ -2,18 +2,41 @@
 
 #include "fields_dfield.h"
 #include "fields_mfield.h"
+#include <array>
 
 namespace BrendanCUDA {
     namespace details {
         template <size_t _DimensionCount, bool _Public, typename _T>
         using publicPrivateSelector_t = std::conditional_t<_Public, Fields::FieldProxyConst<_T, _DimensionCount>, _T>;
 
-        template <size_t _DimensionCount, typename... _Ts>
-        struct MDFPPIKW {
-            template <bool... _Publics>
-                requires (sizeof...(_Publics) == sizeof...(_Ts))
-            using mDFPPIK_t = void(*)(const FixedVector<uint32_t, _DimensionCount>& Pos, const publicPrivateSelector_t<_DimensionCount, _Publics, _Ts>&... Prev, _Ts&... Next);
+        template <size_t _DimensionCount, typename _TTypes, typename _TPublics>
+        struct MDFPPIK;
+        template <size_t _DimensionCount, typename... _Ts, bool... _Publics>
+            requires (sizeof...(_Ts) == sizeof...(_Publics))
+        struct MDFPPIK<_DimensionCount, std::tuple<_Ts...>, std::integer_sequence<bool, _Publics...>> {
+            static constexpr size_t size = sizeof...(_Ts);
+            static constexpr std::array<bool, size> pubArr{ _Publics... };
+
+            template <uintmax_t _Idx>
+            using idx_type_t = std::tuple_element_t<_Idx, std::tuple<_Ts...>>;
+            template <uintmax_t _Idx>
+            static constexpr bool idx_val = pubArr[_Idx];
+
+            template <uintmax_t _Idx>
+            using idx_fieldType_t = publicPrivateSelector_t<_DimensionCount, idx_val<_Idx>, idx_type_t<_Idx>>;
+        
+            template <typename _TIndicies>
+            struct Type2;
+            template <size_t... _Idxs>
+            struct Type2<std::index_sequence<_Idxs...>> {
+                using type_t = void(*)(const FixedVector<uint32_t, _DimensionCount>& Pos, const idx_fieldType_t<_Idxs>&... Prevs, idx_type_t<_Idxs>&... Next);
+            };
+
+            using type_t = Type2<std::make_index_sequence<size>>::type_t;
         };
+
+        template <size_t _DimensionCount, typename _TTypes, typename _TPublics>
+        using mdfppik_t = typename MDFPPIK<_DimensionCount, _TTypes, _TPublics>::type_t;
     }
 
     namespace Fields {
@@ -35,7 +58,8 @@ namespace BrendanCUDA {
             template <size_t _Idx>
             using element_t = std::tuple_element_t<_Idx, tuple_t>;
             template <bool... _Publics>
-            using publicPrivateIterator_t = details::MDFPPIKW<_DimensionCount, _Ts...>::template mDFPPIK_t<_Publics...>;
+                requires (sizeof...(_Publics) == sizeof...(_Ts))
+            using publicPrivateIterator_t = details::mdfppik_t<_DimensionCount, std::tuple<_Ts...>, std::integer_sequence<bool, _Publics...>>;
 
 #pragma region Wrapper
             __host__ __device__ __forceinline MDField(const vector_t& Dimensions)
@@ -178,7 +202,8 @@ namespace BrendanCUDA {
             template <size_t _Idx>
             using element_t = std::tuple_element_t<_Idx, tuple_t>;
             template <bool... _Publics>
-            using publicPrivateIterator_t = details::MDFPPIKW<_DimensionCount, _Ts...>::template mDFPPIK_t<_Publics...>;
+                requires (sizeof...(_Publics) == sizeof...(_Ts))
+            using publicPrivateIterator_t = details::mdfppik_t<_DimensionCount, std::tuple<_Ts...>, std::integer_sequence<bool, _Publics...>>;
 
 #pragma region Wrapper
             __host__ __device__ __forceinline uint32_t LengthX() const requires (_DimensionCount <= 4) {
@@ -283,8 +308,6 @@ namespace BrendanCUDA {
             using tuple_t = std::tuple<_Ts...>;
             template <size_t _Idx>
             using element_t = std::tuple_element_t<_Idx, tuple_t>;
-            template <bool... _Publics>
-            using publicPrivateIterator_t = details::MDFPPIKW<_DimensionCount, _Ts...>::template mDFPPIK_t<_Publics...>;
 
 #pragma region Wrapper
             __host__ __device__ __forceinline uint32_t LengthX() const requires (_DimensionCount <= 4) {


### PR DESCRIPTION
* Fixed instantiation compiler errors for all field objects (all objects derived from/entangled with `BrendanCUDA::Fields::Field`);
* renamed using `MDField::publicPrivateIterator_t` to `MDField::publicPrivateKernelFunc_t`;
* renamed using `MDFieldProxy::publicPrivateIterator_t` to `MDFieldProxy::publicPrivateKernelFunc_t`;
* removed `MDFieldProxyConst::publicPrivateIterator_t`, since it wouldn't be relevant in that context;
* added another using in both classes `MDField` and `MDFieldProxy` called `kernelFunc_t` to be the equivalent of `publicPrivateIterator_t`, but with all fields made public; and
* moved the `BrendanCUDA::Fields::dfieldIteratorKernel_t` into the `DField` and `DFieldProxy` classes under the name `kernelFunc_t`.