### PR TITLE
Refactoring namespace names

### DIFF
--- a/ai.cu
+++ b/ai.cu
@@ -196,7 +196,7 @@ __host__ __forceinline void convertInt32sToFloats(uint32_t* Int32s, _TFloat* Flo
 }
 
 template <bool _FloatsOnHost, std::floating_point _TFloat, bool _BoolsOnHost>
-__host__ void BrendanCUDA::AI::ConvertFloatsToBools(_TFloat* Floats, bool* Bools, size_t Length, _TFloat Split) {
+__host__ void brendancuda::AI::ConvertFloatsToBools(_TFloat* Floats, bool* Bools, size_t Length, _TFloat Split) {
     if constexpr (_FloatsOnHost) {
         if constexpr (_BoolsOnHost) {
             for (bool* boolsU = Bools + Length; Bools < boolsU; ++Floats, ++Bools)
@@ -223,12 +223,12 @@ __host__ void BrendanCUDA::AI::ConvertFloatsToBools(_TFloat* Floats, bool* Bools
     }
 }
 template <std::floating_point _TFloat>
-__device__ void BrendanCUDA::AI::ConvertFloatsToBools(_TFloat* Floats, bool* Bools, size_t Length, _TFloat Split) {
+__device__ void brendancuda::AI::ConvertFloatsToBools(_TFloat* Floats, bool* Bools, size_t Length, _TFloat Split) {
     for (bool* boolsU = Bools + Length; Bools < boolsU; ++Floats, ++Bools)
         *Bools = *Floats > Split;
 }
 template <bool _FloatsOnHost, std::floating_point _TFloat, bool _IntsOnHost, std::integral _TInt>
-__host__ void BrendanCUDA::AI::ConvertFloatsToInts(_TFloat* Floats, _TInt* Ints, size_t FloatsLength, _TFloat Split) {
+__host__ void brendancuda::AI::ConvertFloatsToInts(_TFloat* Floats, _TInt* Ints, size_t FloatsLength, _TFloat Split) {
     if constexpr (_FloatsOnHost) {
         if constexpr (_IntsOnHost) {
             size_t intLength = (FloatsLength + 31) >> 5;
@@ -257,13 +257,13 @@ __host__ void BrendanCUDA::AI::ConvertFloatsToInts(_TFloat* Floats, _TInt* Ints,
     }
 }
 template <std::floating_point _TFloat, std::integral _TInt>
-__device__ void BrendanCUDA::AI::ConvertFloatsToInts(_TFloat* Floats, _TInt* Ints, size_t FloatsLength, _TFloat Split) {
+__device__ void brendancuda::AI::ConvertFloatsToInts(_TFloat* Floats, _TInt* Ints, size_t FloatsLength, _TFloat Split) {
     size_t intLength = (FloatsLength + 31) >> 5;
     for (_TInt* intsU = Ints + intLength; Ints < intsU; Floats += 32, ++Ints, FloatsLength -= 32)
         *Ints = convertFloatsToInt32(Floats, FloatsLength, Split);
 }
 template <bool _FloatsOnHost, bool _BoolsOnHost, std::floating_point _TFloat>
-__host__ void BrendanCUDA::AI::ConvertBoolsToFloats(bool* Bools, _TFloat* Floats, size_t Length, _TFloat ValFalse, _TFloat ValTrue) {
+__host__ void brendancuda::AI::ConvertBoolsToFloats(bool* Bools, _TFloat* Floats, size_t Length, _TFloat ValFalse, _TFloat ValTrue) {
     if constexpr (_BoolsOnHost) {
         if constexpr (_FloatsOnHost) {
             for (bool* boolsU = Bools + Length; Bools < boolsU; ++Floats, ++Bools)
@@ -290,12 +290,12 @@ __host__ void BrendanCUDA::AI::ConvertBoolsToFloats(bool* Bools, _TFloat* Floats
     }
 }
 template <std::floating_point _TFloat>
-__device__ void BrendanCUDA::AI::ConvertBoolsToFloats(bool* Bools, _TFloat* Floats, size_t Length, _TFloat ValFalse, _TFloat ValTrue) {
+__device__ void brendancuda::AI::ConvertBoolsToFloats(bool* Bools, _TFloat* Floats, size_t Length, _TFloat ValFalse, _TFloat ValTrue) {
     for (bool* boolsU = Bools + Length; Bools < boolsU; ++Floats, ++Bools)
         *Floats = *Bools ? ValTrue : ValFalse;
 }
 template <bool _IntsOnHost, std::integral _TInt, bool _FloatsOnHost, std::floating_point _TFloat>
-__host__ void BrendanCUDA::AI::ConvertIntsToFloats(_TInt* Ints, _TFloat* Floats, size_t FloatsLength, _TFloat ValFalse, _TFloat ValTrue) {
+__host__ void brendancuda::AI::ConvertIntsToFloats(_TInt* Ints, _TFloat* Floats, size_t FloatsLength, _TFloat ValFalse, _TFloat ValTrue) {
     if constexpr (_IntsOnHost) {
         if constexpr (_FloatsOnHost) {
             size_t intLength = (FloatsLength + 31) >> 5;
@@ -324,7 +324,7 @@ __host__ void BrendanCUDA::AI::ConvertIntsToFloats(_TInt* Ints, _TFloat* Floats,
     }
 }
 template <std::integral _TInt, std::floating_point _TFloat>
-__device__ void BrendanCUDA::AI::ConvertIntsToFloats(_TInt* Ints, _TFloat* Floats, size_t FloatsLength, _TFloat ValFalse, _TFloat ValTrue) {
+__device__ void brendancuda::AI::ConvertIntsToFloats(_TInt* Ints, _TFloat* Floats, size_t FloatsLength, _TFloat ValFalse, _TFloat ValTrue) {
     size_t intLength = (FloatsLength + 31) >> 5;
     for (_TInt* intsU = Ints + intLength; Ints < intsU; Floats += 32, ++Ints, FloatsLength -= 32)
         convertInt32ToFloats(Ints, Floats, FloatsLength, ValTrue, ValFalse);

--- a/ai.cu
+++ b/ai.cu
@@ -196,7 +196,7 @@ __host__ __forceinline void convertInt32sToFloats(uint32_t* Int32s, _TFloat* Flo
 }
 
 template <bool _FloatsOnHost, std::floating_point _TFloat, bool _BoolsOnHost>
-__host__ void brendancuda::AI::ConvertFloatsToBools(_TFloat* Floats, bool* Bools, size_t Length, _TFloat Split) {
+__host__ void brendancuda::ai::ConvertFloatsToBools(_TFloat* Floats, bool* Bools, size_t Length, _TFloat Split) {
     if constexpr (_FloatsOnHost) {
         if constexpr (_BoolsOnHost) {
             for (bool* boolsU = Bools + Length; Bools < boolsU; ++Floats, ++Bools)
@@ -223,12 +223,12 @@ __host__ void brendancuda::AI::ConvertFloatsToBools(_TFloat* Floats, bool* Bools
     }
 }
 template <std::floating_point _TFloat>
-__device__ void brendancuda::AI::ConvertFloatsToBools(_TFloat* Floats, bool* Bools, size_t Length, _TFloat Split) {
+__device__ void brendancuda::ai::ConvertFloatsToBools(_TFloat* Floats, bool* Bools, size_t Length, _TFloat Split) {
     for (bool* boolsU = Bools + Length; Bools < boolsU; ++Floats, ++Bools)
         *Bools = *Floats > Split;
 }
 template <bool _FloatsOnHost, std::floating_point _TFloat, bool _IntsOnHost, std::integral _TInt>
-__host__ void brendancuda::AI::ConvertFloatsToInts(_TFloat* Floats, _TInt* Ints, size_t FloatsLength, _TFloat Split) {
+__host__ void brendancuda::ai::ConvertFloatsToInts(_TFloat* Floats, _TInt* Ints, size_t FloatsLength, _TFloat Split) {
     if constexpr (_FloatsOnHost) {
         if constexpr (_IntsOnHost) {
             size_t intLength = (FloatsLength + 31) >> 5;
@@ -257,13 +257,13 @@ __host__ void brendancuda::AI::ConvertFloatsToInts(_TFloat* Floats, _TInt* Ints,
     }
 }
 template <std::floating_point _TFloat, std::integral _TInt>
-__device__ void brendancuda::AI::ConvertFloatsToInts(_TFloat* Floats, _TInt* Ints, size_t FloatsLength, _TFloat Split) {
+__device__ void brendancuda::ai::ConvertFloatsToInts(_TFloat* Floats, _TInt* Ints, size_t FloatsLength, _TFloat Split) {
     size_t intLength = (FloatsLength + 31) >> 5;
     for (_TInt* intsU = Ints + intLength; Ints < intsU; Floats += 32, ++Ints, FloatsLength -= 32)
         *Ints = convertFloatsToInt32(Floats, FloatsLength, Split);
 }
 template <bool _FloatsOnHost, bool _BoolsOnHost, std::floating_point _TFloat>
-__host__ void brendancuda::AI::ConvertBoolsToFloats(bool* Bools, _TFloat* Floats, size_t Length, _TFloat ValFalse, _TFloat ValTrue) {
+__host__ void brendancuda::ai::ConvertBoolsToFloats(bool* Bools, _TFloat* Floats, size_t Length, _TFloat ValFalse, _TFloat ValTrue) {
     if constexpr (_BoolsOnHost) {
         if constexpr (_FloatsOnHost) {
             for (bool* boolsU = Bools + Length; Bools < boolsU; ++Floats, ++Bools)
@@ -290,12 +290,12 @@ __host__ void brendancuda::AI::ConvertBoolsToFloats(bool* Bools, _TFloat* Floats
     }
 }
 template <std::floating_point _TFloat>
-__device__ void brendancuda::AI::ConvertBoolsToFloats(bool* Bools, _TFloat* Floats, size_t Length, _TFloat ValFalse, _TFloat ValTrue) {
+__device__ void brendancuda::ai::ConvertBoolsToFloats(bool* Bools, _TFloat* Floats, size_t Length, _TFloat ValFalse, _TFloat ValTrue) {
     for (bool* boolsU = Bools + Length; Bools < boolsU; ++Floats, ++Bools)
         *Floats = *Bools ? ValTrue : ValFalse;
 }
 template <bool _IntsOnHost, std::integral _TInt, bool _FloatsOnHost, std::floating_point _TFloat>
-__host__ void brendancuda::AI::ConvertIntsToFloats(_TInt* Ints, _TFloat* Floats, size_t FloatsLength, _TFloat ValFalse, _TFloat ValTrue) {
+__host__ void brendancuda::ai::ConvertIntsToFloats(_TInt* Ints, _TFloat* Floats, size_t FloatsLength, _TFloat ValFalse, _TFloat ValTrue) {
     if constexpr (_IntsOnHost) {
         if constexpr (_FloatsOnHost) {
             size_t intLength = (FloatsLength + 31) >> 5;
@@ -324,7 +324,7 @@ __host__ void brendancuda::AI::ConvertIntsToFloats(_TInt* Ints, _TFloat* Floats,
     }
 }
 template <std::integral _TInt, std::floating_point _TFloat>
-__device__ void brendancuda::AI::ConvertIntsToFloats(_TInt* Ints, _TFloat* Floats, size_t FloatsLength, _TFloat ValFalse, _TFloat ValTrue) {
+__device__ void brendancuda::ai::ConvertIntsToFloats(_TInt* Ints, _TFloat* Floats, size_t FloatsLength, _TFloat ValFalse, _TFloat ValTrue) {
     size_t intLength = (FloatsLength + 31) >> 5;
     for (_TInt* intsU = Ints + intLength; Ints < intsU; Floats += 32, ++Ints, FloatsLength -= 32)
         convertInt32ToFloats(Ints, Floats, FloatsLength, ValTrue, ValFalse);

--- a/ai.cu
+++ b/ai.cu
@@ -196,7 +196,7 @@ __host__ __forceinline void convertInt32sToFloats(uint32_t* Int32s, _TFloat* Flo
 }
 
 template <bool _FloatsOnHost, std::floating_point _TFloat, bool _BoolsOnHost>
-__host__ void brendancuda::ai::ConvertFloatsToBools(_TFloat* Floats, bool* Bools, size_t Length, _TFloat Split) {
+__host__ void bcuda::ai::ConvertFloatsToBools(_TFloat* Floats, bool* Bools, size_t Length, _TFloat Split) {
     if constexpr (_FloatsOnHost) {
         if constexpr (_BoolsOnHost) {
             for (bool* boolsU = Bools + Length; Bools < boolsU; ++Floats, ++Bools)
@@ -223,12 +223,12 @@ __host__ void brendancuda::ai::ConvertFloatsToBools(_TFloat* Floats, bool* Bools
     }
 }
 template <std::floating_point _TFloat>
-__device__ void brendancuda::ai::ConvertFloatsToBools(_TFloat* Floats, bool* Bools, size_t Length, _TFloat Split) {
+__device__ void bcuda::ai::ConvertFloatsToBools(_TFloat* Floats, bool* Bools, size_t Length, _TFloat Split) {
     for (bool* boolsU = Bools + Length; Bools < boolsU; ++Floats, ++Bools)
         *Bools = *Floats > Split;
 }
 template <bool _FloatsOnHost, std::floating_point _TFloat, bool _IntsOnHost, std::integral _TInt>
-__host__ void brendancuda::ai::ConvertFloatsToInts(_TFloat* Floats, _TInt* Ints, size_t FloatsLength, _TFloat Split) {
+__host__ void bcuda::ai::ConvertFloatsToInts(_TFloat* Floats, _TInt* Ints, size_t FloatsLength, _TFloat Split) {
     if constexpr (_FloatsOnHost) {
         if constexpr (_IntsOnHost) {
             size_t intLength = (FloatsLength + 31) >> 5;
@@ -257,13 +257,13 @@ __host__ void brendancuda::ai::ConvertFloatsToInts(_TFloat* Floats, _TInt* Ints,
     }
 }
 template <std::floating_point _TFloat, std::integral _TInt>
-__device__ void brendancuda::ai::ConvertFloatsToInts(_TFloat* Floats, _TInt* Ints, size_t FloatsLength, _TFloat Split) {
+__device__ void bcuda::ai::ConvertFloatsToInts(_TFloat* Floats, _TInt* Ints, size_t FloatsLength, _TFloat Split) {
     size_t intLength = (FloatsLength + 31) >> 5;
     for (_TInt* intsU = Ints + intLength; Ints < intsU; Floats += 32, ++Ints, FloatsLength -= 32)
         *Ints = convertFloatsToInt32(Floats, FloatsLength, Split);
 }
 template <bool _FloatsOnHost, bool _BoolsOnHost, std::floating_point _TFloat>
-__host__ void brendancuda::ai::ConvertBoolsToFloats(bool* Bools, _TFloat* Floats, size_t Length, _TFloat ValFalse, _TFloat ValTrue) {
+__host__ void bcuda::ai::ConvertBoolsToFloats(bool* Bools, _TFloat* Floats, size_t Length, _TFloat ValFalse, _TFloat ValTrue) {
     if constexpr (_BoolsOnHost) {
         if constexpr (_FloatsOnHost) {
             for (bool* boolsU = Bools + Length; Bools < boolsU; ++Floats, ++Bools)
@@ -290,12 +290,12 @@ __host__ void brendancuda::ai::ConvertBoolsToFloats(bool* Bools, _TFloat* Floats
     }
 }
 template <std::floating_point _TFloat>
-__device__ void brendancuda::ai::ConvertBoolsToFloats(bool* Bools, _TFloat* Floats, size_t Length, _TFloat ValFalse, _TFloat ValTrue) {
+__device__ void bcuda::ai::ConvertBoolsToFloats(bool* Bools, _TFloat* Floats, size_t Length, _TFloat ValFalse, _TFloat ValTrue) {
     for (bool* boolsU = Bools + Length; Bools < boolsU; ++Floats, ++Bools)
         *Floats = *Bools ? ValTrue : ValFalse;
 }
 template <bool _IntsOnHost, std::integral _TInt, bool _FloatsOnHost, std::floating_point _TFloat>
-__host__ void brendancuda::ai::ConvertIntsToFloats(_TInt* Ints, _TFloat* Floats, size_t FloatsLength, _TFloat ValFalse, _TFloat ValTrue) {
+__host__ void bcuda::ai::ConvertIntsToFloats(_TInt* Ints, _TFloat* Floats, size_t FloatsLength, _TFloat ValFalse, _TFloat ValTrue) {
     if constexpr (_IntsOnHost) {
         if constexpr (_FloatsOnHost) {
             size_t intLength = (FloatsLength + 31) >> 5;
@@ -324,7 +324,7 @@ __host__ void brendancuda::ai::ConvertIntsToFloats(_TInt* Ints, _TFloat* Floats,
     }
 }
 template <std::integral _TInt, std::floating_point _TFloat>
-__device__ void brendancuda::ai::ConvertIntsToFloats(_TInt* Ints, _TFloat* Floats, size_t FloatsLength, _TFloat ValFalse, _TFloat ValTrue) {
+__device__ void bcuda::ai::ConvertIntsToFloats(_TInt* Ints, _TFloat* Floats, size_t FloatsLength, _TFloat ValFalse, _TFloat ValTrue) {
     size_t intLength = (FloatsLength + 31) >> 5;
     for (_TInt* intsU = Ints + intLength; Ints < intsU; Floats += 32, ++Ints, FloatsLength -= 32)
         convertInt32ToFloats(Ints, Floats, FloatsLength, ValTrue, ValFalse);

--- a/ai.h
+++ b/ai.h
@@ -6,7 +6,7 @@
 #include <device_launch_parameters.h>
 #include <limits>
 
-namespace BrendanCUDA {
+namespace brendancuda {
     namespace AI {
         template <typename _T>
         using activationFunction_t = _T(*)(_T Value);
@@ -53,31 +53,31 @@ namespace BrendanCUDA {
 }
 
 template <typename _T>
-__host__ __device__ constexpr _T BrendanCUDA::AI::ReLU(_T Value) {
+__host__ __device__ constexpr _T brendancuda::AI::ReLU(_T Value) {
     return (Value < (_T)0.) ? (_T)0. : Value;
 }
 template <typename _T, _T _Slope>
-__host__ __device__ constexpr _T BrendanCUDA::AI::LeakyReLU(_T Value) {
+__host__ __device__ constexpr _T brendancuda::AI::LeakyReLU(_T Value) {
     return (Value < (_T)0.) ? Value * _Slope : Value;
 }
 template <typename _T, _T _Lower, _T _Upper>
-__host__ __device__ constexpr _T BrendanCUDA::AI::BoundReLU(_T Value) {
+__host__ __device__ constexpr _T brendancuda::AI::BoundReLU(_T Value) {
     if (Value < _Lower) return (_T)0.;
     if (Value > _Upper) return (_T)1.;
     return Value;
 }
 template <typename _T, _T _Slope, _T _Lower, _T _Upper>
-__host__ __device__ constexpr _T BrendanCUDA::AI::LeakyBoundReLU(_T Value) {
+__host__ __device__ constexpr _T brendancuda::AI::LeakyBoundReLU(_T Value) {
     if (Value < _Lower) return Value * _Slope;
     if (Value > _Upper) return (_T)1. + (Value - _Upper) * _Slope;
     return Value;
 }
 template <typename _T>
-__host__ __device__ _T BrendanCUDA::AI::TanH(_T Value) {
+__host__ __device__ _T brendancuda::AI::TanH(_T Value) {
     return std::tanh(Value);
 }
 template <typename _T>
-__host__ __device__ _T BrendanCUDA::AI::Sigmoid(_T Value) {
+__host__ __device__ _T brendancuda::AI::Sigmoid(_T Value) {
     Value = std::exp(Value);
     return Value / ((_T)1. + Value);
 }

--- a/ai.h
+++ b/ai.h
@@ -7,7 +7,7 @@
 #include <limits>
 
 namespace brendancuda {
-    namespace AI {
+    namespace ai {
         template <typename _T>
         using activationFunction_t = _T(*)(_T Value);
 
@@ -53,31 +53,31 @@ namespace brendancuda {
 }
 
 template <typename _T>
-__host__ __device__ constexpr _T brendancuda::AI::ReLU(_T Value) {
+__host__ __device__ constexpr _T brendancuda::ai::ReLU(_T Value) {
     return (Value < (_T)0.) ? (_T)0. : Value;
 }
 template <typename _T, _T _Slope>
-__host__ __device__ constexpr _T brendancuda::AI::LeakyReLU(_T Value) {
+__host__ __device__ constexpr _T brendancuda::ai::LeakyReLU(_T Value) {
     return (Value < (_T)0.) ? Value * _Slope : Value;
 }
 template <typename _T, _T _Lower, _T _Upper>
-__host__ __device__ constexpr _T brendancuda::AI::BoundReLU(_T Value) {
+__host__ __device__ constexpr _T brendancuda::ai::BoundReLU(_T Value) {
     if (Value < _Lower) return (_T)0.;
     if (Value > _Upper) return (_T)1.;
     return Value;
 }
 template <typename _T, _T _Slope, _T _Lower, _T _Upper>
-__host__ __device__ constexpr _T brendancuda::AI::LeakyBoundReLU(_T Value) {
+__host__ __device__ constexpr _T brendancuda::ai::LeakyBoundReLU(_T Value) {
     if (Value < _Lower) return Value * _Slope;
     if (Value > _Upper) return (_T)1. + (Value - _Upper) * _Slope;
     return Value;
 }
 template <typename _T>
-__host__ __device__ _T brendancuda::AI::TanH(_T Value) {
+__host__ __device__ _T brendancuda::ai::TanH(_T Value) {
     return std::tanh(Value);
 }
 template <typename _T>
-__host__ __device__ _T brendancuda::AI::Sigmoid(_T Value) {
+__host__ __device__ _T brendancuda::ai::Sigmoid(_T Value) {
     Value = std::exp(Value);
     return Value / ((_T)1. + Value);
 }

--- a/ai.h
+++ b/ai.h
@@ -6,7 +6,7 @@
 #include <device_launch_parameters.h>
 #include <limits>
 
-namespace brendancuda {
+namespace bcuda {
     namespace ai {
         template <typename _T>
         using activationFunction_t = _T(*)(_T Value);
@@ -53,31 +53,31 @@ namespace brendancuda {
 }
 
 template <typename _T>
-__host__ __device__ constexpr _T brendancuda::ai::ReLU(_T Value) {
+__host__ __device__ constexpr _T bcuda::ai::ReLU(_T Value) {
     return (Value < (_T)0.) ? (_T)0. : Value;
 }
 template <typename _T, _T _Slope>
-__host__ __device__ constexpr _T brendancuda::ai::LeakyReLU(_T Value) {
+__host__ __device__ constexpr _T bcuda::ai::LeakyReLU(_T Value) {
     return (Value < (_T)0.) ? Value * _Slope : Value;
 }
 template <typename _T, _T _Lower, _T _Upper>
-__host__ __device__ constexpr _T brendancuda::ai::BoundReLU(_T Value) {
+__host__ __device__ constexpr _T bcuda::ai::BoundReLU(_T Value) {
     if (Value < _Lower) return (_T)0.;
     if (Value > _Upper) return (_T)1.;
     return Value;
 }
 template <typename _T, _T _Slope, _T _Lower, _T _Upper>
-__host__ __device__ constexpr _T brendancuda::ai::LeakyBoundReLU(_T Value) {
+__host__ __device__ constexpr _T bcuda::ai::LeakyBoundReLU(_T Value) {
     if (Value < _Lower) return Value * _Slope;
     if (Value > _Upper) return (_T)1. + (Value - _Upper) * _Slope;
     return Value;
 }
 template <typename _T>
-__host__ __device__ _T brendancuda::ai::TanH(_T Value) {
+__host__ __device__ _T bcuda::ai::TanH(_T Value) {
     return std::tanh(Value);
 }
 template <typename _T>
-__host__ __device__ _T brendancuda::ai::Sigmoid(_T Value) {
+__host__ __device__ _T bcuda::ai::Sigmoid(_T Value) {
     Value = std::exp(Value);
     return Value / ((_T)1. + Value);
 }

--- a/ai_evol.h
+++ b/ai_evol.h
@@ -1,7 +1,7 @@
 #pragma once
 
 namespace brendancuda {
-    namespace AI {
+    namespace ai {
         namespace Evolution {
             //A function that creates an object.
             using creationFunction_t = void*(*)(void* CreationSharedData);

--- a/ai_evol.h
+++ b/ai_evol.h
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace BrendanCUDA {
+namespace brendancuda {
     namespace AI {
         namespace Evolution {
             //A function that creates an object.

--- a/ai_evol.h
+++ b/ai_evol.h
@@ -2,7 +2,7 @@
 
 namespace brendancuda {
     namespace ai {
-        namespace Evolution {
+        namespace evolution {
             //A function that creates an object.
             using creationFunction_t = void*(*)(void* CreationSharedData);
             //A function that evaluates an object.

--- a/ai_evol.h
+++ b/ai_evol.h
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace brendancuda {
+namespace bcuda {
     namespace ai {
         namespace evol {
             //A function that creates an object.

--- a/ai_evol.h
+++ b/ai_evol.h
@@ -2,7 +2,7 @@
 
 namespace brendancuda {
     namespace ai {
-        namespace evolution {
+        namespace evol {
             //A function that creates an object.
             using creationFunction_t = void*(*)(void* CreationSharedData);
             //A function that evaluates an object.

--- a/ai_evol_eval_multieval.h
+++ b/ai_evol_eval_multieval.h
@@ -4,7 +4,7 @@
 #include <algorithm>
 #include <limits>
 
-namespace brendancuda {
+namespace bcuda {
     namespace ai {
         namespace evol {
             namespace eval {
@@ -33,8 +33,8 @@ namespace brendancuda {
     }
 }
 
-template <brendancuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-float brendancuda::ai::evol::eval::Evaluate_MultipleTimes_AM_C(void* Object, void* EvaluationSharedData) {
+template <bcuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
+float bcuda::ai::evol::eval::Evaluate_MultipleTimes_AM_C(void* Object, void* EvaluationSharedData) {
     constexpr float s = 1.f / _IterationCount;
 
     float t = 0.f;
@@ -45,8 +45,8 @@ float brendancuda::ai::evol::eval::Evaluate_MultipleTimes_AM_C(void* Object, voi
     return t * s;
 }
 
-template <brendancuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc>
-float brendancuda::ai::evol::eval::Evaluate_MultipleTimes_AM_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+template <bcuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc>
+float bcuda::ai::evol::eval::Evaluate_MultipleTimes_AM_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
     float t = 0.f;
     for (size_t i = 0; i < Settings.iterationCount; ++i) {
         t += _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);
@@ -55,8 +55,8 @@ float brendancuda::ai::evol::eval::Evaluate_MultipleTimes_AM_V(void* Object, Eva
     return t / Settings.iterationCount;
 }
 
-template <brendancuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-float brendancuda::ai::evol::eval::Evaluate_MultipleTimes_Min_C(void* Object, void* EvaluationSharedData) {
+template <bcuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
+float bcuda::ai::evol::eval::Evaluate_MultipleTimes_Min_C(void* Object, void* EvaluationSharedData) {
     float min = std::numeric_limits<float>::infinity();
     for (size_t i = 0; i < _IterationCount; ++i) {
         float v = _SingleEvaluationFunc(Object, EvaluationSharedData);
@@ -68,8 +68,8 @@ float brendancuda::ai::evol::eval::Evaluate_MultipleTimes_Min_C(void* Object, vo
     return min;
 }
 
-template <brendancuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc>
-float brendancuda::ai::evol::eval::Evaluate_MultipleTimes_Min_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+template <bcuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc>
+float bcuda::ai::evol::eval::Evaluate_MultipleTimes_Min_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
     float min = std::numeric_limits<float>::infinity();
     for (size_t i = 0; i < Settings.iterationCount; ++i) {
         float v = _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);
@@ -81,8 +81,8 @@ float brendancuda::ai::evol::eval::Evaluate_MultipleTimes_Min_V(void* Object, Ev
     return min;
 }
 
-template <brendancuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-float brendancuda::ai::evol::eval::Evaluate_MultipleTimes_Max_C(void* Object, void* EvaluationSharedData) {
+template <bcuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
+float bcuda::ai::evol::eval::Evaluate_MultipleTimes_Max_C(void* Object, void* EvaluationSharedData) {
     float max = -std::numeric_limits<float>::infinity();
     for (size_t i = 0; i < _IterationCount; ++i) {
         float v = _SingleEvaluationFunc(Object, EvaluationSharedData);
@@ -94,8 +94,8 @@ float brendancuda::ai::evol::eval::Evaluate_MultipleTimes_Max_C(void* Object, vo
     return max;
 }
 
-template <brendancuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc>
-float brendancuda::ai::evol::eval::Evaluate_MultipleTimes_Max_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+template <bcuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc>
+float bcuda::ai::evol::eval::Evaluate_MultipleTimes_Max_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
     float max = -std::numeric_limits<float>::infinity();
     for (size_t i = 0; i < Settings.iterationCount; ++i) {
         float v = _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);
@@ -107,8 +107,8 @@ float brendancuda::ai::evol::eval::Evaluate_MultipleTimes_Max_V(void* Object, Ev
     return max;
 }
 
-template <brendancuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-float brendancuda::ai::evol::eval::Evaluate_MultipleTimes_Med_C(void* Object, void* EvaluationSharedData) {
+template <bcuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
+float bcuda::ai::evol::eval::Evaluate_MultipleTimes_Med_C(void* Object, void* EvaluationSharedData) {
     float* arr = new float[_IterationCount];
     for (size_t i = 0; i < _IterationCount; ++i) {
         arr[i] = _SingleEvaluationFunc(Object, EvaluationSharedData);
@@ -130,8 +130,8 @@ float brendancuda::ai::evol::eval::Evaluate_MultipleTimes_Med_C(void* Object, vo
     return r;
 }
 
-template <brendancuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc>
-float brendancuda::ai::evol::eval::Evaluate_MultipleTimes_Med_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+template <bcuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc>
+float bcuda::ai::evol::eval::Evaluate_MultipleTimes_Med_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
     float* arr = new float[Settings.iterationCount];
     for (size_t i = 0; i < Settings.iterationCount; ++i) {
         arr[i] = _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);

--- a/ai_evol_eval_multieval.h
+++ b/ai_evol_eval_multieval.h
@@ -6,7 +6,7 @@
 
 namespace brendancuda {
     namespace ai {
-        namespace Evolution {
+        namespace evolution {
             namespace Evaluation {
                 struct Evaluate_MultipleTimes_V_SD final {
                     size_t iterationCount;
@@ -33,8 +33,8 @@ namespace brendancuda {
     }
 }
 
-template <brendancuda::ai::Evolution::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-float brendancuda::ai::Evolution::Evaluation::Evaluate_MultipleTimes_AM_C(void* Object, void* EvaluationSharedData) {
+template <brendancuda::ai::evolution::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
+float brendancuda::ai::evolution::Evaluation::Evaluate_MultipleTimes_AM_C(void* Object, void* EvaluationSharedData) {
     constexpr float s = 1.f / _IterationCount;
 
     float t = 0.f;
@@ -45,8 +45,8 @@ float brendancuda::ai::Evolution::Evaluation::Evaluate_MultipleTimes_AM_C(void* 
     return t * s;
 }
 
-template <brendancuda::ai::Evolution::evaluationFunction_t _SingleEvaluationFunc>
-float brendancuda::ai::Evolution::Evaluation::Evaluate_MultipleTimes_AM_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+template <brendancuda::ai::evolution::evaluationFunction_t _SingleEvaluationFunc>
+float brendancuda::ai::evolution::Evaluation::Evaluate_MultipleTimes_AM_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
     float t = 0.f;
     for (size_t i = 0; i < Settings.iterationCount; ++i) {
         t += _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);
@@ -55,8 +55,8 @@ float brendancuda::ai::Evolution::Evaluation::Evaluate_MultipleTimes_AM_V(void* 
     return t / Settings.iterationCount;
 }
 
-template <brendancuda::ai::Evolution::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-float brendancuda::ai::Evolution::Evaluation::Evaluate_MultipleTimes_Min_C(void* Object, void* EvaluationSharedData) {
+template <brendancuda::ai::evolution::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
+float brendancuda::ai::evolution::Evaluation::Evaluate_MultipleTimes_Min_C(void* Object, void* EvaluationSharedData) {
     float min = std::numeric_limits<float>::infinity();
     for (size_t i = 0; i < _IterationCount; ++i) {
         float v = _SingleEvaluationFunc(Object, EvaluationSharedData);
@@ -68,8 +68,8 @@ float brendancuda::ai::Evolution::Evaluation::Evaluate_MultipleTimes_Min_C(void*
     return min;
 }
 
-template <brendancuda::ai::Evolution::evaluationFunction_t _SingleEvaluationFunc>
-float brendancuda::ai::Evolution::Evaluation::Evaluate_MultipleTimes_Min_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+template <brendancuda::ai::evolution::evaluationFunction_t _SingleEvaluationFunc>
+float brendancuda::ai::evolution::Evaluation::Evaluate_MultipleTimes_Min_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
     float min = std::numeric_limits<float>::infinity();
     for (size_t i = 0; i < Settings.iterationCount; ++i) {
         float v = _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);
@@ -81,8 +81,8 @@ float brendancuda::ai::Evolution::Evaluation::Evaluate_MultipleTimes_Min_V(void*
     return min;
 }
 
-template <brendancuda::ai::Evolution::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-float brendancuda::ai::Evolution::Evaluation::Evaluate_MultipleTimes_Max_C(void* Object, void* EvaluationSharedData) {
+template <brendancuda::ai::evolution::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
+float brendancuda::ai::evolution::Evaluation::Evaluate_MultipleTimes_Max_C(void* Object, void* EvaluationSharedData) {
     float max = -std::numeric_limits<float>::infinity();
     for (size_t i = 0; i < _IterationCount; ++i) {
         float v = _SingleEvaluationFunc(Object, EvaluationSharedData);
@@ -94,8 +94,8 @@ float brendancuda::ai::Evolution::Evaluation::Evaluate_MultipleTimes_Max_C(void*
     return max;
 }
 
-template <brendancuda::ai::Evolution::evaluationFunction_t _SingleEvaluationFunc>
-float brendancuda::ai::Evolution::Evaluation::Evaluate_MultipleTimes_Max_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+template <brendancuda::ai::evolution::evaluationFunction_t _SingleEvaluationFunc>
+float brendancuda::ai::evolution::Evaluation::Evaluate_MultipleTimes_Max_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
     float max = -std::numeric_limits<float>::infinity();
     for (size_t i = 0; i < Settings.iterationCount; ++i) {
         float v = _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);
@@ -107,8 +107,8 @@ float brendancuda::ai::Evolution::Evaluation::Evaluate_MultipleTimes_Max_V(void*
     return max;
 }
 
-template <brendancuda::ai::Evolution::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-float brendancuda::ai::Evolution::Evaluation::Evaluate_MultipleTimes_Med_C(void* Object, void* EvaluationSharedData) {
+template <brendancuda::ai::evolution::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
+float brendancuda::ai::evolution::Evaluation::Evaluate_MultipleTimes_Med_C(void* Object, void* EvaluationSharedData) {
     float* arr = new float[_IterationCount];
     for (size_t i = 0; i < _IterationCount; ++i) {
         arr[i] = _SingleEvaluationFunc(Object, EvaluationSharedData);
@@ -130,8 +130,8 @@ float brendancuda::ai::Evolution::Evaluation::Evaluate_MultipleTimes_Med_C(void*
     return r;
 }
 
-template <brendancuda::ai::Evolution::evaluationFunction_t _SingleEvaluationFunc>
-float brendancuda::ai::Evolution::Evaluation::Evaluate_MultipleTimes_Med_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+template <brendancuda::ai::evolution::evaluationFunction_t _SingleEvaluationFunc>
+float brendancuda::ai::evolution::Evaluation::Evaluate_MultipleTimes_Med_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
     float* arr = new float[Settings.iterationCount];
     for (size_t i = 0; i < Settings.iterationCount; ++i) {
         arr[i] = _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);

--- a/ai_evol_eval_multieval.h
+++ b/ai_evol_eval_multieval.h
@@ -4,7 +4,7 @@
 #include <algorithm>
 #include <limits>
 
-namespace BrendanCUDA {
+namespace brendancuda {
     namespace AI {
         namespace Evolution {
             namespace Evaluation {
@@ -33,8 +33,8 @@ namespace BrendanCUDA {
     }
 }
 
-template <BrendanCUDA::AI::Evolution::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-float BrendanCUDA::AI::Evolution::Evaluation::Evaluate_MultipleTimes_AM_C(void* Object, void* EvaluationSharedData) {
+template <brendancuda::AI::Evolution::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
+float brendancuda::AI::Evolution::Evaluation::Evaluate_MultipleTimes_AM_C(void* Object, void* EvaluationSharedData) {
     constexpr float s = 1.f / _IterationCount;
 
     float t = 0.f;
@@ -45,8 +45,8 @@ float BrendanCUDA::AI::Evolution::Evaluation::Evaluate_MultipleTimes_AM_C(void* 
     return t * s;
 }
 
-template <BrendanCUDA::AI::Evolution::evaluationFunction_t _SingleEvaluationFunc>
-float BrendanCUDA::AI::Evolution::Evaluation::Evaluate_MultipleTimes_AM_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+template <brendancuda::AI::Evolution::evaluationFunction_t _SingleEvaluationFunc>
+float brendancuda::AI::Evolution::Evaluation::Evaluate_MultipleTimes_AM_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
     float t = 0.f;
     for (size_t i = 0; i < Settings.iterationCount; ++i) {
         t += _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);
@@ -55,8 +55,8 @@ float BrendanCUDA::AI::Evolution::Evaluation::Evaluate_MultipleTimes_AM_V(void* 
     return t / Settings.iterationCount;
 }
 
-template <BrendanCUDA::AI::Evolution::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-float BrendanCUDA::AI::Evolution::Evaluation::Evaluate_MultipleTimes_Min_C(void* Object, void* EvaluationSharedData) {
+template <brendancuda::AI::Evolution::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
+float brendancuda::AI::Evolution::Evaluation::Evaluate_MultipleTimes_Min_C(void* Object, void* EvaluationSharedData) {
     float min = std::numeric_limits<float>::infinity();
     for (size_t i = 0; i < _IterationCount; ++i) {
         float v = _SingleEvaluationFunc(Object, EvaluationSharedData);
@@ -68,8 +68,8 @@ float BrendanCUDA::AI::Evolution::Evaluation::Evaluate_MultipleTimes_Min_C(void*
     return min;
 }
 
-template <BrendanCUDA::AI::Evolution::evaluationFunction_t _SingleEvaluationFunc>
-float BrendanCUDA::AI::Evolution::Evaluation::Evaluate_MultipleTimes_Min_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+template <brendancuda::AI::Evolution::evaluationFunction_t _SingleEvaluationFunc>
+float brendancuda::AI::Evolution::Evaluation::Evaluate_MultipleTimes_Min_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
     float min = std::numeric_limits<float>::infinity();
     for (size_t i = 0; i < Settings.iterationCount; ++i) {
         float v = _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);
@@ -81,8 +81,8 @@ float BrendanCUDA::AI::Evolution::Evaluation::Evaluate_MultipleTimes_Min_V(void*
     return min;
 }
 
-template <BrendanCUDA::AI::Evolution::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-float BrendanCUDA::AI::Evolution::Evaluation::Evaluate_MultipleTimes_Max_C(void* Object, void* EvaluationSharedData) {
+template <brendancuda::AI::Evolution::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
+float brendancuda::AI::Evolution::Evaluation::Evaluate_MultipleTimes_Max_C(void* Object, void* EvaluationSharedData) {
     float max = -std::numeric_limits<float>::infinity();
     for (size_t i = 0; i < _IterationCount; ++i) {
         float v = _SingleEvaluationFunc(Object, EvaluationSharedData);
@@ -94,8 +94,8 @@ float BrendanCUDA::AI::Evolution::Evaluation::Evaluate_MultipleTimes_Max_C(void*
     return max;
 }
 
-template <BrendanCUDA::AI::Evolution::evaluationFunction_t _SingleEvaluationFunc>
-float BrendanCUDA::AI::Evolution::Evaluation::Evaluate_MultipleTimes_Max_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+template <brendancuda::AI::Evolution::evaluationFunction_t _SingleEvaluationFunc>
+float brendancuda::AI::Evolution::Evaluation::Evaluate_MultipleTimes_Max_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
     float max = -std::numeric_limits<float>::infinity();
     for (size_t i = 0; i < Settings.iterationCount; ++i) {
         float v = _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);
@@ -107,8 +107,8 @@ float BrendanCUDA::AI::Evolution::Evaluation::Evaluate_MultipleTimes_Max_V(void*
     return max;
 }
 
-template <BrendanCUDA::AI::Evolution::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-float BrendanCUDA::AI::Evolution::Evaluation::Evaluate_MultipleTimes_Med_C(void* Object, void* EvaluationSharedData) {
+template <brendancuda::AI::Evolution::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
+float brendancuda::AI::Evolution::Evaluation::Evaluate_MultipleTimes_Med_C(void* Object, void* EvaluationSharedData) {
     float* arr = new float[_IterationCount];
     for (size_t i = 0; i < _IterationCount; ++i) {
         arr[i] = _SingleEvaluationFunc(Object, EvaluationSharedData);
@@ -130,8 +130,8 @@ float BrendanCUDA::AI::Evolution::Evaluation::Evaluate_MultipleTimes_Med_C(void*
     return r;
 }
 
-template <BrendanCUDA::AI::Evolution::evaluationFunction_t _SingleEvaluationFunc>
-float BrendanCUDA::AI::Evolution::Evaluation::Evaluate_MultipleTimes_Med_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+template <brendancuda::AI::Evolution::evaluationFunction_t _SingleEvaluationFunc>
+float brendancuda::AI::Evolution::Evaluation::Evaluate_MultipleTimes_Med_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
     float* arr = new float[Settings.iterationCount];
     for (size_t i = 0; i < Settings.iterationCount; ++i) {
         arr[i] = _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);

--- a/ai_evol_eval_multieval.h
+++ b/ai_evol_eval_multieval.h
@@ -5,7 +5,7 @@
 #include <limits>
 
 namespace brendancuda {
-    namespace AI {
+    namespace ai {
         namespace Evolution {
             namespace Evaluation {
                 struct Evaluate_MultipleTimes_V_SD final {
@@ -33,8 +33,8 @@ namespace brendancuda {
     }
 }
 
-template <brendancuda::AI::Evolution::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-float brendancuda::AI::Evolution::Evaluation::Evaluate_MultipleTimes_AM_C(void* Object, void* EvaluationSharedData) {
+template <brendancuda::ai::Evolution::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
+float brendancuda::ai::Evolution::Evaluation::Evaluate_MultipleTimes_AM_C(void* Object, void* EvaluationSharedData) {
     constexpr float s = 1.f / _IterationCount;
 
     float t = 0.f;
@@ -45,8 +45,8 @@ float brendancuda::AI::Evolution::Evaluation::Evaluate_MultipleTimes_AM_C(void* 
     return t * s;
 }
 
-template <brendancuda::AI::Evolution::evaluationFunction_t _SingleEvaluationFunc>
-float brendancuda::AI::Evolution::Evaluation::Evaluate_MultipleTimes_AM_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+template <brendancuda::ai::Evolution::evaluationFunction_t _SingleEvaluationFunc>
+float brendancuda::ai::Evolution::Evaluation::Evaluate_MultipleTimes_AM_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
     float t = 0.f;
     for (size_t i = 0; i < Settings.iterationCount; ++i) {
         t += _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);
@@ -55,8 +55,8 @@ float brendancuda::AI::Evolution::Evaluation::Evaluate_MultipleTimes_AM_V(void* 
     return t / Settings.iterationCount;
 }
 
-template <brendancuda::AI::Evolution::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-float brendancuda::AI::Evolution::Evaluation::Evaluate_MultipleTimes_Min_C(void* Object, void* EvaluationSharedData) {
+template <brendancuda::ai::Evolution::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
+float brendancuda::ai::Evolution::Evaluation::Evaluate_MultipleTimes_Min_C(void* Object, void* EvaluationSharedData) {
     float min = std::numeric_limits<float>::infinity();
     for (size_t i = 0; i < _IterationCount; ++i) {
         float v = _SingleEvaluationFunc(Object, EvaluationSharedData);
@@ -68,8 +68,8 @@ float brendancuda::AI::Evolution::Evaluation::Evaluate_MultipleTimes_Min_C(void*
     return min;
 }
 
-template <brendancuda::AI::Evolution::evaluationFunction_t _SingleEvaluationFunc>
-float brendancuda::AI::Evolution::Evaluation::Evaluate_MultipleTimes_Min_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+template <brendancuda::ai::Evolution::evaluationFunction_t _SingleEvaluationFunc>
+float brendancuda::ai::Evolution::Evaluation::Evaluate_MultipleTimes_Min_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
     float min = std::numeric_limits<float>::infinity();
     for (size_t i = 0; i < Settings.iterationCount; ++i) {
         float v = _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);
@@ -81,8 +81,8 @@ float brendancuda::AI::Evolution::Evaluation::Evaluate_MultipleTimes_Min_V(void*
     return min;
 }
 
-template <brendancuda::AI::Evolution::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-float brendancuda::AI::Evolution::Evaluation::Evaluate_MultipleTimes_Max_C(void* Object, void* EvaluationSharedData) {
+template <brendancuda::ai::Evolution::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
+float brendancuda::ai::Evolution::Evaluation::Evaluate_MultipleTimes_Max_C(void* Object, void* EvaluationSharedData) {
     float max = -std::numeric_limits<float>::infinity();
     for (size_t i = 0; i < _IterationCount; ++i) {
         float v = _SingleEvaluationFunc(Object, EvaluationSharedData);
@@ -94,8 +94,8 @@ float brendancuda::AI::Evolution::Evaluation::Evaluate_MultipleTimes_Max_C(void*
     return max;
 }
 
-template <brendancuda::AI::Evolution::evaluationFunction_t _SingleEvaluationFunc>
-float brendancuda::AI::Evolution::Evaluation::Evaluate_MultipleTimes_Max_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+template <brendancuda::ai::Evolution::evaluationFunction_t _SingleEvaluationFunc>
+float brendancuda::ai::Evolution::Evaluation::Evaluate_MultipleTimes_Max_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
     float max = -std::numeric_limits<float>::infinity();
     for (size_t i = 0; i < Settings.iterationCount; ++i) {
         float v = _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);
@@ -107,8 +107,8 @@ float brendancuda::AI::Evolution::Evaluation::Evaluate_MultipleTimes_Max_V(void*
     return max;
 }
 
-template <brendancuda::AI::Evolution::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-float brendancuda::AI::Evolution::Evaluation::Evaluate_MultipleTimes_Med_C(void* Object, void* EvaluationSharedData) {
+template <brendancuda::ai::Evolution::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
+float brendancuda::ai::Evolution::Evaluation::Evaluate_MultipleTimes_Med_C(void* Object, void* EvaluationSharedData) {
     float* arr = new float[_IterationCount];
     for (size_t i = 0; i < _IterationCount; ++i) {
         arr[i] = _SingleEvaluationFunc(Object, EvaluationSharedData);
@@ -130,8 +130,8 @@ float brendancuda::AI::Evolution::Evaluation::Evaluate_MultipleTimes_Med_C(void*
     return r;
 }
 
-template <brendancuda::AI::Evolution::evaluationFunction_t _SingleEvaluationFunc>
-float brendancuda::AI::Evolution::Evaluation::Evaluate_MultipleTimes_Med_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+template <brendancuda::ai::Evolution::evaluationFunction_t _SingleEvaluationFunc>
+float brendancuda::ai::Evolution::Evaluation::Evaluate_MultipleTimes_Med_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
     float* arr = new float[Settings.iterationCount];
     for (size_t i = 0; i < Settings.iterationCount; ++i) {
         arr[i] = _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);

--- a/ai_evol_eval_multieval.h
+++ b/ai_evol_eval_multieval.h
@@ -7,7 +7,7 @@
 namespace brendancuda {
     namespace ai {
         namespace evol {
-            namespace evaluation {
+            namespace eval {
                 struct Evaluate_MultipleTimes_V_SD final {
                     size_t iterationCount;
                     void* internalEvaluationSharedData;
@@ -34,7 +34,7 @@ namespace brendancuda {
 }
 
 template <brendancuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-float brendancuda::ai::evol::evaluation::Evaluate_MultipleTimes_AM_C(void* Object, void* EvaluationSharedData) {
+float brendancuda::ai::evol::eval::Evaluate_MultipleTimes_AM_C(void* Object, void* EvaluationSharedData) {
     constexpr float s = 1.f / _IterationCount;
 
     float t = 0.f;
@@ -46,7 +46,7 @@ float brendancuda::ai::evol::evaluation::Evaluate_MultipleTimes_AM_C(void* Objec
 }
 
 template <brendancuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc>
-float brendancuda::ai::evol::evaluation::Evaluate_MultipleTimes_AM_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+float brendancuda::ai::evol::eval::Evaluate_MultipleTimes_AM_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
     float t = 0.f;
     for (size_t i = 0; i < Settings.iterationCount; ++i) {
         t += _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);
@@ -56,7 +56,7 @@ float brendancuda::ai::evol::evaluation::Evaluate_MultipleTimes_AM_V(void* Objec
 }
 
 template <brendancuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-float brendancuda::ai::evol::evaluation::Evaluate_MultipleTimes_Min_C(void* Object, void* EvaluationSharedData) {
+float brendancuda::ai::evol::eval::Evaluate_MultipleTimes_Min_C(void* Object, void* EvaluationSharedData) {
     float min = std::numeric_limits<float>::infinity();
     for (size_t i = 0; i < _IterationCount; ++i) {
         float v = _SingleEvaluationFunc(Object, EvaluationSharedData);
@@ -69,7 +69,7 @@ float brendancuda::ai::evol::evaluation::Evaluate_MultipleTimes_Min_C(void* Obje
 }
 
 template <brendancuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc>
-float brendancuda::ai::evol::evaluation::Evaluate_MultipleTimes_Min_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+float brendancuda::ai::evol::eval::Evaluate_MultipleTimes_Min_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
     float min = std::numeric_limits<float>::infinity();
     for (size_t i = 0; i < Settings.iterationCount; ++i) {
         float v = _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);
@@ -82,7 +82,7 @@ float brendancuda::ai::evol::evaluation::Evaluate_MultipleTimes_Min_V(void* Obje
 }
 
 template <brendancuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-float brendancuda::ai::evol::evaluation::Evaluate_MultipleTimes_Max_C(void* Object, void* EvaluationSharedData) {
+float brendancuda::ai::evol::eval::Evaluate_MultipleTimes_Max_C(void* Object, void* EvaluationSharedData) {
     float max = -std::numeric_limits<float>::infinity();
     for (size_t i = 0; i < _IterationCount; ++i) {
         float v = _SingleEvaluationFunc(Object, EvaluationSharedData);
@@ -95,7 +95,7 @@ float brendancuda::ai::evol::evaluation::Evaluate_MultipleTimes_Max_C(void* Obje
 }
 
 template <brendancuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc>
-float brendancuda::ai::evol::evaluation::Evaluate_MultipleTimes_Max_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+float brendancuda::ai::evol::eval::Evaluate_MultipleTimes_Max_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
     float max = -std::numeric_limits<float>::infinity();
     for (size_t i = 0; i < Settings.iterationCount; ++i) {
         float v = _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);
@@ -108,7 +108,7 @@ float brendancuda::ai::evol::evaluation::Evaluate_MultipleTimes_Max_V(void* Obje
 }
 
 template <brendancuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-float brendancuda::ai::evol::evaluation::Evaluate_MultipleTimes_Med_C(void* Object, void* EvaluationSharedData) {
+float brendancuda::ai::evol::eval::Evaluate_MultipleTimes_Med_C(void* Object, void* EvaluationSharedData) {
     float* arr = new float[_IterationCount];
     for (size_t i = 0; i < _IterationCount; ++i) {
         arr[i] = _SingleEvaluationFunc(Object, EvaluationSharedData);
@@ -131,7 +131,7 @@ float brendancuda::ai::evol::evaluation::Evaluate_MultipleTimes_Med_C(void* Obje
 }
 
 template <brendancuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc>
-float brendancuda::ai::evol::evaluation::Evaluate_MultipleTimes_Med_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+float brendancuda::ai::evol::eval::Evaluate_MultipleTimes_Med_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
     float* arr = new float[Settings.iterationCount];
     for (size_t i = 0; i < Settings.iterationCount; ++i) {
         arr[i] = _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);

--- a/ai_evol_eval_multieval.h
+++ b/ai_evol_eval_multieval.h
@@ -6,7 +6,7 @@
 
 namespace brendancuda {
     namespace ai {
-        namespace evolution {
+        namespace evol {
             namespace evaluation {
                 struct Evaluate_MultipleTimes_V_SD final {
                     size_t iterationCount;
@@ -33,8 +33,8 @@ namespace brendancuda {
     }
 }
 
-template <brendancuda::ai::evolution::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-float brendancuda::ai::evolution::evaluation::Evaluate_MultipleTimes_AM_C(void* Object, void* EvaluationSharedData) {
+template <brendancuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
+float brendancuda::ai::evol::evaluation::Evaluate_MultipleTimes_AM_C(void* Object, void* EvaluationSharedData) {
     constexpr float s = 1.f / _IterationCount;
 
     float t = 0.f;
@@ -45,8 +45,8 @@ float brendancuda::ai::evolution::evaluation::Evaluate_MultipleTimes_AM_C(void* 
     return t * s;
 }
 
-template <brendancuda::ai::evolution::evaluationFunction_t _SingleEvaluationFunc>
-float brendancuda::ai::evolution::evaluation::Evaluate_MultipleTimes_AM_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+template <brendancuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc>
+float brendancuda::ai::evol::evaluation::Evaluate_MultipleTimes_AM_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
     float t = 0.f;
     for (size_t i = 0; i < Settings.iterationCount; ++i) {
         t += _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);
@@ -55,8 +55,8 @@ float brendancuda::ai::evolution::evaluation::Evaluate_MultipleTimes_AM_V(void* 
     return t / Settings.iterationCount;
 }
 
-template <brendancuda::ai::evolution::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-float brendancuda::ai::evolution::evaluation::Evaluate_MultipleTimes_Min_C(void* Object, void* EvaluationSharedData) {
+template <brendancuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
+float brendancuda::ai::evol::evaluation::Evaluate_MultipleTimes_Min_C(void* Object, void* EvaluationSharedData) {
     float min = std::numeric_limits<float>::infinity();
     for (size_t i = 0; i < _IterationCount; ++i) {
         float v = _SingleEvaluationFunc(Object, EvaluationSharedData);
@@ -68,8 +68,8 @@ float brendancuda::ai::evolution::evaluation::Evaluate_MultipleTimes_Min_C(void*
     return min;
 }
 
-template <brendancuda::ai::evolution::evaluationFunction_t _SingleEvaluationFunc>
-float brendancuda::ai::evolution::evaluation::Evaluate_MultipleTimes_Min_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+template <brendancuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc>
+float brendancuda::ai::evol::evaluation::Evaluate_MultipleTimes_Min_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
     float min = std::numeric_limits<float>::infinity();
     for (size_t i = 0; i < Settings.iterationCount; ++i) {
         float v = _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);
@@ -81,8 +81,8 @@ float brendancuda::ai::evolution::evaluation::Evaluate_MultipleTimes_Min_V(void*
     return min;
 }
 
-template <brendancuda::ai::evolution::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-float brendancuda::ai::evolution::evaluation::Evaluate_MultipleTimes_Max_C(void* Object, void* EvaluationSharedData) {
+template <brendancuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
+float brendancuda::ai::evol::evaluation::Evaluate_MultipleTimes_Max_C(void* Object, void* EvaluationSharedData) {
     float max = -std::numeric_limits<float>::infinity();
     for (size_t i = 0; i < _IterationCount; ++i) {
         float v = _SingleEvaluationFunc(Object, EvaluationSharedData);
@@ -94,8 +94,8 @@ float brendancuda::ai::evolution::evaluation::Evaluate_MultipleTimes_Max_C(void*
     return max;
 }
 
-template <brendancuda::ai::evolution::evaluationFunction_t _SingleEvaluationFunc>
-float brendancuda::ai::evolution::evaluation::Evaluate_MultipleTimes_Max_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+template <brendancuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc>
+float brendancuda::ai::evol::evaluation::Evaluate_MultipleTimes_Max_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
     float max = -std::numeric_limits<float>::infinity();
     for (size_t i = 0; i < Settings.iterationCount; ++i) {
         float v = _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);
@@ -107,8 +107,8 @@ float brendancuda::ai::evolution::evaluation::Evaluate_MultipleTimes_Max_V(void*
     return max;
 }
 
-template <brendancuda::ai::evolution::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-float brendancuda::ai::evolution::evaluation::Evaluate_MultipleTimes_Med_C(void* Object, void* EvaluationSharedData) {
+template <brendancuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
+float brendancuda::ai::evol::evaluation::Evaluate_MultipleTimes_Med_C(void* Object, void* EvaluationSharedData) {
     float* arr = new float[_IterationCount];
     for (size_t i = 0; i < _IterationCount; ++i) {
         arr[i] = _SingleEvaluationFunc(Object, EvaluationSharedData);
@@ -130,8 +130,8 @@ float brendancuda::ai::evolution::evaluation::Evaluate_MultipleTimes_Med_C(void*
     return r;
 }
 
-template <brendancuda::ai::evolution::evaluationFunction_t _SingleEvaluationFunc>
-float brendancuda::ai::evolution::evaluation::Evaluate_MultipleTimes_Med_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+template <brendancuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc>
+float brendancuda::ai::evol::evaluation::Evaluate_MultipleTimes_Med_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
     float* arr = new float[Settings.iterationCount];
     for (size_t i = 0; i < Settings.iterationCount; ++i) {
         arr[i] = _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);

--- a/ai_evol_eval_multieval.h
+++ b/ai_evol_eval_multieval.h
@@ -7,7 +7,7 @@
 namespace brendancuda {
     namespace ai {
         namespace evolution {
-            namespace Evaluation {
+            namespace evaluation {
                 struct Evaluate_MultipleTimes_V_SD final {
                     size_t iterationCount;
                     void* internalEvaluationSharedData;
@@ -34,7 +34,7 @@ namespace brendancuda {
 }
 
 template <brendancuda::ai::evolution::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-float brendancuda::ai::evolution::Evaluation::Evaluate_MultipleTimes_AM_C(void* Object, void* EvaluationSharedData) {
+float brendancuda::ai::evolution::evaluation::Evaluate_MultipleTimes_AM_C(void* Object, void* EvaluationSharedData) {
     constexpr float s = 1.f / _IterationCount;
 
     float t = 0.f;
@@ -46,7 +46,7 @@ float brendancuda::ai::evolution::Evaluation::Evaluate_MultipleTimes_AM_C(void* 
 }
 
 template <brendancuda::ai::evolution::evaluationFunction_t _SingleEvaluationFunc>
-float brendancuda::ai::evolution::Evaluation::Evaluate_MultipleTimes_AM_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+float brendancuda::ai::evolution::evaluation::Evaluate_MultipleTimes_AM_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
     float t = 0.f;
     for (size_t i = 0; i < Settings.iterationCount; ++i) {
         t += _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);
@@ -56,7 +56,7 @@ float brendancuda::ai::evolution::Evaluation::Evaluate_MultipleTimes_AM_V(void* 
 }
 
 template <brendancuda::ai::evolution::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-float brendancuda::ai::evolution::Evaluation::Evaluate_MultipleTimes_Min_C(void* Object, void* EvaluationSharedData) {
+float brendancuda::ai::evolution::evaluation::Evaluate_MultipleTimes_Min_C(void* Object, void* EvaluationSharedData) {
     float min = std::numeric_limits<float>::infinity();
     for (size_t i = 0; i < _IterationCount; ++i) {
         float v = _SingleEvaluationFunc(Object, EvaluationSharedData);
@@ -69,7 +69,7 @@ float brendancuda::ai::evolution::Evaluation::Evaluate_MultipleTimes_Min_C(void*
 }
 
 template <brendancuda::ai::evolution::evaluationFunction_t _SingleEvaluationFunc>
-float brendancuda::ai::evolution::Evaluation::Evaluate_MultipleTimes_Min_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+float brendancuda::ai::evolution::evaluation::Evaluate_MultipleTimes_Min_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
     float min = std::numeric_limits<float>::infinity();
     for (size_t i = 0; i < Settings.iterationCount; ++i) {
         float v = _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);
@@ -82,7 +82,7 @@ float brendancuda::ai::evolution::Evaluation::Evaluate_MultipleTimes_Min_V(void*
 }
 
 template <brendancuda::ai::evolution::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-float brendancuda::ai::evolution::Evaluation::Evaluate_MultipleTimes_Max_C(void* Object, void* EvaluationSharedData) {
+float brendancuda::ai::evolution::evaluation::Evaluate_MultipleTimes_Max_C(void* Object, void* EvaluationSharedData) {
     float max = -std::numeric_limits<float>::infinity();
     for (size_t i = 0; i < _IterationCount; ++i) {
         float v = _SingleEvaluationFunc(Object, EvaluationSharedData);
@@ -95,7 +95,7 @@ float brendancuda::ai::evolution::Evaluation::Evaluate_MultipleTimes_Max_C(void*
 }
 
 template <brendancuda::ai::evolution::evaluationFunction_t _SingleEvaluationFunc>
-float brendancuda::ai::evolution::Evaluation::Evaluate_MultipleTimes_Max_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+float brendancuda::ai::evolution::evaluation::Evaluate_MultipleTimes_Max_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
     float max = -std::numeric_limits<float>::infinity();
     for (size_t i = 0; i < Settings.iterationCount; ++i) {
         float v = _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);
@@ -108,7 +108,7 @@ float brendancuda::ai::evolution::Evaluation::Evaluate_MultipleTimes_Max_V(void*
 }
 
 template <brendancuda::ai::evolution::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-float brendancuda::ai::evolution::Evaluation::Evaluate_MultipleTimes_Med_C(void* Object, void* EvaluationSharedData) {
+float brendancuda::ai::evolution::evaluation::Evaluate_MultipleTimes_Med_C(void* Object, void* EvaluationSharedData) {
     float* arr = new float[_IterationCount];
     for (size_t i = 0; i < _IterationCount; ++i) {
         arr[i] = _SingleEvaluationFunc(Object, EvaluationSharedData);
@@ -131,7 +131,7 @@ float brendancuda::ai::evolution::Evaluation::Evaluate_MultipleTimes_Med_C(void*
 }
 
 template <brendancuda::ai::evolution::evaluationFunction_t _SingleEvaluationFunc>
-float brendancuda::ai::evolution::Evaluation::Evaluate_MultipleTimes_Med_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+float brendancuda::ai::evolution::evaluation::Evaluate_MultipleTimes_Med_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
     float* arr = new float[Settings.iterationCount];
     for (size_t i = 0; i < Settings.iterationCount; ++i) {
         arr[i] = _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);

--- a/ai_evol_eval_output.h
+++ b/ai_evol_eval_output.h
@@ -6,7 +6,7 @@
 namespace brendancuda {
     namespace ai {
         namespace evolution {
-            namespace Evaluation {
+            namespace evaluation {
                 namespace Output {
                     using constructInstance_t = void*(*)(void* Object, void* ConstructInstanceSharedData);
                     

--- a/ai_evol_eval_output.h
+++ b/ai_evol_eval_output.h
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <utility>
 
-namespace BrendanCUDA {
+namespace brendancuda {
     namespace AI {
         namespace Evolution {
             namespace Evaluation {

--- a/ai_evol_eval_output.h
+++ b/ai_evol_eval_output.h
@@ -5,7 +5,7 @@
 
 namespace brendancuda {
     namespace ai {
-        namespace Evolution {
+        namespace evolution {
             namespace Evaluation {
                 namespace Output {
                     using constructInstance_t = void*(*)(void* Object, void* ConstructInstanceSharedData);

--- a/ai_evol_eval_output.h
+++ b/ai_evol_eval_output.h
@@ -5,7 +5,7 @@
 
 namespace brendancuda {
     namespace ai {
-        namespace evolution {
+        namespace evol {
             namespace evaluation {
                 namespace output {
                     using constructInstance_t = void*(*)(void* Object, void* ConstructInstanceSharedData);

--- a/ai_evol_eval_output.h
+++ b/ai_evol_eval_output.h
@@ -6,7 +6,7 @@
 namespace brendancuda {
     namespace ai {
         namespace evol {
-            namespace evaluation {
+            namespace eval {
                 namespace output {
                     using constructInstance_t = void*(*)(void* Object, void* ConstructInstanceSharedData);
                     

--- a/ai_evol_eval_output.h
+++ b/ai_evol_eval_output.h
@@ -4,7 +4,7 @@
 #include <utility>
 
 namespace brendancuda {
-    namespace AI {
+    namespace ai {
         namespace Evolution {
             namespace Evaluation {
                 namespace Output {

--- a/ai_evol_eval_output.h
+++ b/ai_evol_eval_output.h
@@ -7,7 +7,7 @@ namespace brendancuda {
     namespace ai {
         namespace evolution {
             namespace evaluation {
-                namespace Output {
+                namespace output {
                     using constructInstance_t = void*(*)(void* Object, void* ConstructInstanceSharedData);
                     
                     template <typename _TInput, typename _TOutput>

--- a/ai_evol_eval_output.h
+++ b/ai_evol_eval_output.h
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <utility>
 
-namespace brendancuda {
+namespace bcuda {
     namespace ai {
         namespace evol {
             namespace eval {

--- a/ai_evol_eval_output_impl_proliferation.cpp
+++ b/ai_evol_eval_output_impl_proliferation.cpp
@@ -7,7 +7,7 @@
 #include <type_traits>
 
 template <>
-float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<float>(void* Object, Evaluate_Proliferation_SD<float>& Settings) {
+float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<float>(void* Object, Evaluate_Proliferation_SD<float>& Settings) {
     constexpr float rndSclr = 2.f / (float)std::numeric_limits<uint64_t>::max();
     if (!Settings.inputCount) {
         throw std::runtime_error("'Settings.inputCount' cannot be zero.");
@@ -36,7 +36,7 @@ float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<flo
 }
 
 template<>
-float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<double>(void* Object, Evaluate_Proliferation_SD<double>& Settings) {
+float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<double>(void* Object, Evaluate_Proliferation_SD<double>& Settings) {
     constexpr double rndSclr = 2. / (double)std::numeric_limits<uint64_t>::max();
 
     if (!Settings.inputCount) {
@@ -66,7 +66,7 @@ float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<dou
 }
 
 template <typename _T>
-float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation(void* Object, Evaluate_Proliferation_SD<_T>& Settings) {
+float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation(void* Object, Evaluate_Proliferation_SD<_T>& Settings) {
     if (!Settings.inputCount) {
         throw std::runtime_error("'Settings.inputCount' cannot be zero.");
     }
@@ -122,28 +122,28 @@ float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation(voi
 }
 
 template <typename _T>
-float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation(void* Object, void* Settings) {
+float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation(void* Object, void* Settings) {
     return Evaluate_Proliferation<_T>(Object, *(Evaluate_Proliferation_SD<_T>*)Settings);
 }
 
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<uint8_t>(void*, Evaluate_Proliferation_SD<uint8_t>&);
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<int8_t>(void*, Evaluate_Proliferation_SD<int8_t>&);
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<uint16_t>(void*, Evaluate_Proliferation_SD<uint16_t>&);
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<int16_t>(void*, Evaluate_Proliferation_SD<int16_t>&);
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<uint32_t>(void*, Evaluate_Proliferation_SD<uint32_t>&);
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<int32_t>(void*, Evaluate_Proliferation_SD<int32_t>&);
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<uint64_t>(void*, Evaluate_Proliferation_SD<uint64_t>&);
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<int64_t>(void*, Evaluate_Proliferation_SD<int64_t>&);
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<float>(void*, Evaluate_Proliferation_SD<float>&);
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<double>(void*, Evaluate_Proliferation_SD<double>&);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<uint8_t>(void*, Evaluate_Proliferation_SD<uint8_t>&);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<int8_t>(void*, Evaluate_Proliferation_SD<int8_t>&);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<uint16_t>(void*, Evaluate_Proliferation_SD<uint16_t>&);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<int16_t>(void*, Evaluate_Proliferation_SD<int16_t>&);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<uint32_t>(void*, Evaluate_Proliferation_SD<uint32_t>&);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<int32_t>(void*, Evaluate_Proliferation_SD<int32_t>&);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<uint64_t>(void*, Evaluate_Proliferation_SD<uint64_t>&);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<int64_t>(void*, Evaluate_Proliferation_SD<int64_t>&);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<float>(void*, Evaluate_Proliferation_SD<float>&);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<double>(void*, Evaluate_Proliferation_SD<double>&);
 
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<uint8_t>(void*, void*);
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<int8_t>(void*, void*);
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<uint16_t>(void*, void*);
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<int16_t>(void*, void*);
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<uint32_t>(void*, void*);
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<int32_t>(void*, void*);
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<uint64_t>(void*, void*);
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<int64_t>(void*, void*);
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<float>(void*, void*);
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<double>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<uint8_t>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<int8_t>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<uint16_t>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<int16_t>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<uint32_t>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<int32_t>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<uint64_t>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<int64_t>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<float>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<double>(void*, void*);

--- a/ai_evol_eval_output_impl_proliferation.cpp
+++ b/ai_evol_eval_output_impl_proliferation.cpp
@@ -7,7 +7,7 @@
 #include <type_traits>
 
 template <>
-float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<float>(void* Object, Evaluate_Proliferation_SD<float>& Settings) {
+float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<float>(void* Object, Evaluate_Proliferation_SD<float>& Settings) {
     constexpr float rndSclr = 2.f / (float)std::numeric_limits<uint64_t>::max();
     if (!Settings.inputCount) {
         throw std::runtime_error("'Settings.inputCount' cannot be zero.");
@@ -36,7 +36,7 @@ float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<flo
 }
 
 template<>
-float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<double>(void* Object, Evaluate_Proliferation_SD<double>& Settings) {
+float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<double>(void* Object, Evaluate_Proliferation_SD<double>& Settings) {
     constexpr double rndSclr = 2. / (double)std::numeric_limits<uint64_t>::max();
 
     if (!Settings.inputCount) {
@@ -66,7 +66,7 @@ float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<dou
 }
 
 template <typename _T>
-float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation(void* Object, Evaluate_Proliferation_SD<_T>& Settings) {
+float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation(void* Object, Evaluate_Proliferation_SD<_T>& Settings) {
     if (!Settings.inputCount) {
         throw std::runtime_error("'Settings.inputCount' cannot be zero.");
     }
@@ -122,28 +122,28 @@ float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation(voi
 }
 
 template <typename _T>
-float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation(void* Object, void* Settings) {
+float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation(void* Object, void* Settings) {
     return Evaluate_Proliferation<_T>(Object, *(Evaluate_Proliferation_SD<_T>*)Settings);
 }
 
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<uint8_t>(void*, Evaluate_Proliferation_SD<uint8_t>&);
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<int8_t>(void*, Evaluate_Proliferation_SD<int8_t>&);
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<uint16_t>(void*, Evaluate_Proliferation_SD<uint16_t>&);
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<int16_t>(void*, Evaluate_Proliferation_SD<int16_t>&);
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<uint32_t>(void*, Evaluate_Proliferation_SD<uint32_t>&);
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<int32_t>(void*, Evaluate_Proliferation_SD<int32_t>&);
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<uint64_t>(void*, Evaluate_Proliferation_SD<uint64_t>&);
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<int64_t>(void*, Evaluate_Proliferation_SD<int64_t>&);
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<float>(void*, Evaluate_Proliferation_SD<float>&);
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<double>(void*, Evaluate_Proliferation_SD<double>&);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<uint8_t>(void*, Evaluate_Proliferation_SD<uint8_t>&);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<int8_t>(void*, Evaluate_Proliferation_SD<int8_t>&);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<uint16_t>(void*, Evaluate_Proliferation_SD<uint16_t>&);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<int16_t>(void*, Evaluate_Proliferation_SD<int16_t>&);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<uint32_t>(void*, Evaluate_Proliferation_SD<uint32_t>&);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<int32_t>(void*, Evaluate_Proliferation_SD<int32_t>&);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<uint64_t>(void*, Evaluate_Proliferation_SD<uint64_t>&);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<int64_t>(void*, Evaluate_Proliferation_SD<int64_t>&);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<float>(void*, Evaluate_Proliferation_SD<float>&);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<double>(void*, Evaluate_Proliferation_SD<double>&);
 
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<uint8_t>(void*, void*);
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<int8_t>(void*, void*);
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<uint16_t>(void*, void*);
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<int16_t>(void*, void*);
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<uint32_t>(void*, void*);
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<int32_t>(void*, void*);
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<uint64_t>(void*, void*);
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<int64_t>(void*, void*);
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<float>(void*, void*);
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<double>(void*, void*);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<uint8_t>(void*, void*);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<int8_t>(void*, void*);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<uint16_t>(void*, void*);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<int16_t>(void*, void*);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<uint32_t>(void*, void*);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<int32_t>(void*, void*);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<uint64_t>(void*, void*);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<int64_t>(void*, void*);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<float>(void*, void*);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation<double>(void*, void*);

--- a/ai_evol_eval_output_impl_proliferation.cpp
+++ b/ai_evol_eval_output_impl_proliferation.cpp
@@ -7,7 +7,7 @@
 #include <type_traits>
 
 template <>
-float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<float>(void* Object, Evaluate_Proliferation_SD<float>& Settings) {
+float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<float>(void* Object, Evaluate_Proliferation_SD<float>& Settings) {
     constexpr float rndSclr = 2.f / (float)std::numeric_limits<uint64_t>::max();
     if (!Settings.inputCount) {
         throw std::runtime_error("'Settings.inputCount' cannot be zero.");
@@ -36,7 +36,7 @@ float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<flo
 }
 
 template<>
-float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<double>(void* Object, Evaluate_Proliferation_SD<double>& Settings) {
+float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<double>(void* Object, Evaluate_Proliferation_SD<double>& Settings) {
     constexpr double rndSclr = 2. / (double)std::numeric_limits<uint64_t>::max();
 
     if (!Settings.inputCount) {
@@ -66,7 +66,7 @@ float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<dou
 }
 
 template <typename _T>
-float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation(void* Object, Evaluate_Proliferation_SD<_T>& Settings) {
+float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation(void* Object, Evaluate_Proliferation_SD<_T>& Settings) {
     if (!Settings.inputCount) {
         throw std::runtime_error("'Settings.inputCount' cannot be zero.");
     }
@@ -122,28 +122,28 @@ float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation(voi
 }
 
 template <typename _T>
-float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation(void* Object, void* Settings) {
+float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation(void* Object, void* Settings) {
     return Evaluate_Proliferation<_T>(Object, *(Evaluate_Proliferation_SD<_T>*)Settings);
 }
 
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<uint8_t>(void*, Evaluate_Proliferation_SD<uint8_t>&);
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<int8_t>(void*, Evaluate_Proliferation_SD<int8_t>&);
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<uint16_t>(void*, Evaluate_Proliferation_SD<uint16_t>&);
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<int16_t>(void*, Evaluate_Proliferation_SD<int16_t>&);
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<uint32_t>(void*, Evaluate_Proliferation_SD<uint32_t>&);
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<int32_t>(void*, Evaluate_Proliferation_SD<int32_t>&);
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<uint64_t>(void*, Evaluate_Proliferation_SD<uint64_t>&);
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<int64_t>(void*, Evaluate_Proliferation_SD<int64_t>&);
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<float>(void*, Evaluate_Proliferation_SD<float>&);
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<double>(void*, Evaluate_Proliferation_SD<double>&);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<uint8_t>(void*, Evaluate_Proliferation_SD<uint8_t>&);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<int8_t>(void*, Evaluate_Proliferation_SD<int8_t>&);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<uint16_t>(void*, Evaluate_Proliferation_SD<uint16_t>&);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<int16_t>(void*, Evaluate_Proliferation_SD<int16_t>&);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<uint32_t>(void*, Evaluate_Proliferation_SD<uint32_t>&);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<int32_t>(void*, Evaluate_Proliferation_SD<int32_t>&);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<uint64_t>(void*, Evaluate_Proliferation_SD<uint64_t>&);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<int64_t>(void*, Evaluate_Proliferation_SD<int64_t>&);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<float>(void*, Evaluate_Proliferation_SD<float>&);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<double>(void*, Evaluate_Proliferation_SD<double>&);
 
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<uint8_t>(void*, void*);
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<int8_t>(void*, void*);
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<uint16_t>(void*, void*);
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<int16_t>(void*, void*);
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<uint32_t>(void*, void*);
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<int32_t>(void*, void*);
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<uint64_t>(void*, void*);
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<int64_t>(void*, void*);
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<float>(void*, void*);
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<double>(void*, void*);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<uint8_t>(void*, void*);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<int8_t>(void*, void*);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<uint16_t>(void*, void*);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<int16_t>(void*, void*);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<uint32_t>(void*, void*);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<int32_t>(void*, void*);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<uint64_t>(void*, void*);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<int64_t>(void*, void*);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<float>(void*, void*);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation<double>(void*, void*);

--- a/ai_evol_eval_output_impl_proliferation.cpp
+++ b/ai_evol_eval_output_impl_proliferation.cpp
@@ -7,7 +7,7 @@
 #include <type_traits>
 
 template <>
-float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<float>(void* Object, Evaluate_Proliferation_SD<float>& Settings) {
+float bcuda::ai::evol::eval::output::Evaluate_Proliferation<float>(void* Object, Evaluate_Proliferation_SD<float>& Settings) {
     constexpr float rndSclr = 2.f / (float)std::numeric_limits<uint64_t>::max();
     if (!Settings.inputCount) {
         throw std::runtime_error("'Settings.inputCount' cannot be zero.");
@@ -36,7 +36,7 @@ float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<float>(void* O
 }
 
 template<>
-float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<double>(void* Object, Evaluate_Proliferation_SD<double>& Settings) {
+float bcuda::ai::evol::eval::output::Evaluate_Proliferation<double>(void* Object, Evaluate_Proliferation_SD<double>& Settings) {
     constexpr double rndSclr = 2. / (double)std::numeric_limits<uint64_t>::max();
 
     if (!Settings.inputCount) {
@@ -66,7 +66,7 @@ float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<double>(void* 
 }
 
 template <typename _T>
-float brendancuda::ai::evol::eval::output::Evaluate_Proliferation(void* Object, Evaluate_Proliferation_SD<_T>& Settings) {
+float bcuda::ai::evol::eval::output::Evaluate_Proliferation(void* Object, Evaluate_Proliferation_SD<_T>& Settings) {
     if (!Settings.inputCount) {
         throw std::runtime_error("'Settings.inputCount' cannot be zero.");
     }
@@ -122,28 +122,28 @@ float brendancuda::ai::evol::eval::output::Evaluate_Proliferation(void* Object, 
 }
 
 template <typename _T>
-float brendancuda::ai::evol::eval::output::Evaluate_Proliferation(void* Object, void* Settings) {
+float bcuda::ai::evol::eval::output::Evaluate_Proliferation(void* Object, void* Settings) {
     return Evaluate_Proliferation<_T>(Object, *(Evaluate_Proliferation_SD<_T>*)Settings);
 }
 
-template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<uint8_t>(void*, Evaluate_Proliferation_SD<uint8_t>&);
-template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<int8_t>(void*, Evaluate_Proliferation_SD<int8_t>&);
-template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<uint16_t>(void*, Evaluate_Proliferation_SD<uint16_t>&);
-template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<int16_t>(void*, Evaluate_Proliferation_SD<int16_t>&);
-template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<uint32_t>(void*, Evaluate_Proliferation_SD<uint32_t>&);
-template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<int32_t>(void*, Evaluate_Proliferation_SD<int32_t>&);
-template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<uint64_t>(void*, Evaluate_Proliferation_SD<uint64_t>&);
-template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<int64_t>(void*, Evaluate_Proliferation_SD<int64_t>&);
-template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<float>(void*, Evaluate_Proliferation_SD<float>&);
-template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<double>(void*, Evaluate_Proliferation_SD<double>&);
+template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<uint8_t>(void*, Evaluate_Proliferation_SD<uint8_t>&);
+template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<int8_t>(void*, Evaluate_Proliferation_SD<int8_t>&);
+template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<uint16_t>(void*, Evaluate_Proliferation_SD<uint16_t>&);
+template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<int16_t>(void*, Evaluate_Proliferation_SD<int16_t>&);
+template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<uint32_t>(void*, Evaluate_Proliferation_SD<uint32_t>&);
+template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<int32_t>(void*, Evaluate_Proliferation_SD<int32_t>&);
+template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<uint64_t>(void*, Evaluate_Proliferation_SD<uint64_t>&);
+template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<int64_t>(void*, Evaluate_Proliferation_SD<int64_t>&);
+template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<float>(void*, Evaluate_Proliferation_SD<float>&);
+template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<double>(void*, Evaluate_Proliferation_SD<double>&);
 
-template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<uint8_t>(void*, void*);
-template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<int8_t>(void*, void*);
-template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<uint16_t>(void*, void*);
-template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<int16_t>(void*, void*);
-template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<uint32_t>(void*, void*);
-template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<int32_t>(void*, void*);
-template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<uint64_t>(void*, void*);
-template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<int64_t>(void*, void*);
-template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<float>(void*, void*);
-template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<double>(void*, void*);
+template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<uint8_t>(void*, void*);
+template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<int8_t>(void*, void*);
+template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<uint16_t>(void*, void*);
+template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<int16_t>(void*, void*);
+template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<uint32_t>(void*, void*);
+template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<int32_t>(void*, void*);
+template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<uint64_t>(void*, void*);
+template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<int64_t>(void*, void*);
+template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<float>(void*, void*);
+template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<double>(void*, void*);

--- a/ai_evol_eval_output_impl_proliferation.cpp
+++ b/ai_evol_eval_output_impl_proliferation.cpp
@@ -7,7 +7,7 @@
 #include <type_traits>
 
 template <>
-float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<float>(void* Object, Evaluate_Proliferation_SD<float>& Settings) {
+float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<float>(void* Object, Evaluate_Proliferation_SD<float>& Settings) {
     constexpr float rndSclr = 2.f / (float)std::numeric_limits<uint64_t>::max();
     if (!Settings.inputCount) {
         throw std::runtime_error("'Settings.inputCount' cannot be zero.");
@@ -36,7 +36,7 @@ float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<flo
 }
 
 template<>
-float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<double>(void* Object, Evaluate_Proliferation_SD<double>& Settings) {
+float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<double>(void* Object, Evaluate_Proliferation_SD<double>& Settings) {
     constexpr double rndSclr = 2. / (double)std::numeric_limits<uint64_t>::max();
 
     if (!Settings.inputCount) {
@@ -66,7 +66,7 @@ float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<dou
 }
 
 template <typename _T>
-float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation(void* Object, Evaluate_Proliferation_SD<_T>& Settings) {
+float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation(void* Object, Evaluate_Proliferation_SD<_T>& Settings) {
     if (!Settings.inputCount) {
         throw std::runtime_error("'Settings.inputCount' cannot be zero.");
     }
@@ -122,28 +122,28 @@ float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation(voi
 }
 
 template <typename _T>
-float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation(void* Object, void* Settings) {
+float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation(void* Object, void* Settings) {
     return Evaluate_Proliferation<_T>(Object, *(Evaluate_Proliferation_SD<_T>*)Settings);
 }
 
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<uint8_t>(void*, Evaluate_Proliferation_SD<uint8_t>&);
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<int8_t>(void*, Evaluate_Proliferation_SD<int8_t>&);
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<uint16_t>(void*, Evaluate_Proliferation_SD<uint16_t>&);
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<int16_t>(void*, Evaluate_Proliferation_SD<int16_t>&);
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<uint32_t>(void*, Evaluate_Proliferation_SD<uint32_t>&);
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<int32_t>(void*, Evaluate_Proliferation_SD<int32_t>&);
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<uint64_t>(void*, Evaluate_Proliferation_SD<uint64_t>&);
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<int64_t>(void*, Evaluate_Proliferation_SD<int64_t>&);
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<float>(void*, Evaluate_Proliferation_SD<float>&);
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<double>(void*, Evaluate_Proliferation_SD<double>&);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<uint8_t>(void*, Evaluate_Proliferation_SD<uint8_t>&);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<int8_t>(void*, Evaluate_Proliferation_SD<int8_t>&);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<uint16_t>(void*, Evaluate_Proliferation_SD<uint16_t>&);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<int16_t>(void*, Evaluate_Proliferation_SD<int16_t>&);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<uint32_t>(void*, Evaluate_Proliferation_SD<uint32_t>&);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<int32_t>(void*, Evaluate_Proliferation_SD<int32_t>&);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<uint64_t>(void*, Evaluate_Proliferation_SD<uint64_t>&);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<int64_t>(void*, Evaluate_Proliferation_SD<int64_t>&);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<float>(void*, Evaluate_Proliferation_SD<float>&);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<double>(void*, Evaluate_Proliferation_SD<double>&);
 
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<uint8_t>(void*, void*);
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<int8_t>(void*, void*);
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<uint16_t>(void*, void*);
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<int16_t>(void*, void*);
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<uint32_t>(void*, void*);
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<int32_t>(void*, void*);
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<uint64_t>(void*, void*);
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<int64_t>(void*, void*);
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<float>(void*, void*);
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation<double>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<uint8_t>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<int8_t>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<uint16_t>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<int16_t>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<uint32_t>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<int32_t>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<uint64_t>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<int64_t>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<float>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<double>(void*, void*);

--- a/ai_evol_eval_output_impl_proliferation.cpp
+++ b/ai_evol_eval_output_impl_proliferation.cpp
@@ -7,7 +7,7 @@
 #include <type_traits>
 
 template <>
-float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<float>(void* Object, Evaluate_Proliferation_SD<float>& Settings) {
+float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<float>(void* Object, Evaluate_Proliferation_SD<float>& Settings) {
     constexpr float rndSclr = 2.f / (float)std::numeric_limits<uint64_t>::max();
     if (!Settings.inputCount) {
         throw std::runtime_error("'Settings.inputCount' cannot be zero.");
@@ -36,7 +36,7 @@ float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<flo
 }
 
 template<>
-float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<double>(void* Object, Evaluate_Proliferation_SD<double>& Settings) {
+float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<double>(void* Object, Evaluate_Proliferation_SD<double>& Settings) {
     constexpr double rndSclr = 2. / (double)std::numeric_limits<uint64_t>::max();
 
     if (!Settings.inputCount) {
@@ -66,7 +66,7 @@ float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<dou
 }
 
 template <typename _T>
-float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation(void* Object, Evaluate_Proliferation_SD<_T>& Settings) {
+float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation(void* Object, Evaluate_Proliferation_SD<_T>& Settings) {
     if (!Settings.inputCount) {
         throw std::runtime_error("'Settings.inputCount' cannot be zero.");
     }
@@ -122,28 +122,28 @@ float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation(voi
 }
 
 template <typename _T>
-float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation(void* Object, void* Settings) {
+float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation(void* Object, void* Settings) {
     return Evaluate_Proliferation<_T>(Object, *(Evaluate_Proliferation_SD<_T>*)Settings);
 }
 
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<uint8_t>(void*, Evaluate_Proliferation_SD<uint8_t>&);
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<int8_t>(void*, Evaluate_Proliferation_SD<int8_t>&);
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<uint16_t>(void*, Evaluate_Proliferation_SD<uint16_t>&);
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<int16_t>(void*, Evaluate_Proliferation_SD<int16_t>&);
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<uint32_t>(void*, Evaluate_Proliferation_SD<uint32_t>&);
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<int32_t>(void*, Evaluate_Proliferation_SD<int32_t>&);
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<uint64_t>(void*, Evaluate_Proliferation_SD<uint64_t>&);
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<int64_t>(void*, Evaluate_Proliferation_SD<int64_t>&);
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<float>(void*, Evaluate_Proliferation_SD<float>&);
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<double>(void*, Evaluate_Proliferation_SD<double>&);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<uint8_t>(void*, Evaluate_Proliferation_SD<uint8_t>&);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<int8_t>(void*, Evaluate_Proliferation_SD<int8_t>&);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<uint16_t>(void*, Evaluate_Proliferation_SD<uint16_t>&);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<int16_t>(void*, Evaluate_Proliferation_SD<int16_t>&);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<uint32_t>(void*, Evaluate_Proliferation_SD<uint32_t>&);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<int32_t>(void*, Evaluate_Proliferation_SD<int32_t>&);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<uint64_t>(void*, Evaluate_Proliferation_SD<uint64_t>&);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<int64_t>(void*, Evaluate_Proliferation_SD<int64_t>&);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<float>(void*, Evaluate_Proliferation_SD<float>&);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<double>(void*, Evaluate_Proliferation_SD<double>&);
 
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<uint8_t>(void*, void*);
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<int8_t>(void*, void*);
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<uint16_t>(void*, void*);
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<int16_t>(void*, void*);
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<uint32_t>(void*, void*);
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<int32_t>(void*, void*);
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<uint64_t>(void*, void*);
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<int64_t>(void*, void*);
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<float>(void*, void*);
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation<double>(void*, void*);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<uint8_t>(void*, void*);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<int8_t>(void*, void*);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<uint16_t>(void*, void*);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<int16_t>(void*, void*);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<uint32_t>(void*, void*);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<int32_t>(void*, void*);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<uint64_t>(void*, void*);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<int64_t>(void*, void*);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<float>(void*, void*);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<double>(void*, void*);

--- a/ai_evol_eval_output_impl_proliferation.cpp
+++ b/ai_evol_eval_output_impl_proliferation.cpp
@@ -7,7 +7,7 @@
 #include <type_traits>
 
 template <>
-float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<float>(void* Object, Evaluate_Proliferation_SD<float>& Settings) {
+float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<float>(void* Object, Evaluate_Proliferation_SD<float>& Settings) {
     constexpr float rndSclr = 2.f / (float)std::numeric_limits<uint64_t>::max();
     if (!Settings.inputCount) {
         throw std::runtime_error("'Settings.inputCount' cannot be zero.");
@@ -36,7 +36,7 @@ float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<float>(v
 }
 
 template<>
-float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<double>(void* Object, Evaluate_Proliferation_SD<double>& Settings) {
+float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<double>(void* Object, Evaluate_Proliferation_SD<double>& Settings) {
     constexpr double rndSclr = 2. / (double)std::numeric_limits<uint64_t>::max();
 
     if (!Settings.inputCount) {
@@ -66,7 +66,7 @@ float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<double>(
 }
 
 template <typename _T>
-float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation(void* Object, Evaluate_Proliferation_SD<_T>& Settings) {
+float brendancuda::ai::evol::eval::output::Evaluate_Proliferation(void* Object, Evaluate_Proliferation_SD<_T>& Settings) {
     if (!Settings.inputCount) {
         throw std::runtime_error("'Settings.inputCount' cannot be zero.");
     }
@@ -122,28 +122,28 @@ float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation(void* Ob
 }
 
 template <typename _T>
-float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation(void* Object, void* Settings) {
+float brendancuda::ai::evol::eval::output::Evaluate_Proliferation(void* Object, void* Settings) {
     return Evaluate_Proliferation<_T>(Object, *(Evaluate_Proliferation_SD<_T>*)Settings);
 }
 
-template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<uint8_t>(void*, Evaluate_Proliferation_SD<uint8_t>&);
-template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<int8_t>(void*, Evaluate_Proliferation_SD<int8_t>&);
-template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<uint16_t>(void*, Evaluate_Proliferation_SD<uint16_t>&);
-template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<int16_t>(void*, Evaluate_Proliferation_SD<int16_t>&);
-template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<uint32_t>(void*, Evaluate_Proliferation_SD<uint32_t>&);
-template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<int32_t>(void*, Evaluate_Proliferation_SD<int32_t>&);
-template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<uint64_t>(void*, Evaluate_Proliferation_SD<uint64_t>&);
-template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<int64_t>(void*, Evaluate_Proliferation_SD<int64_t>&);
-template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<float>(void*, Evaluate_Proliferation_SD<float>&);
-template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<double>(void*, Evaluate_Proliferation_SD<double>&);
+template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<uint8_t>(void*, Evaluate_Proliferation_SD<uint8_t>&);
+template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<int8_t>(void*, Evaluate_Proliferation_SD<int8_t>&);
+template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<uint16_t>(void*, Evaluate_Proliferation_SD<uint16_t>&);
+template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<int16_t>(void*, Evaluate_Proliferation_SD<int16_t>&);
+template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<uint32_t>(void*, Evaluate_Proliferation_SD<uint32_t>&);
+template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<int32_t>(void*, Evaluate_Proliferation_SD<int32_t>&);
+template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<uint64_t>(void*, Evaluate_Proliferation_SD<uint64_t>&);
+template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<int64_t>(void*, Evaluate_Proliferation_SD<int64_t>&);
+template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<float>(void*, Evaluate_Proliferation_SD<float>&);
+template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<double>(void*, Evaluate_Proliferation_SD<double>&);
 
-template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<uint8_t>(void*, void*);
-template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<int8_t>(void*, void*);
-template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<uint16_t>(void*, void*);
-template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<int16_t>(void*, void*);
-template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<uint32_t>(void*, void*);
-template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<int32_t>(void*, void*);
-template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<uint64_t>(void*, void*);
-template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<int64_t>(void*, void*);
-template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<float>(void*, void*);
-template float brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation<double>(void*, void*);
+template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<uint8_t>(void*, void*);
+template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<int8_t>(void*, void*);
+template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<uint16_t>(void*, void*);
+template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<int16_t>(void*, void*);
+template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<uint32_t>(void*, void*);
+template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<int32_t>(void*, void*);
+template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<uint64_t>(void*, void*);
+template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<int64_t>(void*, void*);
+template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<float>(void*, void*);
+template float brendancuda::ai::evol::eval::output::Evaluate_Proliferation<double>(void*, void*);

--- a/ai_evol_eval_output_impl_proliferation.cpp
+++ b/ai_evol_eval_output_impl_proliferation.cpp
@@ -7,7 +7,7 @@
 #include <type_traits>
 
 template <>
-float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<float>(void* Object, Evaluate_Proliferation_SD<float>& Settings) {
+float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<float>(void* Object, Evaluate_Proliferation_SD<float>& Settings) {
     constexpr float rndSclr = 2.f / (float)std::numeric_limits<uint64_t>::max();
     if (!Settings.inputCount) {
         throw std::runtime_error("'Settings.inputCount' cannot be zero.");
@@ -36,7 +36,7 @@ float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<flo
 }
 
 template<>
-float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<double>(void* Object, Evaluate_Proliferation_SD<double>& Settings) {
+float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<double>(void* Object, Evaluate_Proliferation_SD<double>& Settings) {
     constexpr double rndSclr = 2. / (double)std::numeric_limits<uint64_t>::max();
 
     if (!Settings.inputCount) {
@@ -66,7 +66,7 @@ float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<dou
 }
 
 template <typename _T>
-float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_Proliferation(void* Object, Evaluate_Proliferation_SD<_T>& Settings) {
+float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation(void* Object, Evaluate_Proliferation_SD<_T>& Settings) {
     if (!Settings.inputCount) {
         throw std::runtime_error("'Settings.inputCount' cannot be zero.");
     }
@@ -122,28 +122,28 @@ float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_Proliferation(voi
 }
 
 template <typename _T>
-float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_Proliferation(void* Object, void* Settings) {
+float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation(void* Object, void* Settings) {
     return Evaluate_Proliferation<_T>(Object, *(Evaluate_Proliferation_SD<_T>*)Settings);
 }
 
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<uint8_t>(void*, Evaluate_Proliferation_SD<uint8_t>&);
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<int8_t>(void*, Evaluate_Proliferation_SD<int8_t>&);
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<uint16_t>(void*, Evaluate_Proliferation_SD<uint16_t>&);
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<int16_t>(void*, Evaluate_Proliferation_SD<int16_t>&);
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<uint32_t>(void*, Evaluate_Proliferation_SD<uint32_t>&);
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<int32_t>(void*, Evaluate_Proliferation_SD<int32_t>&);
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<uint64_t>(void*, Evaluate_Proliferation_SD<uint64_t>&);
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<int64_t>(void*, Evaluate_Proliferation_SD<int64_t>&);
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<float>(void*, Evaluate_Proliferation_SD<float>&);
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<double>(void*, Evaluate_Proliferation_SD<double>&);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<uint8_t>(void*, Evaluate_Proliferation_SD<uint8_t>&);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<int8_t>(void*, Evaluate_Proliferation_SD<int8_t>&);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<uint16_t>(void*, Evaluate_Proliferation_SD<uint16_t>&);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<int16_t>(void*, Evaluate_Proliferation_SD<int16_t>&);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<uint32_t>(void*, Evaluate_Proliferation_SD<uint32_t>&);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<int32_t>(void*, Evaluate_Proliferation_SD<int32_t>&);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<uint64_t>(void*, Evaluate_Proliferation_SD<uint64_t>&);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<int64_t>(void*, Evaluate_Proliferation_SD<int64_t>&);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<float>(void*, Evaluate_Proliferation_SD<float>&);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<double>(void*, Evaluate_Proliferation_SD<double>&);
 
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<uint8_t>(void*, void*);
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<int8_t>(void*, void*);
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<uint16_t>(void*, void*);
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<int16_t>(void*, void*);
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<uint32_t>(void*, void*);
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<int32_t>(void*, void*);
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<uint64_t>(void*, void*);
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<int64_t>(void*, void*);
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<float>(void*, void*);
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<double>(void*, void*);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<uint8_t>(void*, void*);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<int8_t>(void*, void*);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<uint16_t>(void*, void*);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<int16_t>(void*, void*);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<uint32_t>(void*, void*);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<int32_t>(void*, void*);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<uint64_t>(void*, void*);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<int64_t>(void*, void*);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<float>(void*, void*);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation<double>(void*, void*);

--- a/ai_evol_eval_output_impl_proliferation.h
+++ b/ai_evol_eval_output_impl_proliferation.h
@@ -3,7 +3,7 @@
 #include "ai_evol_eval_output.h"
 #include "rand_anyrng.h"
 
-namespace brendancuda {
+namespace bcuda {
     namespace ai {
         namespace evol {
             namespace eval {
@@ -17,8 +17,8 @@ namespace brendancuda {
                         size_t outputCount;
                         _T mask;
                         void* sd_ci;
-                        brendancuda::random::AnyRNG<uint64_t> rng;
-                        __forceinline Evaluate_Proliferation_SD(brendancuda::random::AnyRNG<uint64_t> RNG);
+                        bcuda::random::AnyRNG<uint64_t> rng;
+                        __forceinline Evaluate_Proliferation_SD(bcuda::random::AnyRNG<uint64_t> RNG);
                     };
                     template <>
                     struct Evaluate_Proliferation_SD<float> final {
@@ -28,8 +28,8 @@ namespace brendancuda {
                         size_t inputCount;
                         size_t outputCount;
                         void* sd_ci;
-                        brendancuda::random::AnyRNG<uint64_t> rng;
-                        __forceinline Evaluate_Proliferation_SD(brendancuda::random::AnyRNG<uint64_t> RNG);
+                        bcuda::random::AnyRNG<uint64_t> rng;
+                        __forceinline Evaluate_Proliferation_SD(bcuda::random::AnyRNG<uint64_t> RNG);
                     };
                     template <>
                     struct Evaluate_Proliferation_SD<double> final {
@@ -39,8 +39,8 @@ namespace brendancuda {
                         size_t inputCount;
                         size_t outputCount;
                         void* sd_ci;
-                        brendancuda::random::AnyRNG<uint64_t> rng;
-                        __forceinline Evaluate_Proliferation_SD(brendancuda::random::AnyRNG<uint64_t> RNG);
+                        bcuda::random::AnyRNG<uint64_t> rng;
+                        __forceinline Evaluate_Proliferation_SD(bcuda::random::AnyRNG<uint64_t> RNG);
                     };
 
                     template <typename _T>
@@ -54,7 +54,7 @@ namespace brendancuda {
 }
 
 template <typename _T>
-__forceinline brendancuda::ai::evol::eval::output::Evaluate_Proliferation_SD<_T>::Evaluate_Proliferation_SD(brendancuda::random::AnyRNG<uint64_t> RNG)
+__forceinline bcuda::ai::evol::eval::output::Evaluate_Proliferation_SD<_T>::Evaluate_Proliferation_SD(bcuda::random::AnyRNG<uint64_t> RNG)
     : rng(RNG),
     instanceFunctions() {
     iterationsPerRound = 0;
@@ -64,7 +64,7 @@ __forceinline brendancuda::ai::evol::eval::output::Evaluate_Proliferation_SD<_T>
     mask = 0;
     sd_ci = 0;
 }
-__forceinline brendancuda::ai::evol::eval::output::Evaluate_Proliferation_SD<float>::Evaluate_Proliferation_SD(brendancuda::random::AnyRNG<uint64_t> RNG)
+__forceinline bcuda::ai::evol::eval::output::Evaluate_Proliferation_SD<float>::Evaluate_Proliferation_SD(bcuda::random::AnyRNG<uint64_t> RNG)
     : rng(RNG),
     instanceFunctions() {
     iterationsPerRound = 0;
@@ -73,7 +73,7 @@ __forceinline brendancuda::ai::evol::eval::output::Evaluate_Proliferation_SD<flo
     outputCount = 0;
     sd_ci = 0;
 }
-__forceinline brendancuda::ai::evol::eval::output::Evaluate_Proliferation_SD<double>::Evaluate_Proliferation_SD(brendancuda::random::AnyRNG<uint64_t> RNG)
+__forceinline bcuda::ai::evol::eval::output::Evaluate_Proliferation_SD<double>::Evaluate_Proliferation_SD(bcuda::random::AnyRNG<uint64_t> RNG)
     : rng(RNG),
     instanceFunctions() {
     iterationsPerRound = 0;

--- a/ai_evol_eval_output_impl_proliferation.h
+++ b/ai_evol_eval_output_impl_proliferation.h
@@ -4,7 +4,7 @@
 #include "rand_anyrng.h"
 
 namespace brendancuda {
-    namespace AI {
+    namespace ai {
         namespace Evolution {
             namespace Evaluation {
                 namespace Output {
@@ -54,7 +54,7 @@ namespace brendancuda {
 }
 
 template <typename _T>
-__forceinline brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation_SD<_T>::Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG)
+__forceinline brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation_SD<_T>::Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG)
     : rng(RNG),
     instanceFunctions() {
     iterationsPerRound = 0;
@@ -64,7 +64,7 @@ __forceinline brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Prolifera
     mask = 0;
     sd_ci = 0;
 }
-__forceinline brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation_SD<float>::Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG)
+__forceinline brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation_SD<float>::Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG)
     : rng(RNG),
     instanceFunctions() {
     iterationsPerRound = 0;
@@ -73,7 +73,7 @@ __forceinline brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Prolifera
     outputCount = 0;
     sd_ci = 0;
 }
-__forceinline brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation_SD<double>::Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG)
+__forceinline brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation_SD<double>::Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG)
     : rng(RNG),
     instanceFunctions() {
     iterationsPerRound = 0;

--- a/ai_evol_eval_output_impl_proliferation.h
+++ b/ai_evol_eval_output_impl_proliferation.h
@@ -3,7 +3,7 @@
 #include "ai_evol_eval_output.h"
 #include "rand_anyrng.h"
 
-namespace BrendanCUDA {
+namespace brendancuda {
     namespace AI {
         namespace Evolution {
             namespace Evaluation {
@@ -17,8 +17,8 @@ namespace BrendanCUDA {
                         size_t outputCount;
                         _T mask;
                         void* sd_ci;
-                        BrendanCUDA::Random::AnyRNG<uint64_t> rng;
-                        __forceinline Evaluate_Proliferation_SD(BrendanCUDA::Random::AnyRNG<uint64_t> RNG);
+                        brendancuda::Random::AnyRNG<uint64_t> rng;
+                        __forceinline Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG);
                     };
                     template <>
                     struct Evaluate_Proliferation_SD<float> final {
@@ -28,8 +28,8 @@ namespace BrendanCUDA {
                         size_t inputCount;
                         size_t outputCount;
                         void* sd_ci;
-                        BrendanCUDA::Random::AnyRNG<uint64_t> rng;
-                        __forceinline Evaluate_Proliferation_SD(BrendanCUDA::Random::AnyRNG<uint64_t> RNG);
+                        brendancuda::Random::AnyRNG<uint64_t> rng;
+                        __forceinline Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG);
                     };
                     template <>
                     struct Evaluate_Proliferation_SD<double> final {
@@ -39,8 +39,8 @@ namespace BrendanCUDA {
                         size_t inputCount;
                         size_t outputCount;
                         void* sd_ci;
-                        BrendanCUDA::Random::AnyRNG<uint64_t> rng;
-                        __forceinline Evaluate_Proliferation_SD(BrendanCUDA::Random::AnyRNG<uint64_t> RNG);
+                        brendancuda::Random::AnyRNG<uint64_t> rng;
+                        __forceinline Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG);
                     };
 
                     template <typename _T>
@@ -54,7 +54,7 @@ namespace BrendanCUDA {
 }
 
 template <typename _T>
-__forceinline BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_Proliferation_SD<_T>::Evaluate_Proliferation_SD(BrendanCUDA::Random::AnyRNG<uint64_t> RNG)
+__forceinline brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation_SD<_T>::Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG)
     : rng(RNG),
     instanceFunctions() {
     iterationsPerRound = 0;
@@ -64,7 +64,7 @@ __forceinline BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_Prolifera
     mask = 0;
     sd_ci = 0;
 }
-__forceinline BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_Proliferation_SD<float>::Evaluate_Proliferation_SD(BrendanCUDA::Random::AnyRNG<uint64_t> RNG)
+__forceinline brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation_SD<float>::Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG)
     : rng(RNG),
     instanceFunctions() {
     iterationsPerRound = 0;
@@ -73,7 +73,7 @@ __forceinline BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_Prolifera
     outputCount = 0;
     sd_ci = 0;
 }
-__forceinline BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_Proliferation_SD<double>::Evaluate_Proliferation_SD(BrendanCUDA::Random::AnyRNG<uint64_t> RNG)
+__forceinline brendancuda::AI::Evolution::Evaluation::Output::Evaluate_Proliferation_SD<double>::Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG)
     : rng(RNG),
     instanceFunctions() {
     iterationsPerRound = 0;

--- a/ai_evol_eval_output_impl_proliferation.h
+++ b/ai_evol_eval_output_impl_proliferation.h
@@ -7,7 +7,7 @@ namespace brendancuda {
     namespace ai {
         namespace evolution {
             namespace evaluation {
-                namespace Output {
+                namespace output {
                     template <typename _T>
                     struct Evaluate_Proliferation_SD final {
                         InstanceFunctions<_T*, _T*> instanceFunctions;
@@ -54,7 +54,7 @@ namespace brendancuda {
 }
 
 template <typename _T>
-__forceinline brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation_SD<_T>::Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG)
+__forceinline brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation_SD<_T>::Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG)
     : rng(RNG),
     instanceFunctions() {
     iterationsPerRound = 0;
@@ -64,7 +64,7 @@ __forceinline brendancuda::ai::evolution::evaluation::Output::Evaluate_Prolifera
     mask = 0;
     sd_ci = 0;
 }
-__forceinline brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation_SD<float>::Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG)
+__forceinline brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation_SD<float>::Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG)
     : rng(RNG),
     instanceFunctions() {
     iterationsPerRound = 0;
@@ -73,7 +73,7 @@ __forceinline brendancuda::ai::evolution::evaluation::Output::Evaluate_Prolifera
     outputCount = 0;
     sd_ci = 0;
 }
-__forceinline brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation_SD<double>::Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG)
+__forceinline brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation_SD<double>::Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG)
     : rng(RNG),
     instanceFunctions() {
     iterationsPerRound = 0;

--- a/ai_evol_eval_output_impl_proliferation.h
+++ b/ai_evol_eval_output_impl_proliferation.h
@@ -5,7 +5,7 @@
 
 namespace brendancuda {
     namespace ai {
-        namespace evolution {
+        namespace evol {
             namespace evaluation {
                 namespace output {
                     template <typename _T>
@@ -54,7 +54,7 @@ namespace brendancuda {
 }
 
 template <typename _T>
-__forceinline brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation_SD<_T>::Evaluate_Proliferation_SD(brendancuda::random::AnyRNG<uint64_t> RNG)
+__forceinline brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation_SD<_T>::Evaluate_Proliferation_SD(brendancuda::random::AnyRNG<uint64_t> RNG)
     : rng(RNG),
     instanceFunctions() {
     iterationsPerRound = 0;
@@ -64,7 +64,7 @@ __forceinline brendancuda::ai::evolution::evaluation::output::Evaluate_Prolifera
     mask = 0;
     sd_ci = 0;
 }
-__forceinline brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation_SD<float>::Evaluate_Proliferation_SD(brendancuda::random::AnyRNG<uint64_t> RNG)
+__forceinline brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation_SD<float>::Evaluate_Proliferation_SD(brendancuda::random::AnyRNG<uint64_t> RNG)
     : rng(RNG),
     instanceFunctions() {
     iterationsPerRound = 0;
@@ -73,7 +73,7 @@ __forceinline brendancuda::ai::evolution::evaluation::output::Evaluate_Prolifera
     outputCount = 0;
     sd_ci = 0;
 }
-__forceinline brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation_SD<double>::Evaluate_Proliferation_SD(brendancuda::random::AnyRNG<uint64_t> RNG)
+__forceinline brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation_SD<double>::Evaluate_Proliferation_SD(brendancuda::random::AnyRNG<uint64_t> RNG)
     : rng(RNG),
     instanceFunctions() {
     iterationsPerRound = 0;

--- a/ai_evol_eval_output_impl_proliferation.h
+++ b/ai_evol_eval_output_impl_proliferation.h
@@ -5,7 +5,7 @@
 
 namespace brendancuda {
     namespace ai {
-        namespace Evolution {
+        namespace evolution {
             namespace Evaluation {
                 namespace Output {
                     template <typename _T>
@@ -54,7 +54,7 @@ namespace brendancuda {
 }
 
 template <typename _T>
-__forceinline brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation_SD<_T>::Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG)
+__forceinline brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation_SD<_T>::Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG)
     : rng(RNG),
     instanceFunctions() {
     iterationsPerRound = 0;
@@ -64,7 +64,7 @@ __forceinline brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Prolifera
     mask = 0;
     sd_ci = 0;
 }
-__forceinline brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation_SD<float>::Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG)
+__forceinline brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation_SD<float>::Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG)
     : rng(RNG),
     instanceFunctions() {
     iterationsPerRound = 0;
@@ -73,7 +73,7 @@ __forceinline brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Prolifera
     outputCount = 0;
     sd_ci = 0;
 }
-__forceinline brendancuda::ai::Evolution::Evaluation::Output::Evaluate_Proliferation_SD<double>::Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG)
+__forceinline brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation_SD<double>::Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG)
     : rng(RNG),
     instanceFunctions() {
     iterationsPerRound = 0;

--- a/ai_evol_eval_output_impl_proliferation.h
+++ b/ai_evol_eval_output_impl_proliferation.h
@@ -6,7 +6,7 @@
 namespace brendancuda {
     namespace ai {
         namespace evol {
-            namespace evaluation {
+            namespace eval {
                 namespace output {
                     template <typename _T>
                     struct Evaluate_Proliferation_SD final {
@@ -54,7 +54,7 @@ namespace brendancuda {
 }
 
 template <typename _T>
-__forceinline brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation_SD<_T>::Evaluate_Proliferation_SD(brendancuda::random::AnyRNG<uint64_t> RNG)
+__forceinline brendancuda::ai::evol::eval::output::Evaluate_Proliferation_SD<_T>::Evaluate_Proliferation_SD(brendancuda::random::AnyRNG<uint64_t> RNG)
     : rng(RNG),
     instanceFunctions() {
     iterationsPerRound = 0;
@@ -64,7 +64,7 @@ __forceinline brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation_
     mask = 0;
     sd_ci = 0;
 }
-__forceinline brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation_SD<float>::Evaluate_Proliferation_SD(brendancuda::random::AnyRNG<uint64_t> RNG)
+__forceinline brendancuda::ai::evol::eval::output::Evaluate_Proliferation_SD<float>::Evaluate_Proliferation_SD(brendancuda::random::AnyRNG<uint64_t> RNG)
     : rng(RNG),
     instanceFunctions() {
     iterationsPerRound = 0;
@@ -73,7 +73,7 @@ __forceinline brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation_
     outputCount = 0;
     sd_ci = 0;
 }
-__forceinline brendancuda::ai::evol::evaluation::output::Evaluate_Proliferation_SD<double>::Evaluate_Proliferation_SD(brendancuda::random::AnyRNG<uint64_t> RNG)
+__forceinline brendancuda::ai::evol::eval::output::Evaluate_Proliferation_SD<double>::Evaluate_Proliferation_SD(brendancuda::random::AnyRNG<uint64_t> RNG)
     : rng(RNG),
     instanceFunctions() {
     iterationsPerRound = 0;

--- a/ai_evol_eval_output_impl_proliferation.h
+++ b/ai_evol_eval_output_impl_proliferation.h
@@ -6,7 +6,7 @@
 namespace brendancuda {
     namespace ai {
         namespace evolution {
-            namespace Evaluation {
+            namespace evaluation {
                 namespace Output {
                     template <typename _T>
                     struct Evaluate_Proliferation_SD final {
@@ -54,7 +54,7 @@ namespace brendancuda {
 }
 
 template <typename _T>
-__forceinline brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation_SD<_T>::Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG)
+__forceinline brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation_SD<_T>::Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG)
     : rng(RNG),
     instanceFunctions() {
     iterationsPerRound = 0;
@@ -64,7 +64,7 @@ __forceinline brendancuda::ai::evolution::Evaluation::Output::Evaluate_Prolifera
     mask = 0;
     sd_ci = 0;
 }
-__forceinline brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation_SD<float>::Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG)
+__forceinline brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation_SD<float>::Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG)
     : rng(RNG),
     instanceFunctions() {
     iterationsPerRound = 0;
@@ -73,7 +73,7 @@ __forceinline brendancuda::ai::evolution::Evaluation::Output::Evaluate_Prolifera
     outputCount = 0;
     sd_ci = 0;
 }
-__forceinline brendancuda::ai::evolution::Evaluation::Output::Evaluate_Proliferation_SD<double>::Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG)
+__forceinline brendancuda::ai::evolution::evaluation::Output::Evaluate_Proliferation_SD<double>::Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG)
     : rng(RNG),
     instanceFunctions() {
     iterationsPerRound = 0;

--- a/ai_evol_eval_output_impl_proliferation.h
+++ b/ai_evol_eval_output_impl_proliferation.h
@@ -17,8 +17,8 @@ namespace brendancuda {
                         size_t outputCount;
                         _T mask;
                         void* sd_ci;
-                        brendancuda::Random::AnyRNG<uint64_t> rng;
-                        __forceinline Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG);
+                        brendancuda::random::AnyRNG<uint64_t> rng;
+                        __forceinline Evaluate_Proliferation_SD(brendancuda::random::AnyRNG<uint64_t> RNG);
                     };
                     template <>
                     struct Evaluate_Proliferation_SD<float> final {
@@ -28,8 +28,8 @@ namespace brendancuda {
                         size_t inputCount;
                         size_t outputCount;
                         void* sd_ci;
-                        brendancuda::Random::AnyRNG<uint64_t> rng;
-                        __forceinline Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG);
+                        brendancuda::random::AnyRNG<uint64_t> rng;
+                        __forceinline Evaluate_Proliferation_SD(brendancuda::random::AnyRNG<uint64_t> RNG);
                     };
                     template <>
                     struct Evaluate_Proliferation_SD<double> final {
@@ -39,8 +39,8 @@ namespace brendancuda {
                         size_t inputCount;
                         size_t outputCount;
                         void* sd_ci;
-                        brendancuda::Random::AnyRNG<uint64_t> rng;
-                        __forceinline Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG);
+                        brendancuda::random::AnyRNG<uint64_t> rng;
+                        __forceinline Evaluate_Proliferation_SD(brendancuda::random::AnyRNG<uint64_t> RNG);
                     };
 
                     template <typename _T>
@@ -54,7 +54,7 @@ namespace brendancuda {
 }
 
 template <typename _T>
-__forceinline brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation_SD<_T>::Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG)
+__forceinline brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation_SD<_T>::Evaluate_Proliferation_SD(brendancuda::random::AnyRNG<uint64_t> RNG)
     : rng(RNG),
     instanceFunctions() {
     iterationsPerRound = 0;
@@ -64,7 +64,7 @@ __forceinline brendancuda::ai::evolution::evaluation::output::Evaluate_Prolifera
     mask = 0;
     sd_ci = 0;
 }
-__forceinline brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation_SD<float>::Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG)
+__forceinline brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation_SD<float>::Evaluate_Proliferation_SD(brendancuda::random::AnyRNG<uint64_t> RNG)
     : rng(RNG),
     instanceFunctions() {
     iterationsPerRound = 0;
@@ -73,7 +73,7 @@ __forceinline brendancuda::ai::evolution::evaluation::output::Evaluate_Prolifera
     outputCount = 0;
     sd_ci = 0;
 }
-__forceinline brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation_SD<double>::Evaluate_Proliferation_SD(brendancuda::Random::AnyRNG<uint64_t> RNG)
+__forceinline brendancuda::ai::evolution::evaluation::output::Evaluate_Proliferation_SD<double>::Evaluate_Proliferation_SD(brendancuda::random::AnyRNG<uint64_t> RNG)
     : rng(RNG),
     instanceFunctions() {
     iterationsPerRound = 0;

--- a/ai_evol_eval_output_impl_uniquevalues.cpp
+++ b/ai_evol_eval_output_impl_uniquevalues.cpp
@@ -3,7 +3,7 @@
 #include <unordered_set>
 
 template <typename _T>
-float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues(void* Object, Evaluate_UniqueValues_SD<_T>& Settings) {
+float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues(void* Object, Evaluate_UniqueValues_SD<_T>& Settings) {
     Instance_V<_T*, _T*> oi(Settings.instanceFunctions, Object, Settings.sd_ci);
     if (Settings.individual) {
         std::unordered_set<_T>* s = new std::unordered_set<_T>[Settings.outputCount];
@@ -40,24 +40,24 @@ float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues(void
 }
 
 template <typename _T>
-float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues(void* Object, void* Settings) {
+float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues(void* Object, void* Settings) {
     return Evaluate_UniqueValues(Object, *(Evaluate_UniqueValues_SD<_T>*)Settings);
 }
 
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint8_t>(void*, Evaluate_UniqueValues_SD<uint8_t>&);
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<int8_t>(void*, Evaluate_UniqueValues_SD<int8_t>&);
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint16_t>(void*, Evaluate_UniqueValues_SD<uint16_t>&);
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<int16_t>(void*, Evaluate_UniqueValues_SD<int16_t>&);
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint32_t>(void*, Evaluate_UniqueValues_SD<uint32_t>&);
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<int32_t>(void*, Evaluate_UniqueValues_SD<int32_t>&);
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint64_t>(void*, Evaluate_UniqueValues_SD<uint64_t>&);
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<int64_t>(void*, Evaluate_UniqueValues_SD<int64_t>&);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint8_t>(void*, Evaluate_UniqueValues_SD<uint8_t>&);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues<int8_t>(void*, Evaluate_UniqueValues_SD<int8_t>&);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint16_t>(void*, Evaluate_UniqueValues_SD<uint16_t>&);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues<int16_t>(void*, Evaluate_UniqueValues_SD<int16_t>&);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint32_t>(void*, Evaluate_UniqueValues_SD<uint32_t>&);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues<int32_t>(void*, Evaluate_UniqueValues_SD<int32_t>&);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint64_t>(void*, Evaluate_UniqueValues_SD<uint64_t>&);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues<int64_t>(void*, Evaluate_UniqueValues_SD<int64_t>&);
 
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint8_t>(void*, void*);
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<int8_t>(void*, void*);
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint16_t>(void*, void*);
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<int16_t>(void*, void*);
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint32_t>(void*, void*);
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<int32_t>(void*, void*);
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint64_t>(void*, void*);
-template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<int64_t>(void*, void*);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint8_t>(void*, void*);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues<int8_t>(void*, void*);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint16_t>(void*, void*);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues<int16_t>(void*, void*);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint32_t>(void*, void*);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues<int32_t>(void*, void*);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint64_t>(void*, void*);
+template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues<int64_t>(void*, void*);

--- a/ai_evol_eval_output_impl_uniquevalues.cpp
+++ b/ai_evol_eval_output_impl_uniquevalues.cpp
@@ -3,7 +3,7 @@
 #include <unordered_set>
 
 template <typename _T>
-float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues(void* Object, Evaluate_UniqueValues_SD<_T>& Settings) {
+float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues(void* Object, Evaluate_UniqueValues_SD<_T>& Settings) {
     Instance_V<_T*, _T*> oi(Settings.instanceFunctions, Object, Settings.sd_ci);
     if (Settings.individual) {
         std::unordered_set<_T>* s = new std::unordered_set<_T>[Settings.outputCount];
@@ -40,24 +40,24 @@ float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues(void* Obj
 }
 
 template <typename _T>
-float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues(void* Object, void* Settings) {
+float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues(void* Object, void* Settings) {
     return Evaluate_UniqueValues(Object, *(Evaluate_UniqueValues_SD<_T>*)Settings);
 }
 
-template float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues<uint8_t>(void*, Evaluate_UniqueValues_SD<uint8_t>&);
-template float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues<int8_t>(void*, Evaluate_UniqueValues_SD<int8_t>&);
-template float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues<uint16_t>(void*, Evaluate_UniqueValues_SD<uint16_t>&);
-template float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues<int16_t>(void*, Evaluate_UniqueValues_SD<int16_t>&);
-template float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues<uint32_t>(void*, Evaluate_UniqueValues_SD<uint32_t>&);
-template float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues<int32_t>(void*, Evaluate_UniqueValues_SD<int32_t>&);
-template float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues<uint64_t>(void*, Evaluate_UniqueValues_SD<uint64_t>&);
-template float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues<int64_t>(void*, Evaluate_UniqueValues_SD<int64_t>&);
+template float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues<uint8_t>(void*, Evaluate_UniqueValues_SD<uint8_t>&);
+template float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues<int8_t>(void*, Evaluate_UniqueValues_SD<int8_t>&);
+template float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues<uint16_t>(void*, Evaluate_UniqueValues_SD<uint16_t>&);
+template float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues<int16_t>(void*, Evaluate_UniqueValues_SD<int16_t>&);
+template float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues<uint32_t>(void*, Evaluate_UniqueValues_SD<uint32_t>&);
+template float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues<int32_t>(void*, Evaluate_UniqueValues_SD<int32_t>&);
+template float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues<uint64_t>(void*, Evaluate_UniqueValues_SD<uint64_t>&);
+template float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues<int64_t>(void*, Evaluate_UniqueValues_SD<int64_t>&);
 
-template float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues<uint8_t>(void*, void*);
-template float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues<int8_t>(void*, void*);
-template float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues<uint16_t>(void*, void*);
-template float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues<int16_t>(void*, void*);
-template float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues<uint32_t>(void*, void*);
-template float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues<int32_t>(void*, void*);
-template float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues<uint64_t>(void*, void*);
-template float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues<int64_t>(void*, void*);
+template float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues<uint8_t>(void*, void*);
+template float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues<int8_t>(void*, void*);
+template float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues<uint16_t>(void*, void*);
+template float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues<int16_t>(void*, void*);
+template float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues<uint32_t>(void*, void*);
+template float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues<int32_t>(void*, void*);
+template float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues<uint64_t>(void*, void*);
+template float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues<int64_t>(void*, void*);

--- a/ai_evol_eval_output_impl_uniquevalues.cpp
+++ b/ai_evol_eval_output_impl_uniquevalues.cpp
@@ -3,7 +3,7 @@
 #include <unordered_set>
 
 template <typename _T>
-float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues(void* Object, Evaluate_UniqueValues_SD<_T>& Settings) {
+float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues(void* Object, Evaluate_UniqueValues_SD<_T>& Settings) {
     Instance_V<_T*, _T*> oi(Settings.instanceFunctions, Object, Settings.sd_ci);
     if (Settings.individual) {
         std::unordered_set<_T>* s = new std::unordered_set<_T>[Settings.outputCount];
@@ -40,24 +40,24 @@ float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues(void
 }
 
 template <typename _T>
-float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues(void* Object, void* Settings) {
+float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues(void* Object, void* Settings) {
     return Evaluate_UniqueValues(Object, *(Evaluate_UniqueValues_SD<_T>*)Settings);
 }
 
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint8_t>(void*, Evaluate_UniqueValues_SD<uint8_t>&);
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<int8_t>(void*, Evaluate_UniqueValues_SD<int8_t>&);
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint16_t>(void*, Evaluate_UniqueValues_SD<uint16_t>&);
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<int16_t>(void*, Evaluate_UniqueValues_SD<int16_t>&);
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint32_t>(void*, Evaluate_UniqueValues_SD<uint32_t>&);
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<int32_t>(void*, Evaluate_UniqueValues_SD<int32_t>&);
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint64_t>(void*, Evaluate_UniqueValues_SD<uint64_t>&);
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<int64_t>(void*, Evaluate_UniqueValues_SD<int64_t>&);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint8_t>(void*, Evaluate_UniqueValues_SD<uint8_t>&);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<int8_t>(void*, Evaluate_UniqueValues_SD<int8_t>&);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint16_t>(void*, Evaluate_UniqueValues_SD<uint16_t>&);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<int16_t>(void*, Evaluate_UniqueValues_SD<int16_t>&);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint32_t>(void*, Evaluate_UniqueValues_SD<uint32_t>&);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<int32_t>(void*, Evaluate_UniqueValues_SD<int32_t>&);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint64_t>(void*, Evaluate_UniqueValues_SD<uint64_t>&);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<int64_t>(void*, Evaluate_UniqueValues_SD<int64_t>&);
 
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint8_t>(void*, void*);
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<int8_t>(void*, void*);
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint16_t>(void*, void*);
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<int16_t>(void*, void*);
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint32_t>(void*, void*);
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<int32_t>(void*, void*);
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint64_t>(void*, void*);
-template float BrendanCUDA::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<int64_t>(void*, void*);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint8_t>(void*, void*);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<int8_t>(void*, void*);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint16_t>(void*, void*);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<int16_t>(void*, void*);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint32_t>(void*, void*);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<int32_t>(void*, void*);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint64_t>(void*, void*);
+template float brendancuda::AI::Evolution::Evaluation::Output::Evaluate_UniqueValues<int64_t>(void*, void*);

--- a/ai_evol_eval_output_impl_uniquevalues.cpp
+++ b/ai_evol_eval_output_impl_uniquevalues.cpp
@@ -3,7 +3,7 @@
 #include <unordered_set>
 
 template <typename _T>
-float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues(void* Object, Evaluate_UniqueValues_SD<_T>& Settings) {
+float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues(void* Object, Evaluate_UniqueValues_SD<_T>& Settings) {
     Instance_V<_T*, _T*> oi(Settings.instanceFunctions, Object, Settings.sd_ci);
     if (Settings.individual) {
         std::unordered_set<_T>* s = new std::unordered_set<_T>[Settings.outputCount];
@@ -40,24 +40,24 @@ float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues(void
 }
 
 template <typename _T>
-float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues(void* Object, void* Settings) {
+float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues(void* Object, void* Settings) {
     return Evaluate_UniqueValues(Object, *(Evaluate_UniqueValues_SD<_T>*)Settings);
 }
 
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues<uint8_t>(void*, Evaluate_UniqueValues_SD<uint8_t>&);
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues<int8_t>(void*, Evaluate_UniqueValues_SD<int8_t>&);
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues<uint16_t>(void*, Evaluate_UniqueValues_SD<uint16_t>&);
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues<int16_t>(void*, Evaluate_UniqueValues_SD<int16_t>&);
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues<uint32_t>(void*, Evaluate_UniqueValues_SD<uint32_t>&);
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues<int32_t>(void*, Evaluate_UniqueValues_SD<int32_t>&);
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues<uint64_t>(void*, Evaluate_UniqueValues_SD<uint64_t>&);
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues<int64_t>(void*, Evaluate_UniqueValues_SD<int64_t>&);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues<uint8_t>(void*, Evaluate_UniqueValues_SD<uint8_t>&);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues<int8_t>(void*, Evaluate_UniqueValues_SD<int8_t>&);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues<uint16_t>(void*, Evaluate_UniqueValues_SD<uint16_t>&);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues<int16_t>(void*, Evaluate_UniqueValues_SD<int16_t>&);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues<uint32_t>(void*, Evaluate_UniqueValues_SD<uint32_t>&);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues<int32_t>(void*, Evaluate_UniqueValues_SD<int32_t>&);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues<uint64_t>(void*, Evaluate_UniqueValues_SD<uint64_t>&);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues<int64_t>(void*, Evaluate_UniqueValues_SD<int64_t>&);
 
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues<uint8_t>(void*, void*);
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues<int8_t>(void*, void*);
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues<uint16_t>(void*, void*);
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues<int16_t>(void*, void*);
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues<uint32_t>(void*, void*);
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues<int32_t>(void*, void*);
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues<uint64_t>(void*, void*);
-template float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues<int64_t>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues<uint8_t>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues<int8_t>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues<uint16_t>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues<int16_t>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues<uint32_t>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues<int32_t>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues<uint64_t>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues<int64_t>(void*, void*);

--- a/ai_evol_eval_output_impl_uniquevalues.cpp
+++ b/ai_evol_eval_output_impl_uniquevalues.cpp
@@ -3,7 +3,7 @@
 #include <unordered_set>
 
 template <typename _T>
-float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues(void* Object, Evaluate_UniqueValues_SD<_T>& Settings) {
+float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues(void* Object, Evaluate_UniqueValues_SD<_T>& Settings) {
     Instance_V<_T*, _T*> oi(Settings.instanceFunctions, Object, Settings.sd_ci);
     if (Settings.individual) {
         std::unordered_set<_T>* s = new std::unordered_set<_T>[Settings.outputCount];
@@ -40,24 +40,24 @@ float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues(void
 }
 
 template <typename _T>
-float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues(void* Object, void* Settings) {
+float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues(void* Object, void* Settings) {
     return Evaluate_UniqueValues(Object, *(Evaluate_UniqueValues_SD<_T>*)Settings);
 }
 
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues<uint8_t>(void*, Evaluate_UniqueValues_SD<uint8_t>&);
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues<int8_t>(void*, Evaluate_UniqueValues_SD<int8_t>&);
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues<uint16_t>(void*, Evaluate_UniqueValues_SD<uint16_t>&);
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues<int16_t>(void*, Evaluate_UniqueValues_SD<int16_t>&);
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues<uint32_t>(void*, Evaluate_UniqueValues_SD<uint32_t>&);
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues<int32_t>(void*, Evaluate_UniqueValues_SD<int32_t>&);
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues<uint64_t>(void*, Evaluate_UniqueValues_SD<uint64_t>&);
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues<int64_t>(void*, Evaluate_UniqueValues_SD<int64_t>&);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues<uint8_t>(void*, Evaluate_UniqueValues_SD<uint8_t>&);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues<int8_t>(void*, Evaluate_UniqueValues_SD<int8_t>&);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues<uint16_t>(void*, Evaluate_UniqueValues_SD<uint16_t>&);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues<int16_t>(void*, Evaluate_UniqueValues_SD<int16_t>&);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues<uint32_t>(void*, Evaluate_UniqueValues_SD<uint32_t>&);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues<int32_t>(void*, Evaluate_UniqueValues_SD<int32_t>&);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues<uint64_t>(void*, Evaluate_UniqueValues_SD<uint64_t>&);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues<int64_t>(void*, Evaluate_UniqueValues_SD<int64_t>&);
 
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues<uint8_t>(void*, void*);
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues<int8_t>(void*, void*);
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues<uint16_t>(void*, void*);
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues<int16_t>(void*, void*);
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues<uint32_t>(void*, void*);
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues<int32_t>(void*, void*);
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues<uint64_t>(void*, void*);
-template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues<int64_t>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues<uint8_t>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues<int8_t>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues<uint16_t>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues<int16_t>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues<uint32_t>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues<int32_t>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues<uint64_t>(void*, void*);
+template float brendancuda::ai::evolution::evaluation::Output::Evaluate_UniqueValues<int64_t>(void*, void*);

--- a/ai_evol_eval_output_impl_uniquevalues.cpp
+++ b/ai_evol_eval_output_impl_uniquevalues.cpp
@@ -3,7 +3,7 @@
 #include <unordered_set>
 
 template <typename _T>
-float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues(void* Object, Evaluate_UniqueValues_SD<_T>& Settings) {
+float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues(void* Object, Evaluate_UniqueValues_SD<_T>& Settings) {
     Instance_V<_T*, _T*> oi(Settings.instanceFunctions, Object, Settings.sd_ci);
     if (Settings.individual) {
         std::unordered_set<_T>* s = new std::unordered_set<_T>[Settings.outputCount];
@@ -40,24 +40,24 @@ float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues(void
 }
 
 template <typename _T>
-float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues(void* Object, void* Settings) {
+float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues(void* Object, void* Settings) {
     return Evaluate_UniqueValues(Object, *(Evaluate_UniqueValues_SD<_T>*)Settings);
 }
 
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint8_t>(void*, Evaluate_UniqueValues_SD<uint8_t>&);
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues<int8_t>(void*, Evaluate_UniqueValues_SD<int8_t>&);
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint16_t>(void*, Evaluate_UniqueValues_SD<uint16_t>&);
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues<int16_t>(void*, Evaluate_UniqueValues_SD<int16_t>&);
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint32_t>(void*, Evaluate_UniqueValues_SD<uint32_t>&);
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues<int32_t>(void*, Evaluate_UniqueValues_SD<int32_t>&);
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint64_t>(void*, Evaluate_UniqueValues_SD<uint64_t>&);
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues<int64_t>(void*, Evaluate_UniqueValues_SD<int64_t>&);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues<uint8_t>(void*, Evaluate_UniqueValues_SD<uint8_t>&);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues<int8_t>(void*, Evaluate_UniqueValues_SD<int8_t>&);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues<uint16_t>(void*, Evaluate_UniqueValues_SD<uint16_t>&);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues<int16_t>(void*, Evaluate_UniqueValues_SD<int16_t>&);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues<uint32_t>(void*, Evaluate_UniqueValues_SD<uint32_t>&);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues<int32_t>(void*, Evaluate_UniqueValues_SD<int32_t>&);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues<uint64_t>(void*, Evaluate_UniqueValues_SD<uint64_t>&);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues<int64_t>(void*, Evaluate_UniqueValues_SD<int64_t>&);
 
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint8_t>(void*, void*);
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues<int8_t>(void*, void*);
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint16_t>(void*, void*);
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues<int16_t>(void*, void*);
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint32_t>(void*, void*);
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues<int32_t>(void*, void*);
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues<uint64_t>(void*, void*);
-template float brendancuda::ai::Evolution::Evaluation::Output::Evaluate_UniqueValues<int64_t>(void*, void*);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues<uint8_t>(void*, void*);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues<int8_t>(void*, void*);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues<uint16_t>(void*, void*);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues<int16_t>(void*, void*);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues<uint32_t>(void*, void*);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues<int32_t>(void*, void*);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues<uint64_t>(void*, void*);
+template float brendancuda::ai::evolution::Evaluation::Output::Evaluate_UniqueValues<int64_t>(void*, void*);

--- a/ai_evol_eval_output_impl_uniquevalues.cpp
+++ b/ai_evol_eval_output_impl_uniquevalues.cpp
@@ -3,7 +3,7 @@
 #include <unordered_set>
 
 template <typename _T>
-float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues(void* Object, Evaluate_UniqueValues_SD<_T>& Settings) {
+float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues(void* Object, Evaluate_UniqueValues_SD<_T>& Settings) {
     Instance_V<_T*, _T*> oi(Settings.instanceFunctions, Object, Settings.sd_ci);
     if (Settings.individual) {
         std::unordered_set<_T>* s = new std::unordered_set<_T>[Settings.outputCount];
@@ -40,24 +40,24 @@ float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues(void
 }
 
 template <typename _T>
-float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues(void* Object, void* Settings) {
+float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues(void* Object, void* Settings) {
     return Evaluate_UniqueValues(Object, *(Evaluate_UniqueValues_SD<_T>*)Settings);
 }
 
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues<uint8_t>(void*, Evaluate_UniqueValues_SD<uint8_t>&);
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues<int8_t>(void*, Evaluate_UniqueValues_SD<int8_t>&);
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues<uint16_t>(void*, Evaluate_UniqueValues_SD<uint16_t>&);
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues<int16_t>(void*, Evaluate_UniqueValues_SD<int16_t>&);
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues<uint32_t>(void*, Evaluate_UniqueValues_SD<uint32_t>&);
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues<int32_t>(void*, Evaluate_UniqueValues_SD<int32_t>&);
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues<uint64_t>(void*, Evaluate_UniqueValues_SD<uint64_t>&);
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues<int64_t>(void*, Evaluate_UniqueValues_SD<int64_t>&);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues<uint8_t>(void*, Evaluate_UniqueValues_SD<uint8_t>&);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues<int8_t>(void*, Evaluate_UniqueValues_SD<int8_t>&);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues<uint16_t>(void*, Evaluate_UniqueValues_SD<uint16_t>&);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues<int16_t>(void*, Evaluate_UniqueValues_SD<int16_t>&);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues<uint32_t>(void*, Evaluate_UniqueValues_SD<uint32_t>&);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues<int32_t>(void*, Evaluate_UniqueValues_SD<int32_t>&);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues<uint64_t>(void*, Evaluate_UniqueValues_SD<uint64_t>&);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues<int64_t>(void*, Evaluate_UniqueValues_SD<int64_t>&);
 
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues<uint8_t>(void*, void*);
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues<int8_t>(void*, void*);
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues<uint16_t>(void*, void*);
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues<int16_t>(void*, void*);
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues<uint32_t>(void*, void*);
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues<int32_t>(void*, void*);
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues<uint64_t>(void*, void*);
-template float brendancuda::ai::evolution::evaluation::output::Evaluate_UniqueValues<int64_t>(void*, void*);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues<uint8_t>(void*, void*);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues<int8_t>(void*, void*);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues<uint16_t>(void*, void*);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues<int16_t>(void*, void*);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues<uint32_t>(void*, void*);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues<int32_t>(void*, void*);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues<uint64_t>(void*, void*);
+template float brendancuda::ai::evol::evaluation::output::Evaluate_UniqueValues<int64_t>(void*, void*);

--- a/ai_evol_eval_output_impl_uniquevalues.cpp
+++ b/ai_evol_eval_output_impl_uniquevalues.cpp
@@ -3,7 +3,7 @@
 #include <unordered_set>
 
 template <typename _T>
-float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues(void* Object, Evaluate_UniqueValues_SD<_T>& Settings) {
+float bcuda::ai::evol::eval::output::Evaluate_UniqueValues(void* Object, Evaluate_UniqueValues_SD<_T>& Settings) {
     Instance_V<_T*, _T*> oi(Settings.instanceFunctions, Object, Settings.sd_ci);
     if (Settings.individual) {
         std::unordered_set<_T>* s = new std::unordered_set<_T>[Settings.outputCount];
@@ -40,24 +40,24 @@ float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues(void* Object, E
 }
 
 template <typename _T>
-float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues(void* Object, void* Settings) {
+float bcuda::ai::evol::eval::output::Evaluate_UniqueValues(void* Object, void* Settings) {
     return Evaluate_UniqueValues(Object, *(Evaluate_UniqueValues_SD<_T>*)Settings);
 }
 
-template float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues<uint8_t>(void*, Evaluate_UniqueValues_SD<uint8_t>&);
-template float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues<int8_t>(void*, Evaluate_UniqueValues_SD<int8_t>&);
-template float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues<uint16_t>(void*, Evaluate_UniqueValues_SD<uint16_t>&);
-template float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues<int16_t>(void*, Evaluate_UniqueValues_SD<int16_t>&);
-template float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues<uint32_t>(void*, Evaluate_UniqueValues_SD<uint32_t>&);
-template float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues<int32_t>(void*, Evaluate_UniqueValues_SD<int32_t>&);
-template float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues<uint64_t>(void*, Evaluate_UniqueValues_SD<uint64_t>&);
-template float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues<int64_t>(void*, Evaluate_UniqueValues_SD<int64_t>&);
+template float bcuda::ai::evol::eval::output::Evaluate_UniqueValues<uint8_t>(void*, Evaluate_UniqueValues_SD<uint8_t>&);
+template float bcuda::ai::evol::eval::output::Evaluate_UniqueValues<int8_t>(void*, Evaluate_UniqueValues_SD<int8_t>&);
+template float bcuda::ai::evol::eval::output::Evaluate_UniqueValues<uint16_t>(void*, Evaluate_UniqueValues_SD<uint16_t>&);
+template float bcuda::ai::evol::eval::output::Evaluate_UniqueValues<int16_t>(void*, Evaluate_UniqueValues_SD<int16_t>&);
+template float bcuda::ai::evol::eval::output::Evaluate_UniqueValues<uint32_t>(void*, Evaluate_UniqueValues_SD<uint32_t>&);
+template float bcuda::ai::evol::eval::output::Evaluate_UniqueValues<int32_t>(void*, Evaluate_UniqueValues_SD<int32_t>&);
+template float bcuda::ai::evol::eval::output::Evaluate_UniqueValues<uint64_t>(void*, Evaluate_UniqueValues_SD<uint64_t>&);
+template float bcuda::ai::evol::eval::output::Evaluate_UniqueValues<int64_t>(void*, Evaluate_UniqueValues_SD<int64_t>&);
 
-template float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues<uint8_t>(void*, void*);
-template float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues<int8_t>(void*, void*);
-template float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues<uint16_t>(void*, void*);
-template float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues<int16_t>(void*, void*);
-template float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues<uint32_t>(void*, void*);
-template float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues<int32_t>(void*, void*);
-template float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues<uint64_t>(void*, void*);
-template float brendancuda::ai::evol::eval::output::Evaluate_UniqueValues<int64_t>(void*, void*);
+template float bcuda::ai::evol::eval::output::Evaluate_UniqueValues<uint8_t>(void*, void*);
+template float bcuda::ai::evol::eval::output::Evaluate_UniqueValues<int8_t>(void*, void*);
+template float bcuda::ai::evol::eval::output::Evaluate_UniqueValues<uint16_t>(void*, void*);
+template float bcuda::ai::evol::eval::output::Evaluate_UniqueValues<int16_t>(void*, void*);
+template float bcuda::ai::evol::eval::output::Evaluate_UniqueValues<uint32_t>(void*, void*);
+template float bcuda::ai::evol::eval::output::Evaluate_UniqueValues<int32_t>(void*, void*);
+template float bcuda::ai::evol::eval::output::Evaluate_UniqueValues<uint64_t>(void*, void*);
+template float bcuda::ai::evol::eval::output::Evaluate_UniqueValues<int64_t>(void*, void*);

--- a/ai_evol_eval_output_impl_uniquevalues.h
+++ b/ai_evol_eval_output_impl_uniquevalues.h
@@ -4,7 +4,7 @@
 
 namespace brendancuda {
     namespace ai {
-        namespace Evolution {
+        namespace evolution {
             namespace Evaluation {
                 namespace Output {
                     template <typename _T>

--- a/ai_evol_eval_output_impl_uniquevalues.h
+++ b/ai_evol_eval_output_impl_uniquevalues.h
@@ -2,7 +2,7 @@
 
 #include "ai_evol_eval_output.h"
 
-namespace brendancuda {
+namespace bcuda {
     namespace ai {
         namespace evol {
             namespace eval {

--- a/ai_evol_eval_output_impl_uniquevalues.h
+++ b/ai_evol_eval_output_impl_uniquevalues.h
@@ -6,7 +6,7 @@ namespace brendancuda {
     namespace ai {
         namespace evolution {
             namespace evaluation {
-                namespace Output {
+                namespace output {
                     template <typename _T>
                     struct Evaluate_UniqueValues_SD final {
                         InstanceFunctions<_T*, _T*> instanceFunctions;

--- a/ai_evol_eval_output_impl_uniquevalues.h
+++ b/ai_evol_eval_output_impl_uniquevalues.h
@@ -2,7 +2,7 @@
 
 #include "ai_evol_eval_output.h"
 
-namespace BrendanCUDA {
+namespace brendancuda {
     namespace AI {
         namespace Evolution {
             namespace Evaluation {

--- a/ai_evol_eval_output_impl_uniquevalues.h
+++ b/ai_evol_eval_output_impl_uniquevalues.h
@@ -5,7 +5,7 @@
 namespace brendancuda {
     namespace ai {
         namespace evol {
-            namespace evaluation {
+            namespace eval {
                 namespace output {
                     template <typename _T>
                     struct Evaluate_UniqueValues_SD final {

--- a/ai_evol_eval_output_impl_uniquevalues.h
+++ b/ai_evol_eval_output_impl_uniquevalues.h
@@ -4,7 +4,7 @@
 
 namespace brendancuda {
     namespace ai {
-        namespace evolution {
+        namespace evol {
             namespace evaluation {
                 namespace output {
                     template <typename _T>

--- a/ai_evol_eval_output_impl_uniquevalues.h
+++ b/ai_evol_eval_output_impl_uniquevalues.h
@@ -5,7 +5,7 @@
 namespace brendancuda {
     namespace ai {
         namespace evolution {
-            namespace Evaluation {
+            namespace evaluation {
                 namespace Output {
                     template <typename _T>
                     struct Evaluate_UniqueValues_SD final {

--- a/ai_evol_eval_output_impl_uniquevalues.h
+++ b/ai_evol_eval_output_impl_uniquevalues.h
@@ -3,7 +3,7 @@
 #include "ai_evol_eval_output.h"
 
 namespace brendancuda {
-    namespace AI {
+    namespace ai {
         namespace Evolution {
             namespace Evaluation {
                 namespace Output {

--- a/ai_evol_evolver.cpp
+++ b/ai_evol_evolver.cpp
@@ -1,7 +1,7 @@
 #include "ai_evol_evolver.h"
 #include <algorithm>
 
-brendancuda::ai::evol::Evolver::Evolver(
+bcuda::ai::evol::Evolver::Evolver(
     size_t ContestantCount,
     evaluationFunction_t EvaluationFunction,
     reproductionFunction_t ReproductionFunction,
@@ -11,7 +11,7 @@ brendancuda::ai::evol::Evolver::Evolver(
     reproductionFunction = ReproductionFunction;
     disposeFunction = DisposeFunction;
 }
-brendancuda::ai::evol::Evolver::Evolver(
+bcuda::ai::evol::Evolver::Evolver(
     size_t ContestantCount,
     evaluationFunction_t EvaluationFunction,
     reproductionFunction_t ReproductionFunction,
@@ -21,17 +21,17 @@ brendancuda::ai::evol::Evolver::Evolver(
 ) : Evolver(ContestantCount, EvaluationFunction, ReproductionFunction, DisposeFunction) {
     InitAllNoDisposal(CreationFunction, CreationSharedData);
 }
-brendancuda::ArrayV<void*> brendancuda::ai::evol::Evolver::Objects() {
+bcuda::ArrayV<void*> bcuda::ai::evol::Evolver::Objects() {
     return objs;
 }
-void brendancuda::ai::evol::Evolver::InitAllNoDisposal(creationFunction_t CreationFunction, void* CreationSharedData) {
+void bcuda::ai::evol::Evolver::InitAllNoDisposal(creationFunction_t CreationFunction, void* CreationSharedData) {
     std::uniform_int_distribution<uint64_t> dis(std::numeric_limits<uint64_t>::min(), std::numeric_limits<uint64_t>::max());
 
     for (size_t i = 0; i < objs.Size(); ++i) {
         objs[i] = CreationFunction(CreationSharedData);
     }
 }
-void brendancuda::ai::evol::Evolver::InitAll(void* DisposeSharedData, creationFunction_t CreationFunction, void* CreationSharedData) {
+void bcuda::ai::evol::Evolver::InitAll(void* DisposeSharedData, creationFunction_t CreationFunction, void* CreationSharedData) {
     std::uniform_int_distribution<uint64_t> dis(std::numeric_limits<uint64_t>::min(), std::numeric_limits<uint64_t>::max());
 
     for (size_t i = 0; i < objs.Size(); ++i) {
@@ -40,7 +40,7 @@ void brendancuda::ai::evol::Evolver::InitAll(void* DisposeSharedData, creationFu
         v = CreationFunction(CreationSharedData);
     }
 }
-brendancuda::ArrayV<std::pair<float, size_t>> brendancuda::ai::evol::Evolver::EvaluateAll(void* EvaluationSharedData) {
+bcuda::ArrayV<std::pair<float, size_t>> bcuda::ai::evol::Evolver::EvaluateAll(void* EvaluationSharedData) {
     std::uniform_int_distribution<uint64_t> dis(std::numeric_limits<uint64_t>::min(), std::numeric_limits<uint64_t>::max());
 
     ArrayV<std::pair<float, size_t>> scores(objs.Size());
@@ -49,12 +49,12 @@ brendancuda::ArrayV<std::pair<float, size_t>> brendancuda::ai::evol::Evolver::Ev
     }
     return scores;
 }
-void brendancuda::ai::evol::SortEvaluations(ArrayV<std::pair<float, size_t>> Evaluations) {
+void bcuda::ai::evol::SortEvaluations(ArrayV<std::pair<float, size_t>> Evaluations) {
     std::sort(Evaluations.Data(), Evaluations.Data() + Evaluations.Size(), [](const auto& a, const auto& b) {
         return a.first < b.first;
     });
 }
-void brendancuda::ai::evol::Evolver::ActOnSortedEvaluations(ArrayV<std::pair<float, size_t>> Evaluations, void* DisposeSharedData, void* ReproductionSharedData) {
+void bcuda::ai::evol::Evolver::ActOnSortedEvaluations(ArrayV<std::pair<float, size_t>> Evaluations, void* DisposeSharedData, void* ReproductionSharedData) {
     std::uniform_int_distribution<uint64_t> dis(std::numeric_limits<uint64_t>::min(), std::numeric_limits<uint64_t>::max());
     
     if (Evaluations.Size() != objs.Size())
@@ -74,13 +74,13 @@ void brendancuda::ai::evol::Evolver::ActOnSortedEvaluations(ArrayV<std::pair<flo
         ++j;
     }
 }
-brendancuda::ArrayV<std::pair<float, size_t>> brendancuda::ai::evol::Evolver::RunStep(void* EvaluationSharedData, void* ReproductionSharedData, void* DisposeSharedData) {
+bcuda::ArrayV<std::pair<float, size_t>> bcuda::ai::evol::Evolver::RunStep(void* EvaluationSharedData, void* ReproductionSharedData, void* DisposeSharedData) {
     auto eval = EvaluateAll(EvaluationSharedData);
     SortEvaluations(eval);
     ActOnSortedEvaluations(eval, DisposeSharedData, ReproductionSharedData);
     return eval;
 }
-void brendancuda::ai::evol::Evolver::Dispose(void* DisposeSharedData) {
+void bcuda::ai::evol::Evolver::Dispose(void* DisposeSharedData) {
     for (size_t i = 0; i < objs.Size(); ++i) {
         void* v = objs[i];
         if (v) disposeFunction(v, DisposeSharedData);

--- a/ai_evol_evolver.cpp
+++ b/ai_evol_evolver.cpp
@@ -1,7 +1,7 @@
 #include "ai_evol_evolver.h"
 #include <algorithm>
 
-brendancuda::AI::Evolution::Evolver::Evolver(
+brendancuda::ai::Evolution::Evolver::Evolver(
     size_t ContestantCount,
     evaluationFunction_t EvaluationFunction,
     reproductionFunction_t ReproductionFunction,
@@ -11,7 +11,7 @@ brendancuda::AI::Evolution::Evolver::Evolver(
     reproductionFunction = ReproductionFunction;
     disposeFunction = DisposeFunction;
 }
-brendancuda::AI::Evolution::Evolver::Evolver(
+brendancuda::ai::Evolution::Evolver::Evolver(
     size_t ContestantCount,
     evaluationFunction_t EvaluationFunction,
     reproductionFunction_t ReproductionFunction,
@@ -21,17 +21,17 @@ brendancuda::AI::Evolution::Evolver::Evolver(
 ) : Evolver(ContestantCount, EvaluationFunction, ReproductionFunction, DisposeFunction) {
     InitAllNoDisposal(CreationFunction, CreationSharedData);
 }
-brendancuda::ArrayV<void*> brendancuda::AI::Evolution::Evolver::Objects() {
+brendancuda::ArrayV<void*> brendancuda::ai::Evolution::Evolver::Objects() {
     return objs;
 }
-void brendancuda::AI::Evolution::Evolver::InitAllNoDisposal(creationFunction_t CreationFunction, void* CreationSharedData) {
+void brendancuda::ai::Evolution::Evolver::InitAllNoDisposal(creationFunction_t CreationFunction, void* CreationSharedData) {
     std::uniform_int_distribution<uint64_t> dis(std::numeric_limits<uint64_t>::min(), std::numeric_limits<uint64_t>::max());
 
     for (size_t i = 0; i < objs.Size(); ++i) {
         objs[i] = CreationFunction(CreationSharedData);
     }
 }
-void brendancuda::AI::Evolution::Evolver::InitAll(void* DisposeSharedData, creationFunction_t CreationFunction, void* CreationSharedData) {
+void brendancuda::ai::Evolution::Evolver::InitAll(void* DisposeSharedData, creationFunction_t CreationFunction, void* CreationSharedData) {
     std::uniform_int_distribution<uint64_t> dis(std::numeric_limits<uint64_t>::min(), std::numeric_limits<uint64_t>::max());
 
     for (size_t i = 0; i < objs.Size(); ++i) {
@@ -40,7 +40,7 @@ void brendancuda::AI::Evolution::Evolver::InitAll(void* DisposeSharedData, creat
         v = CreationFunction(CreationSharedData);
     }
 }
-brendancuda::ArrayV<std::pair<float, size_t>> brendancuda::AI::Evolution::Evolver::EvaluateAll(void* EvaluationSharedData) {
+brendancuda::ArrayV<std::pair<float, size_t>> brendancuda::ai::Evolution::Evolver::EvaluateAll(void* EvaluationSharedData) {
     std::uniform_int_distribution<uint64_t> dis(std::numeric_limits<uint64_t>::min(), std::numeric_limits<uint64_t>::max());
 
     ArrayV<std::pair<float, size_t>> scores(objs.Size());
@@ -49,12 +49,12 @@ brendancuda::ArrayV<std::pair<float, size_t>> brendancuda::AI::Evolution::Evolve
     }
     return scores;
 }
-void brendancuda::AI::Evolution::SortEvaluations(ArrayV<std::pair<float, size_t>> Evaluations) {
+void brendancuda::ai::Evolution::SortEvaluations(ArrayV<std::pair<float, size_t>> Evaluations) {
     std::sort(Evaluations.Data(), Evaluations.Data() + Evaluations.Size(), [](const auto& a, const auto& b) {
         return a.first < b.first;
     });
 }
-void brendancuda::AI::Evolution::Evolver::ActOnSortedEvaluations(ArrayV<std::pair<float, size_t>> Evaluations, void* DisposeSharedData, void* ReproductionSharedData) {
+void brendancuda::ai::Evolution::Evolver::ActOnSortedEvaluations(ArrayV<std::pair<float, size_t>> Evaluations, void* DisposeSharedData, void* ReproductionSharedData) {
     std::uniform_int_distribution<uint64_t> dis(std::numeric_limits<uint64_t>::min(), std::numeric_limits<uint64_t>::max());
     
     if (Evaluations.Size() != objs.Size())
@@ -74,13 +74,13 @@ void brendancuda::AI::Evolution::Evolver::ActOnSortedEvaluations(ArrayV<std::pai
         ++j;
     }
 }
-brendancuda::ArrayV<std::pair<float, size_t>> brendancuda::AI::Evolution::Evolver::RunStep(void* EvaluationSharedData, void* ReproductionSharedData, void* DisposeSharedData) {
+brendancuda::ArrayV<std::pair<float, size_t>> brendancuda::ai::Evolution::Evolver::RunStep(void* EvaluationSharedData, void* ReproductionSharedData, void* DisposeSharedData) {
     auto eval = EvaluateAll(EvaluationSharedData);
     SortEvaluations(eval);
     ActOnSortedEvaluations(eval, DisposeSharedData, ReproductionSharedData);
     return eval;
 }
-void brendancuda::AI::Evolution::Evolver::Dispose(void* DisposeSharedData) {
+void brendancuda::ai::Evolution::Evolver::Dispose(void* DisposeSharedData) {
     for (size_t i = 0; i < objs.Size(); ++i) {
         void* v = objs[i];
         if (v) disposeFunction(v, DisposeSharedData);

--- a/ai_evol_evolver.cpp
+++ b/ai_evol_evolver.cpp
@@ -1,7 +1,7 @@
 #include "ai_evol_evolver.h"
 #include <algorithm>
 
-brendancuda::ai::evolution::Evolver::Evolver(
+brendancuda::ai::evol::Evolver::Evolver(
     size_t ContestantCount,
     evaluationFunction_t EvaluationFunction,
     reproductionFunction_t ReproductionFunction,
@@ -11,7 +11,7 @@ brendancuda::ai::evolution::Evolver::Evolver(
     reproductionFunction = ReproductionFunction;
     disposeFunction = DisposeFunction;
 }
-brendancuda::ai::evolution::Evolver::Evolver(
+brendancuda::ai::evol::Evolver::Evolver(
     size_t ContestantCount,
     evaluationFunction_t EvaluationFunction,
     reproductionFunction_t ReproductionFunction,
@@ -21,17 +21,17 @@ brendancuda::ai::evolution::Evolver::Evolver(
 ) : Evolver(ContestantCount, EvaluationFunction, ReproductionFunction, DisposeFunction) {
     InitAllNoDisposal(CreationFunction, CreationSharedData);
 }
-brendancuda::ArrayV<void*> brendancuda::ai::evolution::Evolver::Objects() {
+brendancuda::ArrayV<void*> brendancuda::ai::evol::Evolver::Objects() {
     return objs;
 }
-void brendancuda::ai::evolution::Evolver::InitAllNoDisposal(creationFunction_t CreationFunction, void* CreationSharedData) {
+void brendancuda::ai::evol::Evolver::InitAllNoDisposal(creationFunction_t CreationFunction, void* CreationSharedData) {
     std::uniform_int_distribution<uint64_t> dis(std::numeric_limits<uint64_t>::min(), std::numeric_limits<uint64_t>::max());
 
     for (size_t i = 0; i < objs.Size(); ++i) {
         objs[i] = CreationFunction(CreationSharedData);
     }
 }
-void brendancuda::ai::evolution::Evolver::InitAll(void* DisposeSharedData, creationFunction_t CreationFunction, void* CreationSharedData) {
+void brendancuda::ai::evol::Evolver::InitAll(void* DisposeSharedData, creationFunction_t CreationFunction, void* CreationSharedData) {
     std::uniform_int_distribution<uint64_t> dis(std::numeric_limits<uint64_t>::min(), std::numeric_limits<uint64_t>::max());
 
     for (size_t i = 0; i < objs.Size(); ++i) {
@@ -40,7 +40,7 @@ void brendancuda::ai::evolution::Evolver::InitAll(void* DisposeSharedData, creat
         v = CreationFunction(CreationSharedData);
     }
 }
-brendancuda::ArrayV<std::pair<float, size_t>> brendancuda::ai::evolution::Evolver::EvaluateAll(void* EvaluationSharedData) {
+brendancuda::ArrayV<std::pair<float, size_t>> brendancuda::ai::evol::Evolver::EvaluateAll(void* EvaluationSharedData) {
     std::uniform_int_distribution<uint64_t> dis(std::numeric_limits<uint64_t>::min(), std::numeric_limits<uint64_t>::max());
 
     ArrayV<std::pair<float, size_t>> scores(objs.Size());
@@ -49,12 +49,12 @@ brendancuda::ArrayV<std::pair<float, size_t>> brendancuda::ai::evolution::Evolve
     }
     return scores;
 }
-void brendancuda::ai::evolution::SortEvaluations(ArrayV<std::pair<float, size_t>> Evaluations) {
+void brendancuda::ai::evol::SortEvaluations(ArrayV<std::pair<float, size_t>> Evaluations) {
     std::sort(Evaluations.Data(), Evaluations.Data() + Evaluations.Size(), [](const auto& a, const auto& b) {
         return a.first < b.first;
     });
 }
-void brendancuda::ai::evolution::Evolver::ActOnSortedEvaluations(ArrayV<std::pair<float, size_t>> Evaluations, void* DisposeSharedData, void* ReproductionSharedData) {
+void brendancuda::ai::evol::Evolver::ActOnSortedEvaluations(ArrayV<std::pair<float, size_t>> Evaluations, void* DisposeSharedData, void* ReproductionSharedData) {
     std::uniform_int_distribution<uint64_t> dis(std::numeric_limits<uint64_t>::min(), std::numeric_limits<uint64_t>::max());
     
     if (Evaluations.Size() != objs.Size())
@@ -74,13 +74,13 @@ void brendancuda::ai::evolution::Evolver::ActOnSortedEvaluations(ArrayV<std::pai
         ++j;
     }
 }
-brendancuda::ArrayV<std::pair<float, size_t>> brendancuda::ai::evolution::Evolver::RunStep(void* EvaluationSharedData, void* ReproductionSharedData, void* DisposeSharedData) {
+brendancuda::ArrayV<std::pair<float, size_t>> brendancuda::ai::evol::Evolver::RunStep(void* EvaluationSharedData, void* ReproductionSharedData, void* DisposeSharedData) {
     auto eval = EvaluateAll(EvaluationSharedData);
     SortEvaluations(eval);
     ActOnSortedEvaluations(eval, DisposeSharedData, ReproductionSharedData);
     return eval;
 }
-void brendancuda::ai::evolution::Evolver::Dispose(void* DisposeSharedData) {
+void brendancuda::ai::evol::Evolver::Dispose(void* DisposeSharedData) {
     for (size_t i = 0; i < objs.Size(); ++i) {
         void* v = objs[i];
         if (v) disposeFunction(v, DisposeSharedData);

--- a/ai_evol_evolver.cpp
+++ b/ai_evol_evolver.cpp
@@ -1,7 +1,7 @@
 #include "ai_evol_evolver.h"
 #include <algorithm>
 
-BrendanCUDA::AI::Evolution::Evolver::Evolver(
+brendancuda::AI::Evolution::Evolver::Evolver(
     size_t ContestantCount,
     evaluationFunction_t EvaluationFunction,
     reproductionFunction_t ReproductionFunction,
@@ -11,7 +11,7 @@ BrendanCUDA::AI::Evolution::Evolver::Evolver(
     reproductionFunction = ReproductionFunction;
     disposeFunction = DisposeFunction;
 }
-BrendanCUDA::AI::Evolution::Evolver::Evolver(
+brendancuda::AI::Evolution::Evolver::Evolver(
     size_t ContestantCount,
     evaluationFunction_t EvaluationFunction,
     reproductionFunction_t ReproductionFunction,
@@ -21,17 +21,17 @@ BrendanCUDA::AI::Evolution::Evolver::Evolver(
 ) : Evolver(ContestantCount, EvaluationFunction, ReproductionFunction, DisposeFunction) {
     InitAllNoDisposal(CreationFunction, CreationSharedData);
 }
-BrendanCUDA::ArrayV<void*> BrendanCUDA::AI::Evolution::Evolver::Objects() {
+brendancuda::ArrayV<void*> brendancuda::AI::Evolution::Evolver::Objects() {
     return objs;
 }
-void BrendanCUDA::AI::Evolution::Evolver::InitAllNoDisposal(creationFunction_t CreationFunction, void* CreationSharedData) {
+void brendancuda::AI::Evolution::Evolver::InitAllNoDisposal(creationFunction_t CreationFunction, void* CreationSharedData) {
     std::uniform_int_distribution<uint64_t> dis(std::numeric_limits<uint64_t>::min(), std::numeric_limits<uint64_t>::max());
 
     for (size_t i = 0; i < objs.Size(); ++i) {
         objs[i] = CreationFunction(CreationSharedData);
     }
 }
-void BrendanCUDA::AI::Evolution::Evolver::InitAll(void* DisposeSharedData, creationFunction_t CreationFunction, void* CreationSharedData) {
+void brendancuda::AI::Evolution::Evolver::InitAll(void* DisposeSharedData, creationFunction_t CreationFunction, void* CreationSharedData) {
     std::uniform_int_distribution<uint64_t> dis(std::numeric_limits<uint64_t>::min(), std::numeric_limits<uint64_t>::max());
 
     for (size_t i = 0; i < objs.Size(); ++i) {
@@ -40,7 +40,7 @@ void BrendanCUDA::AI::Evolution::Evolver::InitAll(void* DisposeSharedData, creat
         v = CreationFunction(CreationSharedData);
     }
 }
-BrendanCUDA::ArrayV<std::pair<float, size_t>> BrendanCUDA::AI::Evolution::Evolver::EvaluateAll(void* EvaluationSharedData) {
+brendancuda::ArrayV<std::pair<float, size_t>> brendancuda::AI::Evolution::Evolver::EvaluateAll(void* EvaluationSharedData) {
     std::uniform_int_distribution<uint64_t> dis(std::numeric_limits<uint64_t>::min(), std::numeric_limits<uint64_t>::max());
 
     ArrayV<std::pair<float, size_t>> scores(objs.Size());
@@ -49,12 +49,12 @@ BrendanCUDA::ArrayV<std::pair<float, size_t>> BrendanCUDA::AI::Evolution::Evolve
     }
     return scores;
 }
-void BrendanCUDA::AI::Evolution::SortEvaluations(ArrayV<std::pair<float, size_t>> Evaluations) {
+void brendancuda::AI::Evolution::SortEvaluations(ArrayV<std::pair<float, size_t>> Evaluations) {
     std::sort(Evaluations.Data(), Evaluations.Data() + Evaluations.Size(), [](const auto& a, const auto& b) {
         return a.first < b.first;
     });
 }
-void BrendanCUDA::AI::Evolution::Evolver::ActOnSortedEvaluations(ArrayV<std::pair<float, size_t>> Evaluations, void* DisposeSharedData, void* ReproductionSharedData) {
+void brendancuda::AI::Evolution::Evolver::ActOnSortedEvaluations(ArrayV<std::pair<float, size_t>> Evaluations, void* DisposeSharedData, void* ReproductionSharedData) {
     std::uniform_int_distribution<uint64_t> dis(std::numeric_limits<uint64_t>::min(), std::numeric_limits<uint64_t>::max());
     
     if (Evaluations.Size() != objs.Size())
@@ -74,13 +74,13 @@ void BrendanCUDA::AI::Evolution::Evolver::ActOnSortedEvaluations(ArrayV<std::pai
         ++j;
     }
 }
-BrendanCUDA::ArrayV<std::pair<float, size_t>> BrendanCUDA::AI::Evolution::Evolver::RunStep(void* EvaluationSharedData, void* ReproductionSharedData, void* DisposeSharedData) {
+brendancuda::ArrayV<std::pair<float, size_t>> brendancuda::AI::Evolution::Evolver::RunStep(void* EvaluationSharedData, void* ReproductionSharedData, void* DisposeSharedData) {
     auto eval = EvaluateAll(EvaluationSharedData);
     SortEvaluations(eval);
     ActOnSortedEvaluations(eval, DisposeSharedData, ReproductionSharedData);
     return eval;
 }
-void BrendanCUDA::AI::Evolution::Evolver::Dispose(void* DisposeSharedData) {
+void brendancuda::AI::Evolution::Evolver::Dispose(void* DisposeSharedData) {
     for (size_t i = 0; i < objs.Size(); ++i) {
         void* v = objs[i];
         if (v) disposeFunction(v, DisposeSharedData);

--- a/ai_evol_evolver.cpp
+++ b/ai_evol_evolver.cpp
@@ -1,7 +1,7 @@
 #include "ai_evol_evolver.h"
 #include <algorithm>
 
-brendancuda::ai::Evolution::Evolver::Evolver(
+brendancuda::ai::evolution::Evolver::Evolver(
     size_t ContestantCount,
     evaluationFunction_t EvaluationFunction,
     reproductionFunction_t ReproductionFunction,
@@ -11,7 +11,7 @@ brendancuda::ai::Evolution::Evolver::Evolver(
     reproductionFunction = ReproductionFunction;
     disposeFunction = DisposeFunction;
 }
-brendancuda::ai::Evolution::Evolver::Evolver(
+brendancuda::ai::evolution::Evolver::Evolver(
     size_t ContestantCount,
     evaluationFunction_t EvaluationFunction,
     reproductionFunction_t ReproductionFunction,
@@ -21,17 +21,17 @@ brendancuda::ai::Evolution::Evolver::Evolver(
 ) : Evolver(ContestantCount, EvaluationFunction, ReproductionFunction, DisposeFunction) {
     InitAllNoDisposal(CreationFunction, CreationSharedData);
 }
-brendancuda::ArrayV<void*> brendancuda::ai::Evolution::Evolver::Objects() {
+brendancuda::ArrayV<void*> brendancuda::ai::evolution::Evolver::Objects() {
     return objs;
 }
-void brendancuda::ai::Evolution::Evolver::InitAllNoDisposal(creationFunction_t CreationFunction, void* CreationSharedData) {
+void brendancuda::ai::evolution::Evolver::InitAllNoDisposal(creationFunction_t CreationFunction, void* CreationSharedData) {
     std::uniform_int_distribution<uint64_t> dis(std::numeric_limits<uint64_t>::min(), std::numeric_limits<uint64_t>::max());
 
     for (size_t i = 0; i < objs.Size(); ++i) {
         objs[i] = CreationFunction(CreationSharedData);
     }
 }
-void brendancuda::ai::Evolution::Evolver::InitAll(void* DisposeSharedData, creationFunction_t CreationFunction, void* CreationSharedData) {
+void brendancuda::ai::evolution::Evolver::InitAll(void* DisposeSharedData, creationFunction_t CreationFunction, void* CreationSharedData) {
     std::uniform_int_distribution<uint64_t> dis(std::numeric_limits<uint64_t>::min(), std::numeric_limits<uint64_t>::max());
 
     for (size_t i = 0; i < objs.Size(); ++i) {
@@ -40,7 +40,7 @@ void brendancuda::ai::Evolution::Evolver::InitAll(void* DisposeSharedData, creat
         v = CreationFunction(CreationSharedData);
     }
 }
-brendancuda::ArrayV<std::pair<float, size_t>> brendancuda::ai::Evolution::Evolver::EvaluateAll(void* EvaluationSharedData) {
+brendancuda::ArrayV<std::pair<float, size_t>> brendancuda::ai::evolution::Evolver::EvaluateAll(void* EvaluationSharedData) {
     std::uniform_int_distribution<uint64_t> dis(std::numeric_limits<uint64_t>::min(), std::numeric_limits<uint64_t>::max());
 
     ArrayV<std::pair<float, size_t>> scores(objs.Size());
@@ -49,12 +49,12 @@ brendancuda::ArrayV<std::pair<float, size_t>> brendancuda::ai::Evolution::Evolve
     }
     return scores;
 }
-void brendancuda::ai::Evolution::SortEvaluations(ArrayV<std::pair<float, size_t>> Evaluations) {
+void brendancuda::ai::evolution::SortEvaluations(ArrayV<std::pair<float, size_t>> Evaluations) {
     std::sort(Evaluations.Data(), Evaluations.Data() + Evaluations.Size(), [](const auto& a, const auto& b) {
         return a.first < b.first;
     });
 }
-void brendancuda::ai::Evolution::Evolver::ActOnSortedEvaluations(ArrayV<std::pair<float, size_t>> Evaluations, void* DisposeSharedData, void* ReproductionSharedData) {
+void brendancuda::ai::evolution::Evolver::ActOnSortedEvaluations(ArrayV<std::pair<float, size_t>> Evaluations, void* DisposeSharedData, void* ReproductionSharedData) {
     std::uniform_int_distribution<uint64_t> dis(std::numeric_limits<uint64_t>::min(), std::numeric_limits<uint64_t>::max());
     
     if (Evaluations.Size() != objs.Size())
@@ -74,13 +74,13 @@ void brendancuda::ai::Evolution::Evolver::ActOnSortedEvaluations(ArrayV<std::pai
         ++j;
     }
 }
-brendancuda::ArrayV<std::pair<float, size_t>> brendancuda::ai::Evolution::Evolver::RunStep(void* EvaluationSharedData, void* ReproductionSharedData, void* DisposeSharedData) {
+brendancuda::ArrayV<std::pair<float, size_t>> brendancuda::ai::evolution::Evolver::RunStep(void* EvaluationSharedData, void* ReproductionSharedData, void* DisposeSharedData) {
     auto eval = EvaluateAll(EvaluationSharedData);
     SortEvaluations(eval);
     ActOnSortedEvaluations(eval, DisposeSharedData, ReproductionSharedData);
     return eval;
 }
-void brendancuda::ai::Evolution::Evolver::Dispose(void* DisposeSharedData) {
+void brendancuda::ai::evolution::Evolver::Dispose(void* DisposeSharedData) {
     for (size_t i = 0; i < objs.Size(); ++i) {
         void* v = objs[i];
         if (v) disposeFunction(v, DisposeSharedData);

--- a/ai_evol_evolver.h
+++ b/ai_evol_evolver.h
@@ -7,18 +7,18 @@
 
 namespace brendancuda {
     namespace ai {
-        namespace Evolution {
+        namespace evolution {
             //A class to reduce the boilerplate code of implementing an evolutionary algorithm.
             class Evolver {
             public:
-                //Creates an instance of the brendancuda::ai::Evolution::Evolver class.
+                //Creates an instance of the brendancuda::ai::evolution::Evolver class.
                 Evolver(
                     size_t ContestantCount,
                     evaluationFunction_t EvaluationFunction,
                     reproductionFunction_t ReproductionFunction,
                     disposeFunction_t DisposeFunction
                 );
-                //Creates an instance of the brendancuda::ai::Evolution::Evolver class.
+                //Creates an instance of the brendancuda::ai::evolution::Evolver class.
                 Evolver(
                     size_t ContestantCount,
                     evaluationFunction_t EvaluationFunction,

--- a/ai_evol_evolver.h
+++ b/ai_evol_evolver.h
@@ -5,20 +5,20 @@
 #include <cstdint>
 #include <random>
 
-namespace brendancuda {
+namespace bcuda {
     namespace ai {
         namespace evol {
             //A class to reduce the boilerplate code of implementing an evolutionary algorithm.
             class Evolver {
             public:
-                //Creates an instance of the brendancuda::ai::evol::Evolver class.
+                //Creates an instance of the bcuda::ai::evol::Evolver class.
                 Evolver(
                     size_t ContestantCount,
                     evaluationFunction_t EvaluationFunction,
                     reproductionFunction_t ReproductionFunction,
                     disposeFunction_t DisposeFunction
                 );
-                //Creates an instance of the brendancuda::ai::evol::Evolver class.
+                //Creates an instance of the bcuda::ai::evol::Evolver class.
                 Evolver(
                     size_t ContestantCount,
                     evaluationFunction_t EvaluationFunction,

--- a/ai_evol_evolver.h
+++ b/ai_evol_evolver.h
@@ -5,20 +5,20 @@
 #include <cstdint>
 #include <random>
 
-namespace BrendanCUDA {
+namespace brendancuda {
     namespace AI {
         namespace Evolution {
             //A class to reduce the boilerplate code of implementing an evolutionary algorithm.
             class Evolver {
             public:
-                //Creates an instance of the BrendanCUDA::AI::Evolution::Evolver class.
+                //Creates an instance of the brendancuda::AI::Evolution::Evolver class.
                 Evolver(
                     size_t ContestantCount,
                     evaluationFunction_t EvaluationFunction,
                     reproductionFunction_t ReproductionFunction,
                     disposeFunction_t DisposeFunction
                 );
-                //Creates an instance of the BrendanCUDA::AI::Evolution::Evolver class.
+                //Creates an instance of the brendancuda::AI::Evolution::Evolver class.
                 Evolver(
                     size_t ContestantCount,
                     evaluationFunction_t EvaluationFunction,

--- a/ai_evol_evolver.h
+++ b/ai_evol_evolver.h
@@ -7,18 +7,18 @@
 
 namespace brendancuda {
     namespace ai {
-        namespace evolution {
+        namespace evol {
             //A class to reduce the boilerplate code of implementing an evolutionary algorithm.
             class Evolver {
             public:
-                //Creates an instance of the brendancuda::ai::evolution::Evolver class.
+                //Creates an instance of the brendancuda::ai::evol::Evolver class.
                 Evolver(
                     size_t ContestantCount,
                     evaluationFunction_t EvaluationFunction,
                     reproductionFunction_t ReproductionFunction,
                     disposeFunction_t DisposeFunction
                 );
-                //Creates an instance of the brendancuda::ai::evolution::Evolver class.
+                //Creates an instance of the brendancuda::ai::evol::Evolver class.
                 Evolver(
                     size_t ContestantCount,
                     evaluationFunction_t EvaluationFunction,

--- a/ai_evol_evolver.h
+++ b/ai_evol_evolver.h
@@ -6,19 +6,19 @@
 #include <random>
 
 namespace brendancuda {
-    namespace AI {
+    namespace ai {
         namespace Evolution {
             //A class to reduce the boilerplate code of implementing an evolutionary algorithm.
             class Evolver {
             public:
-                //Creates an instance of the brendancuda::AI::Evolution::Evolver class.
+                //Creates an instance of the brendancuda::ai::Evolution::Evolver class.
                 Evolver(
                     size_t ContestantCount,
                     evaluationFunction_t EvaluationFunction,
                     reproductionFunction_t ReproductionFunction,
                     disposeFunction_t DisposeFunction
                 );
-                //Creates an instance of the brendancuda::AI::Evolution::Evolver class.
+                //Creates an instance of the brendancuda::ai::Evolution::Evolver class.
                 Evolver(
                     size_t ContestantCount,
                     evaluationFunction_t EvaluationFunction,

--- a/ai_genetics_genefixedmlp.h
+++ b/ai_genetics_genefixedmlp.h
@@ -7,7 +7,7 @@
 #include <array>
 #include <cuda_runtime.h>
 
-namespace BrendanCUDA {
+namespace brendancuda {
     namespace AI {
         namespace Genetics {
             template <typename _T, activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
@@ -71,146 +71,146 @@ namespace BrendanCUDA {
     }
 }
 
-template <typename _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-auto BrendanCUDA::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Run() -> outputArray_t* {
+template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+auto brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Run() -> outputArray_t* {
     auto* outputArr = new outputArray_t;
     Run(outputArr);
     return outputArr;
 }
-template <typename _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-void BrendanCUDA::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Run(outputArray_t* OutputArray) {
+template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+void brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Run(outputArray_t* OutputArray) {
     mlp.Run(base.data(), OutputArray->data());
 }
-template <typename _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-void BrendanCUDA::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _TRNG& RNG) {
+void brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _TRNG& RNG) {
     Random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, RNG);
     mlp.Randomize(Scalar, RNG);
 }
-template <typename _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-void BrendanCUDA::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+void brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     Random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, LowerBound, UpperBound, RNG);
     mlp.Randomize(Scalar, LowerBound, UpperBound, RNG);
 }
-template <typename _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-void BrendanCUDA::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
+void brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
     Random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, RNG);
     mlp.Randomize(Scalar_MLP, RNG);
 }
-template <typename _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-void BrendanCUDA::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+void brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     Random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, LowerBound, UpperBound, RNG);
     mlp.Randomize(Scalar_MLP, LowerBound, UpperBound, RNG);
 }
-template <typename _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-BrendanCUDA::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> BrendanCUDA::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _TRNG& RNG) {
+brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _TRNG& RNG) {
     GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
     n.Randomize(Scalar, RNG);
     return n;
 }
-template <typename _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-BrendanCUDA::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> BrendanCUDA::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
     n.Randomize(Scalar, LowerBound, UpperBound, RNG);
     return n;
 }
-template <typename _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-BrendanCUDA::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> BrendanCUDA::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
+brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
     GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
     n.Randomize(Scalar_Base, Scalar_MLP, RNG);
     return n;
 }
-template <typename _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-BrendanCUDA::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> BrendanCUDA::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
     n.Randomize(Scalar_Base, Scalar_MLP, LowerBound, UpperBound, RNG);
     return n;
 }
-template <typename _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ void BrendanCUDA::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _TRNG& RNG) {
+template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <brendancuda::KernelCurandState _TRNG>
+__device__ void brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _TRNG& RNG) {
     Random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, RNG);
     mlp.Randomize(Scalar, RNG);
 }
-template <typename _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ void BrendanCUDA::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <brendancuda::KernelCurandState _TRNG>
+__device__ void brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     Random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, LowerBound, UpperBound, RNG);
     mlp.Randomize(Scalar, LowerBound, UpperBound, RNG);
 }
-template <typename _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ void BrendanCUDA::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
+template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <brendancuda::KernelCurandState _TRNG>
+__device__ void brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
     Random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, RNG);
     mlp.Randomize(Scalar_MLP, RNG);
 }
-template <typename _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ void BrendanCUDA::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <brendancuda::KernelCurandState _TRNG>
+__device__ void brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     Random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, LowerBound, UpperBound, RNG);
     mlp.Randomize(Scalar_MLP, LowerBound, UpperBound, RNG);
 }
-template <typename _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ BrendanCUDA::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> BrendanCUDA::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _TRNG& RNG) {
+template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <brendancuda::KernelCurandState _TRNG>
+__device__ brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _TRNG& RNG) {
     GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
     n.Randomize(Scalar, RNG);
     return n;
 }
-template <typename _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ BrendanCUDA::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> BrendanCUDA::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <brendancuda::KernelCurandState _TRNG>
+__device__ brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
     n.Randomize(Scalar, LowerBound, UpperBound, RNG);
     return n;
 }
-template <typename _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ BrendanCUDA::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> BrendanCUDA::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
+template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <brendancuda::KernelCurandState _TRNG>
+__device__ brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
     GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
     n.Randomize(Scalar_Base, Scalar_MLP, RNG);
     return n;
 }
-template <typename _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ BrendanCUDA::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> BrendanCUDA::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <brendancuda::KernelCurandState _TRNG>
+__device__ brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
     n.Randomize(Scalar_Base, Scalar_MLP, LowerBound, UpperBound, RNG);
     return n;
 }
-template <typename _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-void BrendanCUDA::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::ZeroOverwrite() {
+template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+void brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::ZeroOverwrite() {
     Random::ClearArray<false, _T>(Span<_T>(base, mlp.InputLength()));
     mlp.ZeroOverwrite();
 }
-template <typename _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-void BrendanCUDA::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_TRNG& RNG) {
+void brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_TRNG& RNG) {
     Random::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), RNG);
     mlp.RandomOverwrite(RNG);
 }
-template <typename _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-void BrendanCUDA::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_T LowerBound, _T UpperBound, _TRNG& RNG) {
+void brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_T LowerBound, _T UpperBound, _TRNG& RNG) {
     Random::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), LowerBound, UpperBound, RNG);
     mlp.RandomOverwrite(LowerBound, UpperBound, RNG);
 }
-template <typename _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ void BrendanCUDA::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_TRNG& RNG) {
+template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <brendancuda::KernelCurandState _TRNG>
+__device__ void brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_TRNG& RNG) {
     Random::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), RNG);
     mlp.RandomOverwrite(RNG);
 }
-template <typename _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ void BrendanCUDA::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_T LowerBound, _T UpperBound, _TRNG& RNG) {
+template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <brendancuda::KernelCurandState _TRNG>
+__device__ void brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_T LowerBound, _T UpperBound, _TRNG& RNG) {
     Random::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), LowerBound, UpperBound, RNG);
     mlp.RandomOverwrite(LowerBound, UpperBound, RNG);
 }

--- a/ai_genetics_genefixedmlp.h
+++ b/ai_genetics_genefixedmlp.h
@@ -9,7 +9,7 @@
 
 namespace brendancuda {
     namespace ai {
-        namespace Genetics {
+        namespace genes {
             template <typename _T, activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
             struct GeneFixedMLP final {
             private:
@@ -72,145 +72,145 @@ namespace brendancuda {
 }
 
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-auto brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Run() -> outputArray_t* {
+auto brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Run() -> outputArray_t* {
     auto* outputArr = new outputArray_t;
     Run(outputArr);
     return outputArr;
 }
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-void brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Run(outputArray_t* OutputArray) {
+void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Run(outputArray_t* OutputArray) {
     mlp.Run(base.data(), OutputArray->data());
 }
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-void brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _TRNG& RNG) {
+void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _TRNG& RNG) {
     Random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, RNG);
     mlp.Randomize(Scalar, RNG);
 }
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-void brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     Random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, LowerBound, UpperBound, RNG);
     mlp.Randomize(Scalar, LowerBound, UpperBound, RNG);
 }
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-void brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
+void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
     Random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, RNG);
     mlp.Randomize(Scalar_MLP, RNG);
 }
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-void brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     Random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, LowerBound, UpperBound, RNG);
     mlp.Randomize(Scalar_MLP, LowerBound, UpperBound, RNG);
 }
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _TRNG& RNG) {
+brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _TRNG& RNG) {
     GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
     n.Randomize(Scalar, RNG);
     return n;
 }
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
     n.Randomize(Scalar, LowerBound, UpperBound, RNG);
     return n;
 }
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
+brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
     GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
     n.Randomize(Scalar_Base, Scalar_MLP, RNG);
     return n;
 }
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
     n.Randomize(Scalar_Base, Scalar_MLP, LowerBound, UpperBound, RNG);
     return n;
 }
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _TRNG& RNG) {
+__device__ void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _TRNG& RNG) {
     Random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, RNG);
     mlp.Randomize(Scalar, RNG);
 }
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__device__ void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     Random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, LowerBound, UpperBound, RNG);
     mlp.Randomize(Scalar, LowerBound, UpperBound, RNG);
 }
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
+__device__ void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
     Random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, RNG);
     mlp.Randomize(Scalar_MLP, RNG);
 }
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__device__ void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     Random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, LowerBound, UpperBound, RNG);
     mlp.Randomize(Scalar_MLP, LowerBound, UpperBound, RNG);
 }
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _TRNG& RNG) {
+__device__ brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _TRNG& RNG) {
     GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
     n.Randomize(Scalar, RNG);
     return n;
 }
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__device__ brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
     n.Randomize(Scalar, LowerBound, UpperBound, RNG);
     return n;
 }
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
+__device__ brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
     GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
     n.Randomize(Scalar_Base, Scalar_MLP, RNG);
     return n;
 }
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__device__ brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
     n.Randomize(Scalar_Base, Scalar_MLP, LowerBound, UpperBound, RNG);
     return n;
 }
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-void brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::ZeroOverwrite() {
+void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::ZeroOverwrite() {
     Random::ClearArray<false, _T>(Span<_T>(base, mlp.InputLength()));
     mlp.ZeroOverwrite();
 }
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-void brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_TRNG& RNG) {
+void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_TRNG& RNG) {
     Random::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), RNG);
     mlp.RandomOverwrite(RNG);
 }
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-void brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_T LowerBound, _T UpperBound, _TRNG& RNG) {
+void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_T LowerBound, _T UpperBound, _TRNG& RNG) {
     Random::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), LowerBound, UpperBound, RNG);
     mlp.RandomOverwrite(LowerBound, UpperBound, RNG);
 }
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_TRNG& RNG) {
+__device__ void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_TRNG& RNG) {
     Random::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), RNG);
     mlp.RandomOverwrite(RNG);
 }
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_T LowerBound, _T UpperBound, _TRNG& RNG) {
+__device__ void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_T LowerBound, _T UpperBound, _TRNG& RNG) {
     Random::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), LowerBound, UpperBound, RNG);
     mlp.RandomOverwrite(LowerBound, UpperBound, RNG);
 }

--- a/ai_genetics_genefixedmlp.h
+++ b/ai_genetics_genefixedmlp.h
@@ -7,7 +7,7 @@
 #include <array>
 #include <cuda_runtime.h>
 
-namespace brendancuda {
+namespace bcuda {
     namespace ai {
         namespace genes {
             template <typename _T, activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
@@ -71,146 +71,146 @@ namespace brendancuda {
     }
 }
 
-template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-auto brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Run() -> outputArray_t* {
+template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+auto bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Run() -> outputArray_t* {
     auto* outputArr = new outputArray_t;
     Run(outputArr);
     return outputArr;
 }
-template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Run(outputArray_t* OutputArray) {
+template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Run(outputArray_t* OutputArray) {
     mlp.Run(base.data(), OutputArray->data());
 }
-template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _TRNG& RNG) {
+void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _TRNG& RNG) {
     random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, RNG);
     mlp.Randomize(Scalar, RNG);
 }
-template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, LowerBound, UpperBound, RNG);
     mlp.Randomize(Scalar, LowerBound, UpperBound, RNG);
 }
-template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
+void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
     random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, RNG);
     mlp.Randomize(Scalar_MLP, RNG);
 }
-template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, LowerBound, UpperBound, RNG);
     mlp.Randomize(Scalar_MLP, LowerBound, UpperBound, RNG);
 }
-template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _TRNG& RNG) {
+bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _TRNG& RNG) {
     GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
     n.Randomize(Scalar, RNG);
     return n;
 }
-template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
     n.Randomize(Scalar, LowerBound, UpperBound, RNG);
     return n;
 }
-template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
+bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
     GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
     n.Randomize(Scalar_Base, Scalar_MLP, RNG);
     return n;
 }
-template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
     n.Randomize(Scalar_Base, Scalar_MLP, LowerBound, UpperBound, RNG);
     return n;
 }
-template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _TRNG& RNG) {
+template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <bcuda::KernelCurandState _TRNG>
+__device__ void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _TRNG& RNG) {
     random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, RNG);
     mlp.Randomize(Scalar, RNG);
 }
-template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <bcuda::KernelCurandState _TRNG>
+__device__ void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, LowerBound, UpperBound, RNG);
     mlp.Randomize(Scalar, LowerBound, UpperBound, RNG);
 }
-template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
+template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <bcuda::KernelCurandState _TRNG>
+__device__ void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
     random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, RNG);
     mlp.Randomize(Scalar_MLP, RNG);
 }
-template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <bcuda::KernelCurandState _TRNG>
+__device__ void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, LowerBound, UpperBound, RNG);
     mlp.Randomize(Scalar_MLP, LowerBound, UpperBound, RNG);
 }
-template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <brendancuda::KernelCurandState _TRNG>
-__device__ brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _TRNG& RNG) {
+template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <bcuda::KernelCurandState _TRNG>
+__device__ bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _TRNG& RNG) {
     GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
     n.Randomize(Scalar, RNG);
     return n;
 }
-template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <brendancuda::KernelCurandState _TRNG>
-__device__ brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <bcuda::KernelCurandState _TRNG>
+__device__ bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
     n.Randomize(Scalar, LowerBound, UpperBound, RNG);
     return n;
 }
-template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <brendancuda::KernelCurandState _TRNG>
-__device__ brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
+template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <bcuda::KernelCurandState _TRNG>
+__device__ bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
     GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
     n.Randomize(Scalar_Base, Scalar_MLP, RNG);
     return n;
 }
-template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <brendancuda::KernelCurandState _TRNG>
-__device__ brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <bcuda::KernelCurandState _TRNG>
+__device__ bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
     n.Randomize(Scalar_Base, Scalar_MLP, LowerBound, UpperBound, RNG);
     return n;
 }
-template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::ZeroOverwrite() {
+template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::ZeroOverwrite() {
     random::ClearArray<false, _T>(Span<_T>(base, mlp.InputLength()));
     mlp.ZeroOverwrite();
 }
-template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_TRNG& RNG) {
+void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_TRNG& RNG) {
     random::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), RNG);
     mlp.RandomOverwrite(RNG);
 }
-template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_T LowerBound, _T UpperBound, _TRNG& RNG) {
+void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_T LowerBound, _T UpperBound, _TRNG& RNG) {
     random::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), LowerBound, UpperBound, RNG);
     mlp.RandomOverwrite(LowerBound, UpperBound, RNG);
 }
-template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_TRNG& RNG) {
+template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <bcuda::KernelCurandState _TRNG>
+__device__ void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_TRNG& RNG) {
     random::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), RNG);
     mlp.RandomOverwrite(RNG);
 }
-template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_T LowerBound, _T UpperBound, _TRNG& RNG) {
+template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <bcuda::KernelCurandState _TRNG>
+__device__ void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_T LowerBound, _T UpperBound, _TRNG& RNG) {
     random::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), LowerBound, UpperBound, RNG);
     mlp.RandomOverwrite(LowerBound, UpperBound, RNG);
 }

--- a/ai_genetics_genefixedmlp.h
+++ b/ai_genetics_genefixedmlp.h
@@ -84,25 +84,25 @@ void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, 
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
 void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _TRNG& RNG) {
-    Random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, RNG);
+    random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, RNG);
     mlp.Randomize(Scalar, RNG);
 }
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
 void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
-    Random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, LowerBound, UpperBound, RNG);
+    random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, LowerBound, UpperBound, RNG);
     mlp.Randomize(Scalar, LowerBound, UpperBound, RNG);
 }
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
 void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
-    Random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, RNG);
+    random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, RNG);
     mlp.Randomize(Scalar_MLP, RNG);
 }
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
 void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
-    Random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, LowerBound, UpperBound, RNG);
+    random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, LowerBound, UpperBound, RNG);
     mlp.Randomize(Scalar_MLP, LowerBound, UpperBound, RNG);
 }
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
@@ -136,25 +136,25 @@ brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Outp
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <brendancuda::KernelCurandState _TRNG>
 __device__ void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _TRNG& RNG) {
-    Random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, RNG);
+    random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, RNG);
     mlp.Randomize(Scalar, RNG);
 }
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <brendancuda::KernelCurandState _TRNG>
 __device__ void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
-    Random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, LowerBound, UpperBound, RNG);
+    random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, LowerBound, UpperBound, RNG);
     mlp.Randomize(Scalar, LowerBound, UpperBound, RNG);
 }
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <brendancuda::KernelCurandState _TRNG>
 __device__ void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
-    Random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, RNG);
+    random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, RNG);
     mlp.Randomize(Scalar_MLP, RNG);
 }
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <brendancuda::KernelCurandState _TRNG>
 __device__ void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
-    Random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, LowerBound, UpperBound, RNG);
+    random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, LowerBound, UpperBound, RNG);
     mlp.Randomize(Scalar_MLP, LowerBound, UpperBound, RNG);
 }
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
@@ -187,30 +187,30 @@ __device__ brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputC
 }
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::ZeroOverwrite() {
-    Random::ClearArray<false, _T>(Span<_T>(base, mlp.InputLength()));
+    random::ClearArray<false, _T>(Span<_T>(base, mlp.InputLength()));
     mlp.ZeroOverwrite();
 }
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
 void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_TRNG& RNG) {
-    Random::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), RNG);
+    random::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), RNG);
     mlp.RandomOverwrite(RNG);
 }
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
 void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_T LowerBound, _T UpperBound, _TRNG& RNG) {
-    Random::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), LowerBound, UpperBound, RNG);
+    random::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), LowerBound, UpperBound, RNG);
     mlp.RandomOverwrite(LowerBound, UpperBound, RNG);
 }
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <brendancuda::KernelCurandState _TRNG>
 __device__ void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_TRNG& RNG) {
-    Random::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), RNG);
+    random::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), RNG);
     mlp.RandomOverwrite(RNG);
 }
 template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <brendancuda::KernelCurandState _TRNG>
 __device__ void brendancuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_T LowerBound, _T UpperBound, _TRNG& RNG) {
-    Random::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), LowerBound, UpperBound, RNG);
+    random::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), LowerBound, UpperBound, RNG);
     mlp.RandomOverwrite(LowerBound, UpperBound, RNG);
 }

--- a/ai_genetics_genefixedmlp.h
+++ b/ai_genetics_genefixedmlp.h
@@ -14,7 +14,7 @@ namespace brendancuda {
             struct GeneFixedMLP final {
             private:
                 using this_t = GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>;
-                using mlp_t = MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>;
+                using mlp_t = mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>;
                 using inputArray_t = std::array<_T, mlp_t::InputCount()>;
                 using outputArray_t = std::array<_T, mlp_t::OutputCount()>;
             public:

--- a/ai_genetics_genefixedmlp.h
+++ b/ai_genetics_genefixedmlp.h
@@ -8,7 +8,7 @@
 #include <cuda_runtime.h>
 
 namespace brendancuda {
-    namespace AI {
+    namespace ai {
         namespace Genetics {
             template <typename _T, activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
             struct GeneFixedMLP final {
@@ -71,146 +71,146 @@ namespace brendancuda {
     }
 }
 
-template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-auto brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Run() -> outputArray_t* {
+template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+auto brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Run() -> outputArray_t* {
     auto* outputArr = new outputArray_t;
     Run(outputArr);
     return outputArr;
 }
-template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-void brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Run(outputArray_t* OutputArray) {
+template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+void brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Run(outputArray_t* OutputArray) {
     mlp.Run(base.data(), OutputArray->data());
 }
-template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-void brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _TRNG& RNG) {
+void brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _TRNG& RNG) {
     Random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, RNG);
     mlp.Randomize(Scalar, RNG);
 }
-template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-void brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+void brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     Random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, LowerBound, UpperBound, RNG);
     mlp.Randomize(Scalar, LowerBound, UpperBound, RNG);
 }
-template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-void brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
+void brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
     Random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, RNG);
     mlp.Randomize(Scalar_MLP, RNG);
 }
-template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-void brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+void brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     Random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, LowerBound, UpperBound, RNG);
     mlp.Randomize(Scalar_MLP, LowerBound, UpperBound, RNG);
 }
-template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _TRNG& RNG) {
+brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _TRNG& RNG) {
     GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
     n.Randomize(Scalar, RNG);
     return n;
 }
-template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
     n.Randomize(Scalar, LowerBound, UpperBound, RNG);
     return n;
 }
-template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
+brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
     GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
     n.Randomize(Scalar_Base, Scalar_MLP, RNG);
     return n;
 }
-template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
     n.Randomize(Scalar_Base, Scalar_MLP, LowerBound, UpperBound, RNG);
     return n;
 }
-template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _TRNG& RNG) {
+__device__ void brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _TRNG& RNG) {
     Random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, RNG);
     mlp.Randomize(Scalar, RNG);
 }
-template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__device__ void brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     Random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, LowerBound, UpperBound, RNG);
     mlp.Randomize(Scalar, LowerBound, UpperBound, RNG);
 }
-template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
+__device__ void brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
     Random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, RNG);
     mlp.Randomize(Scalar_MLP, RNG);
 }
-template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__device__ void brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     Random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, LowerBound, UpperBound, RNG);
     mlp.Randomize(Scalar_MLP, LowerBound, UpperBound, RNG);
 }
-template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _TRNG& RNG) {
+__device__ brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _TRNG& RNG) {
     GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
     n.Randomize(Scalar, RNG);
     return n;
 }
-template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__device__ brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
     n.Randomize(Scalar, LowerBound, UpperBound, RNG);
     return n;
 }
-template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
+__device__ brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
     GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
     n.Randomize(Scalar_Base, Scalar_MLP, RNG);
     return n;
 }
-template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__device__ brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
     n.Randomize(Scalar_Base, Scalar_MLP, LowerBound, UpperBound, RNG);
     return n;
 }
-template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-void brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::ZeroOverwrite() {
+template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+void brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::ZeroOverwrite() {
     Random::ClearArray<false, _T>(Span<_T>(base, mlp.InputLength()));
     mlp.ZeroOverwrite();
 }
-template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-void brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_TRNG& RNG) {
+void brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_TRNG& RNG) {
     Random::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), RNG);
     mlp.RandomOverwrite(RNG);
 }
-template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
-void brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_T LowerBound, _T UpperBound, _TRNG& RNG) {
+void brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_T LowerBound, _T UpperBound, _TRNG& RNG) {
     Random::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), LowerBound, UpperBound, RNG);
     mlp.RandomOverwrite(LowerBound, UpperBound, RNG);
 }
-template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_TRNG& RNG) {
+__device__ void brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_TRNG& RNG) {
     Random::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), RNG);
     mlp.RandomOverwrite(RNG);
 }
-template <typename _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+template <typename _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::AI::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_T LowerBound, _T UpperBound, _TRNG& RNG) {
+__device__ void brendancuda::ai::Genetics::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_T LowerBound, _T UpperBound, _TRNG& RNG) {
     Random::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), LowerBound, UpperBound, RNG);
     mlp.RandomOverwrite(LowerBound, UpperBound, RNG);
 }

--- a/ai_mlp_fixedmlp.h
+++ b/ai_mlp_fixedmlp.h
@@ -14,7 +14,7 @@
 
 namespace brendancuda {
     namespace ai {
-        namespace MLP {
+        namespace mlp {
             template <std::floating_point _T, activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
             struct FixedMLPL;
         }
@@ -28,12 +28,12 @@ namespace brendancuda {
         };
         template <std::floating_point _T, ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
         struct MLPLayerType<0, _T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...> {
-            using type = ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _Output1Count>;
+            using type = ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _Output1Count>;
         };
         template <size_t _Index, std::floating_point _T, ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
         struct MLPLayerType<_Index, _T, _ActivationFunction, _InputCount, _Output1Count> {
             static_assert(!_Index, "_Index is out of bounds.");
-            using type = ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _Output1Count>;
+            using type = ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _Output1Count>;
         };
 
         template <size_t _Index, std::floating_point _T, ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _ContinuedOutputCounts>
@@ -51,7 +51,7 @@ namespace brendancuda {
         };
     }
     namespace ai {
-        namespace MLP {
+        namespace mlp {
             template <std::floating_point _T, activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
             struct FixedMLPL {
                 static_assert(_InputCount, "_InputCount must be greater than 0.");
@@ -202,14 +202,14 @@ namespace brendancuda {
         template <typename _T>
         struct isFixedMLPL : std::false_type { };
         template <std::floating_point _T, ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
-        struct isFixedMLPL<ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>> : std::true_type { };
+        struct isFixedMLPL<ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>> : std::true_type { };
         template <typename _T>
         struct isFixedMLP : std::false_type { };
         template <std::floating_point _T, ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-        struct isFixedMLP<ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>> : std::true_type { };
+        struct isFixedMLP<ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>> : std::true_type { };
     }
     namespace ai {
-        namespace MLP {
+        namespace mlp {
             template <typename _T>
             concept IsFixedMLPL = details::isFixedMLPL<_T>::value;
             template <typename _T>
@@ -217,11 +217,11 @@ namespace brendancuda {
         }
     }
     namespace details {
-        template <ai::MLP::IsFixedMLP _TFixedMLP>
-        void FixedMLP_Run(const _TFixedMLP* MLP, const typename _TFixedMLP::element_t* Inputs, typename _TFixedMLP::element_t* Intermediate0, typename _TFixedMLP::element_t* Intermediate1, typename _TFixedMLP::element_t* Outputs);
+        template <ai::mlp::IsFixedMLP _TFixedMLP>
+        void FixedMLP_Run(const _TFixedMLP* mlp, const typename _TFixedMLP::element_t* Inputs, typename _TFixedMLP::element_t* Intermediate0, typename _TFixedMLP::element_t* Intermediate1, typename _TFixedMLP::element_t* Outputs);
     }
     namespace ai {
-        namespace MLP {
+        namespace mlp {
             template <typename _TFixedMLPL>
                 requires IsFixedMLPL<std::remove_const_t<_TFixedMLPL>>
             __host__ __device__ Span<std::conditional_t<std::is_const_v<_TFixedMLPL>, const typename _TFixedMLPL::element_t, typename _TFixedMLPL::element_t>> FixedMLPL_GetElementSpan(_TFixedMLPL* MLPL);
@@ -256,7 +256,7 @@ namespace brendancuda {
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
-__host__ __device__ void brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::FillWith0() {
+__host__ __device__ void brendancuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::FillWith0() {
     for (size_t i = 0; i < _OutputCount; ++i) {
         for (size_t j = 0; j < _InputCount; ++j) {
             weights[i][j] = 0.;
@@ -267,7 +267,7 @@ __host__ __device__ void brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::FillWithRandom(_TRNG& RNG) {
+__host__ void brendancuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::FillWithRandom(_TRNG& RNG) {
     std::uniform_real_distribution<_T> dis(-1., 1.);
 
     for (size_t i = 0; i < _OutputCount; ++i) {
@@ -281,7 +281,7 @@ __host__ void brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputCou
 #ifdef __CUDACC__
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::FillWithRandom(_TRNG& RNG) {
+__device__ void brendancuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::FillWithRandom(_TRNG& RNG) {
     if constexpr (std::same_as<_T, float>) {
         for (size_t i = 0; i < _OutputCount; ++i) {
             for (size_t j = 0; j < _InputCount; ++j) {
@@ -303,7 +303,7 @@ __device__ void brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputC
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
+__host__ void brendancuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
     std::uniform_real_distribution<_T> dis(-Scalar, Scalar);
 
     for (size_t i = 0; i < _OutputCount; ++i) {
@@ -317,7 +317,7 @@ __host__ void brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputCou
 #ifdef __CUDACC__
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
+__device__ void brendancuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
     if constexpr (std::same_as<_T, float>) {
         for (size_t i = 0; i < _OutputCount; ++i) {
             for (size_t j = 0; j < _InputCount; ++j) {
@@ -339,7 +339,7 @@ __device__ void brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputC
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__host__ void brendancuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     std::uniform_real_distribution<_T> dis(-Scalar, Scalar);
 
     for (size_t i = 0; i < _OutputCount; ++i) {
@@ -355,7 +355,7 @@ __host__ void brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputCou
 #ifdef __CUDACC__
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__device__ void brendancuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     if constexpr (std::same_as<_T, float>) {
         for (size_t i = 0; i < _OutputCount; ++i) {
             for (size_t j = 0; j < _InputCount; ++j) {
@@ -380,7 +380,7 @@ __device__ void brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputC
 #endif
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
-__host__ __device__ void brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::Run(const _T* Input, _T* output) const {
+__host__ __device__ void brendancuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::Run(const _T* Input, _T* output) const {
     if (Input == output) {
         _T* secondOutput = new _T[_OutputCount];
         for (size_t j = 0; j < _OutputCount; ++j) {
@@ -404,57 +404,57 @@ __host__ __device__ void brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
-size_t brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::SerializedSize() const {
+size_t brendancuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::SerializedSize() const {
     return sizeof(this_t);
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
-void brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::Serialize(void*& Data) const {
+void brendancuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::Serialize(void*& Data) const {
     BSerializer::SerializeArray(Data, weights, _InputCount * _OutputCount);
     BSerializer::SerializeArray(Data, bias, _OutputCount);
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
-auto brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::Deserialize(const void*& Data) -> this_t {
+auto brendancuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::Deserialize(const void*& Data) -> this_t {
     uint8_t bytes[sizeof(this_t)];
     Deserialize(Data, &bytes);
     return *(this_t*)&bytes;
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
-void brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::Deserialize(const void*& Data, void* ObjMem) {
+void brendancuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::Deserialize(const void*& Data, void* ObjMem) {
     this_t& obj = &(this_t*)ObjMem;
     BSerializer::DeserializeArray(Data, obj.weights, _InputCount * _OutputCount);
     BSerializer::DeserializeArray(Data, obj.bias, _OutputCount);
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-__host__ __device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::FillWith0() {
+__host__ __device__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::FillWith0() {
     layer.FillWith0();
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::FillWithRandom(_TRNG& RNG) {
+__host__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::FillWithRandom(_TRNG& RNG) {
     layer.FillWithRandom(RNG);
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
+__host__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
     layer.ChangeWithRandom(Scalar, RNG);
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__host__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     layer.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
 }
 
 #ifdef __CUDACC__
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::FillWithRandom(_TRNG& RNG) {
+__device__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::FillWithRandom(_TRNG& RNG) {
     layer.FillWithRandom(RNG);
 }
 #endif
@@ -462,7 +462,7 @@ __device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCo
 #ifdef __CUDACC__
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
+__device__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
     layer.ChangeWithRandom(Scalar, RNG);
 }
 #endif
@@ -470,34 +470,34 @@ __device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCo
 #ifdef __CUDACC__
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__device__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     layer.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
 }
 #endif
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-__host__ __device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::FillWith0() {
+__host__ __device__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::FillWith0() {
     layer.FillWith0();
     nextLayers.FillWith0();
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::FillWithRandom(_TRNG& RNG) {
+__host__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::FillWithRandom(_TRNG& RNG) {
     layer.FillWithRandom(RNG);
     nextLayers.FillWithRandom(RNG);
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
+__host__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
     layer.ChangeWithRandom(Scalar, RNG);
     nextLayers.ChangeWithRandom(Scalar, RNG);
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__host__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     layer.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
     nextLayers.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
 }
@@ -505,7 +505,7 @@ __host__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCoun
 #ifdef __CUDACC__
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::FillWithRandom(_TRNG& RNG) {
+__device__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::FillWithRandom(_TRNG& RNG) {
     layer.FillWithRandom(RNG);
     nextLayers.FillWithRandom(RNG);
 }
@@ -514,7 +514,7 @@ __device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCo
 #ifdef __CUDACC__
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
+__device__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
     layer.ChangeWithRandom(Scalar, RNG);
     nextLayers.ChangeWithRandom(Scalar, RNG);
 }
@@ -523,19 +523,19 @@ __device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCo
 #ifdef __CUDACC__
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__device__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     layer.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
     nextLayers.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
 }
 #endif
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-__host__ __device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Run(const _T* Input, _T* output) const {
+__host__ __device__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Run(const _T* Input, _T* output) const {
     Run(Input, 0, 0, output);
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-__host__ __device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Run(const _T* Input, _T* Intermediate1, _T* Intermediate2, _T* output) const {
+__host__ __device__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Run(const _T* Input, _T* Intermediate1, _T* Intermediate2, _T* output) const {
     _T* i1 = Intermediate1 ? Intermediate1 : new _T[Intermediate0Count()];
     _T* i2 = Intermediate2 ? Intermediate2 : new _T[Intermediate1Count()];
 
@@ -548,7 +548,7 @@ __host__ __device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction,
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
 template <size_t _Index>
-__host__ __device__ brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::layerType_t<_Index>& brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Layer() {
+__host__ __device__ brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::layerType_t<_Index>& brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Layer() {
     if constexpr (_Index) {
         return nextLayers.Layer<_Index - 1>();
     }
@@ -558,132 +558,132 @@ __host__ __device__ brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _Inp
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-__host__ __device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Run(const _T* Input, _T* output) const {
+__host__ __device__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Run(const _T* Input, _T* output) const {
     layer.Run(Input, output);
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-__host__ __device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Run(const _T* Input, _T* Intermediate1, _T* Intermediate2, _T* output) const {
+__host__ __device__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Run(const _T* Input, _T* Intermediate1, _T* Intermediate2, _T* output) const {
     layer.Run(Input, output);
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
 template <size_t _Index>
-__host__ __device__ brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::layerType_t<_Index>& brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Layer() {
+__host__ __device__ brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::layerType_t<_Index>& brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Layer() {
     static_assert(!_Index, "_Index is out of bounds.");
     return layer;
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-constexpr size_t brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::InputCount() {
+constexpr size_t brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::InputCount() {
     return _InputCount;
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-constexpr size_t brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::InputCount() {
+constexpr size_t brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::InputCount() {
     return _InputCount;
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-constexpr size_t brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::OutputCount() {
-    return brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::OutputCount();
+constexpr size_t brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::OutputCount() {
+    return brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::OutputCount();
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-constexpr size_t brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::OutputCount() {
+constexpr size_t brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::OutputCount() {
     return _Output1Count;
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-constexpr size_t brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Intermediate0Count() {
-    return std::max(_Output1Count, brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Intermediate1Count());
+constexpr size_t brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Intermediate0Count() {
+    return std::max(_Output1Count, brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Intermediate1Count());
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-constexpr size_t brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Intermediate0Count() {
+constexpr size_t brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Intermediate0Count() {
     return 0;
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-constexpr size_t brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Intermediate1Count() {
-    return brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Intermediate0Count();
+constexpr size_t brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Intermediate1Count() {
+    return brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Intermediate0Count();
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-constexpr size_t brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Intermediate1Count() {
+constexpr size_t brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Intermediate1Count() {
     return 0;
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-constexpr size_t brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::MaxLayerOutputCount() {
+constexpr size_t brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::MaxLayerOutputCount() {
     constexpr size_t maxNextLayers = FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::MaxLayerOutputCount();
     return _Output1Count > maxNextLayers ? _Output1Count : maxNextLayers;
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-constexpr size_t brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::LayerCount() {
+constexpr size_t brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::LayerCount() {
     return FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::LayerCount() + 1;
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-size_t brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::SerializedSize() const {
+size_t brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::SerializedSize() const {
     return sizeof(this_t);
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Serialize(void*& Data) const {
+void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Serialize(void*& Data) const {
     layer.Serialize(Data);
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-auto brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Deserialize(const void*& Data) -> this_t {
+auto brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Deserialize(const void*& Data) -> this_t {
     uint8_t bytes[sizeof(this_t)];
     Deserialize(Data, &bytes);
     return *(this_t*)&bytes;
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Deserialize(const void*& Data, void* ObjMem) {
+void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Deserialize(const void*& Data, void* ObjMem) {
     this_t& obj = &(this_t*)ObjMem;
     BSerializer::Deserialize(Data, &obj.layer);
     BSerializer::Deserialize(Data, &obj.nextLayers);
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-constexpr size_t brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::MaxLayerOutputCount() {
+constexpr size_t brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::MaxLayerOutputCount() {
     return _Output1Count;
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-constexpr size_t brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::LayerCount() {
+constexpr size_t brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::LayerCount() {
     return 1;
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-size_t brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::SerializedSize() const {
+size_t brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::SerializedSize() const {
     return sizeof(this_t);
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Serialize(void*& Data) const {
+void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Serialize(void*& Data) const {
     layer.Serialize(Data);
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-auto brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Deserialize(const void*& Data) -> this_t {
+auto brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Deserialize(const void*& Data) -> this_t {
     uint8_t bytes[sizeof(this_t)];
     Deserialize(Data, &bytes);
     return *(this_t*)&bytes;
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Deserialize(const void*& Data, void* ObjMem) {
+void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Deserialize(const void*& Data, void* ObjMem) {
     this_t& obj = &(this_t*)ObjMem;
     BSerializer::Deserialize(Data, &obj.layer);
 }
 
-template <brendancuda::ai::MLP::IsFixedMLPL _TFixedMLPL, bool _InputOnHost, bool _OutputOnHost>
-void brendancuda::ai::MLP::FixedMLPL_Run(const _TFixedMLPL* MLPL, const typename _TFixedMLPL::element_t* Inputs, typename _TFixedMLPL::element_t* Outputs) {
+template <brendancuda::ai::mlp::IsFixedMLPL _TFixedMLPL, bool _InputOnHost, bool _OutputOnHost>
+void brendancuda::ai::mlp::FixedMLPL_Run(const _TFixedMLPL* MLPL, const typename _TFixedMLPL::element_t* Inputs, typename _TFixedMLPL::element_t* Outputs) {
     using element_t = typename _TFixedMLPL::element_t;
     if constexpr (_InputOnHost) {
         if constexpr (_OutputOnHost) {
@@ -724,8 +724,8 @@ void brendancuda::ai::MLP::FixedMLPL_Run(const _TFixedMLPL* MLPL, const typename
     }
 }
 
-template <brendancuda::ai::MLP::IsFixedMLP _TFixedMLP, bool _InputOnHost, bool _OutputOnHost>
-void brendancuda::ai::MLP::FixedMLP_Run(const _TFixedMLP* MLP, const typename _TFixedMLP::element_t* Inputs, typename _TFixedMLP::element_t* Outputs) {
+template <brendancuda::ai::mlp::IsFixedMLP _TFixedMLP, bool _InputOnHost, bool _OutputOnHost>
+void brendancuda::ai::mlp::FixedMLP_Run(const _TFixedMLP* MLP, const typename _TFixedMLP::element_t* Inputs, typename _TFixedMLP::element_t* Outputs) {
     using element_t = typename _TFixedMLP::element_t;
     if constexpr (_InputOnHost) {
         if constexpr (_OutputOnHost) {
@@ -768,7 +768,7 @@ void brendancuda::ai::MLP::FixedMLP_Run(const _TFixedMLP* MLP, const typename _T
     }
 }
 
-template <brendancuda::ai::MLP::IsFixedMLP _TFixedMLP>
+template <brendancuda::ai::mlp::IsFixedMLP _TFixedMLP>
 void brendancuda::details::FixedMLP_Run(const _TFixedMLP* MLP, const typename _TFixedMLP::element_t* Inputs, typename _TFixedMLP::element_t* Intermediate0, typename _TFixedMLP::element_t* Intermediate1, typename _TFixedMLP::element_t* Outputs) {
     using element_t = typename _TFixedMLP::element_t;
 
@@ -776,69 +776,69 @@ void brendancuda::details::FixedMLP_Run(const _TFixedMLP* MLP, const typename _T
         FixedMLPL_Run<decltype(MLP->layer), false, false>(&MLP->layer, Inputs, Outputs);
     }
     else {
-        ai::MLP::FixedMLPL_Run<decltype(MLP->layer), false, false>(&MLP->layer, Inputs, Intermediate0);
+        ai::mlp::FixedMLPL_Run<decltype(MLP->layer), false, false>(&MLP->layer, Inputs, Intermediate0);
         FixedMLP_Run(&MLP->nextLayers, Intermediate0, Intermediate1, Intermediate0, Outputs);
     }
 }
 
 template <typename _TFixedMLPL>
-    requires brendancuda::ai::MLP::IsFixedMLPL<std::remove_const_t<_TFixedMLPL>>
-__host__ __device__ brendancuda::Span<std::conditional_t<std::is_const_v<_TFixedMLPL>, const typename _TFixedMLPL::element_t, typename _TFixedMLPL::element_t>> brendancuda::ai::MLP::FixedMLPL_GetElementSpan(_TFixedMLPL* MLPL) {
+    requires brendancuda::ai::mlp::IsFixedMLPL<std::remove_const_t<_TFixedMLPL>>
+__host__ __device__ brendancuda::Span<std::conditional_t<std::is_const_v<_TFixedMLPL>, const typename _TFixedMLPL::element_t, typename _TFixedMLPL::element_t>> brendancuda::ai::mlp::FixedMLPL_GetElementSpan(_TFixedMLPL* MLPL) {
     using element_t = std::conditional_t<std::is_const_v<_TFixedMLPL>, const typename _TFixedMLPL::element_t, typename _TFixedMLPL::element_t>;
     return Span<element_t>((element_t*)MLPL, sizeof(_TFixedMLPL) / sizeof(element_t));
 }
 template <typename _TFixedMLP>
-    requires brendancuda::ai::MLP::IsFixedMLP<std::remove_const_t<_TFixedMLP>>
-__host__ __device__ brendancuda::Span<std::conditional_t<std::is_const_v<_TFixedMLP>, const typename _TFixedMLP::element_t, typename _TFixedMLP::element_t>> brendancuda::ai::MLP::FixedMLP_GetElementSpan(_TFixedMLP* MLP) {
+    requires brendancuda::ai::mlp::IsFixedMLP<std::remove_const_t<_TFixedMLP>>
+__host__ __device__ brendancuda::Span<std::conditional_t<std::is_const_v<_TFixedMLP>, const typename _TFixedMLP::element_t, typename _TFixedMLP::element_t>> brendancuda::ai::mlp::FixedMLP_GetElementSpan(_TFixedMLP* MLP) {
     using element_t = std::conditional_t<std::is_const_v<_TFixedMLP>, const typename _TFixedMLP::element_t, typename _TFixedMLP::element_t>;
     return Span<element_t>((element_t*)MLP, sizeof(_TFixedMLP) / sizeof(element_t));
 }
 
-template <brendancuda::ai::MLP::IsFixedMLPL _TFixedMLPL>
-void brendancuda::ai::MLP::FixedMLPL_FillWith0(_TFixedMLPL* MLPL) {
+template <brendancuda::ai::mlp::IsFixedMLPL _TFixedMLPL>
+void brendancuda::ai::mlp::FixedMLPL_FillWith0(_TFixedMLPL* MLPL) {
     using element_t = typename _TFixedMLPL::element_t;
 
     Random::ClearArray<false, element_t>(FixedMLPL_GetElementSpan(MLPL));
 }
-template <brendancuda::ai::MLP::IsFixedMLPL _TFixedMLPL, std::uniform_random_bit_generator _TRNG>
-void brendancuda::ai::MLP::FixedMLPL_FillWithRandom(_TFixedMLPL* MLPL, _TRNG& RNG) {
+template <brendancuda::ai::mlp::IsFixedMLPL _TFixedMLPL, std::uniform_random_bit_generator _TRNG>
+void brendancuda::ai::mlp::FixedMLPL_FillWithRandom(_TFixedMLPL* MLPL, _TRNG& RNG) {
     using element_t = typename _TFixedMLPL::element_t;
 
     Random::InitRandomArray<false, element_t, _TRNG>(FixedMLPL_GetElementSpan(MLPL), RNG);
 }
-template <brendancuda::ai::MLP::IsFixedMLPL _TFixedMLPL, std::uniform_random_bit_generator _TRNG>
-void brendancuda::ai::MLP::FixedMLPL_ChangeWithRandom(_TFixedMLPL* MLPL, typename _TFixedMLPL::element_t Scalar, _TRNG& RNG) {
+template <brendancuda::ai::mlp::IsFixedMLPL _TFixedMLPL, std::uniform_random_bit_generator _TRNG>
+void brendancuda::ai::mlp::FixedMLPL_ChangeWithRandom(_TFixedMLPL* MLPL, typename _TFixedMLPL::element_t Scalar, _TRNG& RNG) {
     using element_t = typename _TFixedMLPL::element_t;
 
     Random::RandomizeArray<false, element_t, _TRNG>(FixedMLPL_GetElementSpan(MLPL), Scalar, RNG);
 }
-template <brendancuda::ai::MLP::IsFixedMLPL _TFixedMLPL, std::uniform_random_bit_generator _TRNG>
-void brendancuda::ai::MLP::FixedMLPL_ChangeWithRandom(_TFixedMLPL* MLPL, typename _TFixedMLPL::element_t Scalar, typename _TFixedMLPL::element_t LowerBound, typename _TFixedMLPL::element_t UpperBound, _TRNG& RNG) {
+template <brendancuda::ai::mlp::IsFixedMLPL _TFixedMLPL, std::uniform_random_bit_generator _TRNG>
+void brendancuda::ai::mlp::FixedMLPL_ChangeWithRandom(_TFixedMLPL* MLPL, typename _TFixedMLPL::element_t Scalar, typename _TFixedMLPL::element_t LowerBound, typename _TFixedMLPL::element_t UpperBound, _TRNG& RNG) {
     using element_t = typename _TFixedMLPL::element_t;
 
     Random::RandomizeArray<false, element_t, _TRNG>(FixedMLPL_GetElementSpan(MLPL), Scalar, LowerBound, UpperBound, RNG);
 }
 
-template <brendancuda::ai::MLP::IsFixedMLP _TFixedMLP>
-void brendancuda::ai::MLP::FixedMLP_FillWith0(_TFixedMLP* MLP) {
+template <brendancuda::ai::mlp::IsFixedMLP _TFixedMLP>
+void brendancuda::ai::mlp::FixedMLP_FillWith0(_TFixedMLP* MLP) {
     using element_t = typename _TFixedMLP::element_t;
 
     Random::ClearArray<false, element_t>(FixedMLP_GetElementSpan(MLP));
 }
-template <brendancuda::ai::MLP::IsFixedMLP _TFixedMLP, std::uniform_random_bit_generator _TRNG>
-void brendancuda::ai::MLP::FixedMLP_FillWithRandom(_TFixedMLP* MLP, _TRNG& RNG) {
+template <brendancuda::ai::mlp::IsFixedMLP _TFixedMLP, std::uniform_random_bit_generator _TRNG>
+void brendancuda::ai::mlp::FixedMLP_FillWithRandom(_TFixedMLP* MLP, _TRNG& RNG) {
     using element_t = typename _TFixedMLP::element_t;
 
     Random::InitRandomArray<false, element_t, _TRNG>(FixedMLP_GetElementSpan(MLP), RNG);
 }
-template <brendancuda::ai::MLP::IsFixedMLP _TFixedMLP, std::uniform_random_bit_generator _TRNG>
-void brendancuda::ai::MLP::FixedMLP_ChangeWithRandom(_TFixedMLP* MLP, typename _TFixedMLP::element_t Scalar, _TRNG& RNG) {
+template <brendancuda::ai::mlp::IsFixedMLP _TFixedMLP, std::uniform_random_bit_generator _TRNG>
+void brendancuda::ai::mlp::FixedMLP_ChangeWithRandom(_TFixedMLP* MLP, typename _TFixedMLP::element_t Scalar, _TRNG& RNG) {
     using element_t = typename _TFixedMLP::element_t;
 
     Random::RandomizeArray<false, element_t, _TRNG>(FixedMLP_GetElementSpan(MLP), Scalar, RNG);
 }
-template <brendancuda::ai::MLP::IsFixedMLP _TFixedMLP, std::uniform_random_bit_generator _TRNG>
-void brendancuda::ai::MLP::FixedMLP_ChangeWithRandom(_TFixedMLP* MLP, typename _TFixedMLP::element_t Scalar, typename _TFixedMLP::element_t LowerBound, typename _TFixedMLP::element_t UpperBound, _TRNG& RNG) {
+template <brendancuda::ai::mlp::IsFixedMLP _TFixedMLP, std::uniform_random_bit_generator _TRNG>
+void brendancuda::ai::mlp::FixedMLP_ChangeWithRandom(_TFixedMLP* MLP, typename _TFixedMLP::element_t Scalar, typename _TFixedMLP::element_t LowerBound, typename _TFixedMLP::element_t UpperBound, _TRNG& RNG) {
     using element_t = typename _TFixedMLP::element_t;
 
     Random::RandomizeArray<false, element_t, _TRNG>(FixedMLP_GetElementSpan(MLP), Scalar, LowerBound, UpperBound, RNG);

--- a/ai_mlp_fixedmlp.h
+++ b/ai_mlp_fixedmlp.h
@@ -12,7 +12,7 @@
 #include <random>
 #include <type_traits>
 
-namespace brendancuda {
+namespace bcuda {
     namespace ai {
         namespace mlp {
             template <std::floating_point _T, activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
@@ -255,8 +255,8 @@ namespace brendancuda {
     }
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
-__host__ __device__ void brendancuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::FillWith0() {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+__host__ __device__ void bcuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::FillWith0() {
     for (size_t i = 0; i < _OutputCount; ++i) {
         for (size_t j = 0; j < _InputCount; ++j) {
             weights[i][j] = 0.;
@@ -265,9 +265,9 @@ __host__ __device__ void brendancuda::ai::mlp::FixedMLPL<_T, _ActivationFunction
     }
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::FillWithRandom(_TRNG& RNG) {
+__host__ void bcuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::FillWithRandom(_TRNG& RNG) {
     std::uniform_real_distribution<_T> dis(-1., 1.);
 
     for (size_t i = 0; i < _OutputCount; ++i) {
@@ -279,9 +279,9 @@ __host__ void brendancuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCou
 }
 
 #ifdef __CUDACC__
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
-template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::FillWithRandom(_TRNG& RNG) {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+template <bcuda::KernelCurandState _TRNG>
+__device__ void bcuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::FillWithRandom(_TRNG& RNG) {
     if constexpr (std::same_as<_T, float>) {
         for (size_t i = 0; i < _OutputCount; ++i) {
             for (size_t j = 0; j < _InputCount; ++j) {
@@ -301,9 +301,9 @@ __device__ void brendancuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputC
 }
 #endif
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
+__host__ void bcuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
     std::uniform_real_distribution<_T> dis(-Scalar, Scalar);
 
     for (size_t i = 0; i < _OutputCount; ++i) {
@@ -315,9 +315,9 @@ __host__ void brendancuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCou
 }
 
 #ifdef __CUDACC__
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
-template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+template <bcuda::KernelCurandState _TRNG>
+__device__ void bcuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
     if constexpr (std::same_as<_T, float>) {
         for (size_t i = 0; i < _OutputCount; ++i) {
             for (size_t j = 0; j < _InputCount; ++j) {
@@ -337,9 +337,9 @@ __device__ void brendancuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputC
 }
 #endif
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__host__ void bcuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     std::uniform_real_distribution<_T> dis(-Scalar, Scalar);
 
     for (size_t i = 0; i < _OutputCount; ++i) {
@@ -353,9 +353,9 @@ __host__ void brendancuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCou
 }
 
 #ifdef __CUDACC__
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
-template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+template <bcuda::KernelCurandState _TRNG>
+__device__ void bcuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     if constexpr (std::same_as<_T, float>) {
         for (size_t i = 0; i < _OutputCount; ++i) {
             for (size_t j = 0; j < _InputCount; ++j) {
@@ -379,8 +379,8 @@ __device__ void brendancuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputC
 }
 #endif
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
-__host__ __device__ void brendancuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::Run(const _T* Input, _T* output) const {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+__host__ __device__ void bcuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::Run(const _T* Input, _T* output) const {
     if (Input == output) {
         _T* secondOutput = new _T[_OutputCount];
         for (size_t j = 0; j < _OutputCount; ++j) {
@@ -403,139 +403,139 @@ __host__ __device__ void brendancuda::ai::mlp::FixedMLPL<_T, _ActivationFunction
     }
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
-size_t brendancuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::SerializedSize() const {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+size_t bcuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::SerializedSize() const {
     return sizeof(this_t);
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
-void brendancuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::Serialize(void*& Data) const {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+void bcuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::Serialize(void*& Data) const {
     BSerializer::SerializeArray(Data, weights, _InputCount * _OutputCount);
     BSerializer::SerializeArray(Data, bias, _OutputCount);
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
-auto brendancuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::Deserialize(const void*& Data) -> this_t {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+auto bcuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::Deserialize(const void*& Data) -> this_t {
     uint8_t bytes[sizeof(this_t)];
     Deserialize(Data, &bytes);
     return *(this_t*)&bytes;
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
-void brendancuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::Deserialize(const void*& Data, void* ObjMem) {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+void bcuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::Deserialize(const void*& Data, void* ObjMem) {
     this_t& obj = &(this_t*)ObjMem;
     BSerializer::DeserializeArray(Data, obj.weights, _InputCount * _OutputCount);
     BSerializer::DeserializeArray(Data, obj.bias, _OutputCount);
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-__host__ __device__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::FillWith0() {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+__host__ __device__ void bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::FillWith0() {
     layer.FillWith0();
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::FillWithRandom(_TRNG& RNG) {
+__host__ void bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::FillWithRandom(_TRNG& RNG) {
     layer.FillWithRandom(RNG);
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
+__host__ void bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
     layer.ChangeWithRandom(Scalar, RNG);
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__host__ void bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     layer.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
 }
 
 #ifdef __CUDACC__
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::FillWithRandom(_TRNG& RNG) {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+template <bcuda::KernelCurandState _TRNG>
+__device__ void bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::FillWithRandom(_TRNG& RNG) {
     layer.FillWithRandom(RNG);
 }
 #endif
 
 #ifdef __CUDACC__
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+template <bcuda::KernelCurandState _TRNG>
+__device__ void bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
     layer.ChangeWithRandom(Scalar, RNG);
 }
 #endif
 
 #ifdef __CUDACC__
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+template <bcuda::KernelCurandState _TRNG>
+__device__ void bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     layer.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
 }
 #endif
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-__host__ __device__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::FillWith0() {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+__host__ __device__ void bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::FillWith0() {
     layer.FillWith0();
     nextLayers.FillWith0();
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::FillWithRandom(_TRNG& RNG) {
+__host__ void bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::FillWithRandom(_TRNG& RNG) {
     layer.FillWithRandom(RNG);
     nextLayers.FillWithRandom(RNG);
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
+__host__ void bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
     layer.ChangeWithRandom(Scalar, RNG);
     nextLayers.ChangeWithRandom(Scalar, RNG);
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__host__ void bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     layer.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
     nextLayers.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
 }
 
 #ifdef __CUDACC__
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::FillWithRandom(_TRNG& RNG) {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+template <bcuda::KernelCurandState _TRNG>
+__device__ void bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::FillWithRandom(_TRNG& RNG) {
     layer.FillWithRandom(RNG);
     nextLayers.FillWithRandom(RNG);
 }
 #endif
 
 #ifdef __CUDACC__
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+template <bcuda::KernelCurandState _TRNG>
+__device__ void bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
     layer.ChangeWithRandom(Scalar, RNG);
     nextLayers.ChangeWithRandom(Scalar, RNG);
 }
 #endif
 
 #ifdef __CUDACC__
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+template <bcuda::KernelCurandState _TRNG>
+__device__ void bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     layer.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
     nextLayers.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
 }
 #endif
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-__host__ __device__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Run(const _T* Input, _T* output) const {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+__host__ __device__ void bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Run(const _T* Input, _T* output) const {
     Run(Input, 0, 0, output);
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-__host__ __device__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Run(const _T* Input, _T* Intermediate1, _T* Intermediate2, _T* output) const {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+__host__ __device__ void bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Run(const _T* Input, _T* Intermediate1, _T* Intermediate2, _T* output) const {
     _T* i1 = Intermediate1 ? Intermediate1 : new _T[Intermediate0Count()];
     _T* i2 = Intermediate2 ? Intermediate2 : new _T[Intermediate1Count()];
 
@@ -546,9 +546,9 @@ __host__ __device__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction,
     if (!Intermediate2) delete[] i2;
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
 template <size_t _Index>
-__host__ __device__ brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::layerType_t<_Index>& brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Layer() {
+__host__ __device__ bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::layerType_t<_Index>& bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Layer() {
     if constexpr (_Index) {
         return nextLayers.Layer<_Index - 1>();
     }
@@ -557,133 +557,133 @@ __host__ __device__ brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _Inp
     }
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-__host__ __device__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Run(const _T* Input, _T* output) const {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+__host__ __device__ void bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Run(const _T* Input, _T* output) const {
     layer.Run(Input, output);
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-__host__ __device__ void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Run(const _T* Input, _T* Intermediate1, _T* Intermediate2, _T* output) const {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+__host__ __device__ void bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Run(const _T* Input, _T* Intermediate1, _T* Intermediate2, _T* output) const {
     layer.Run(Input, output);
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
 template <size_t _Index>
-__host__ __device__ brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::layerType_t<_Index>& brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Layer() {
+__host__ __device__ bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::layerType_t<_Index>& bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Layer() {
     static_assert(!_Index, "_Index is out of bounds.");
     return layer;
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-constexpr size_t brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::InputCount() {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+constexpr size_t bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::InputCount() {
     return _InputCount;
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-constexpr size_t brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::InputCount() {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+constexpr size_t bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::InputCount() {
     return _InputCount;
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-constexpr size_t brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::OutputCount() {
-    return brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::OutputCount();
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+constexpr size_t bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::OutputCount() {
+    return bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::OutputCount();
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-constexpr size_t brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::OutputCount() {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+constexpr size_t bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::OutputCount() {
     return _Output1Count;
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-constexpr size_t brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Intermediate0Count() {
-    return std::max(_Output1Count, brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Intermediate1Count());
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+constexpr size_t bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Intermediate0Count() {
+    return std::max(_Output1Count, bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Intermediate1Count());
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-constexpr size_t brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Intermediate0Count() {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+constexpr size_t bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Intermediate0Count() {
     return 0;
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-constexpr size_t brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Intermediate1Count() {
-    return brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Intermediate0Count();
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+constexpr size_t bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Intermediate1Count() {
+    return bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Intermediate0Count();
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-constexpr size_t brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Intermediate1Count() {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+constexpr size_t bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Intermediate1Count() {
     return 0;
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-constexpr size_t brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::MaxLayerOutputCount() {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+constexpr size_t bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::MaxLayerOutputCount() {
     constexpr size_t maxNextLayers = FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::MaxLayerOutputCount();
     return _Output1Count > maxNextLayers ? _Output1Count : maxNextLayers;
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-constexpr size_t brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::LayerCount() {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+constexpr size_t bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::LayerCount() {
     return FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::LayerCount() + 1;
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-size_t brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::SerializedSize() const {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+size_t bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::SerializedSize() const {
     return sizeof(this_t);
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Serialize(void*& Data) const {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+void bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Serialize(void*& Data) const {
     layer.Serialize(Data);
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-auto brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Deserialize(const void*& Data) -> this_t {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+auto bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Deserialize(const void*& Data) -> this_t {
     uint8_t bytes[sizeof(this_t)];
     Deserialize(Data, &bytes);
     return *(this_t*)&bytes;
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Deserialize(const void*& Data, void* ObjMem) {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+void bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Deserialize(const void*& Data, void* ObjMem) {
     this_t& obj = &(this_t*)ObjMem;
     BSerializer::Deserialize(Data, &obj.layer);
     BSerializer::Deserialize(Data, &obj.nextLayers);
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-constexpr size_t brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::MaxLayerOutputCount() {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+constexpr size_t bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::MaxLayerOutputCount() {
     return _Output1Count;
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-constexpr size_t brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::LayerCount() {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+constexpr size_t bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::LayerCount() {
     return 1;
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-size_t brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::SerializedSize() const {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+size_t bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::SerializedSize() const {
     return sizeof(this_t);
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Serialize(void*& Data) const {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+void bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Serialize(void*& Data) const {
     layer.Serialize(Data);
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-auto brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Deserialize(const void*& Data) -> this_t {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+auto bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Deserialize(const void*& Data) -> this_t {
     uint8_t bytes[sizeof(this_t)];
     Deserialize(Data, &bytes);
     return *(this_t*)&bytes;
 }
 
-template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-void brendancuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Deserialize(const void*& Data, void* ObjMem) {
+template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+void bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Deserialize(const void*& Data, void* ObjMem) {
     this_t& obj = &(this_t*)ObjMem;
     BSerializer::Deserialize(Data, &obj.layer);
 }
 
-template <brendancuda::ai::mlp::IsFixedMLPL _TFixedMLPL, bool _InputOnHost, bool _OutputOnHost>
-void brendancuda::ai::mlp::FixedMLPL_Run(const _TFixedMLPL* MLPL, const typename _TFixedMLPL::element_t* Inputs, typename _TFixedMLPL::element_t* Outputs) {
+template <bcuda::ai::mlp::IsFixedMLPL _TFixedMLPL, bool _InputOnHost, bool _OutputOnHost>
+void bcuda::ai::mlp::FixedMLPL_Run(const _TFixedMLPL* MLPL, const typename _TFixedMLPL::element_t* Inputs, typename _TFixedMLPL::element_t* Outputs) {
     using element_t = typename _TFixedMLPL::element_t;
     if constexpr (_InputOnHost) {
         if constexpr (_OutputOnHost) {
@@ -724,8 +724,8 @@ void brendancuda::ai::mlp::FixedMLPL_Run(const _TFixedMLPL* MLPL, const typename
     }
 }
 
-template <brendancuda::ai::mlp::IsFixedMLP _TFixedMLP, bool _InputOnHost, bool _OutputOnHost>
-void brendancuda::ai::mlp::FixedMLP_Run(const _TFixedMLP* MLP, const typename _TFixedMLP::element_t* Inputs, typename _TFixedMLP::element_t* Outputs) {
+template <bcuda::ai::mlp::IsFixedMLP _TFixedMLP, bool _InputOnHost, bool _OutputOnHost>
+void bcuda::ai::mlp::FixedMLP_Run(const _TFixedMLP* MLP, const typename _TFixedMLP::element_t* Inputs, typename _TFixedMLP::element_t* Outputs) {
     using element_t = typename _TFixedMLP::element_t;
     if constexpr (_InputOnHost) {
         if constexpr (_OutputOnHost) {
@@ -768,8 +768,8 @@ void brendancuda::ai::mlp::FixedMLP_Run(const _TFixedMLP* MLP, const typename _T
     }
 }
 
-template <brendancuda::ai::mlp::IsFixedMLP _TFixedMLP>
-void brendancuda::details::FixedMLP_Run(const _TFixedMLP* MLP, const typename _TFixedMLP::element_t* Inputs, typename _TFixedMLP::element_t* Intermediate0, typename _TFixedMLP::element_t* Intermediate1, typename _TFixedMLP::element_t* Outputs) {
+template <bcuda::ai::mlp::IsFixedMLP _TFixedMLP>
+void bcuda::details::FixedMLP_Run(const _TFixedMLP* MLP, const typename _TFixedMLP::element_t* Inputs, typename _TFixedMLP::element_t* Intermediate0, typename _TFixedMLP::element_t* Intermediate1, typename _TFixedMLP::element_t* Outputs) {
     using element_t = typename _TFixedMLP::element_t;
 
     if constexpr (_TFixedMLP::LayerCount() == 1) {
@@ -782,63 +782,63 @@ void brendancuda::details::FixedMLP_Run(const _TFixedMLP* MLP, const typename _T
 }
 
 template <typename _TFixedMLPL>
-    requires brendancuda::ai::mlp::IsFixedMLPL<std::remove_const_t<_TFixedMLPL>>
-__host__ __device__ brendancuda::Span<std::conditional_t<std::is_const_v<_TFixedMLPL>, const typename _TFixedMLPL::element_t, typename _TFixedMLPL::element_t>> brendancuda::ai::mlp::FixedMLPL_GetElementSpan(_TFixedMLPL* MLPL) {
+    requires bcuda::ai::mlp::IsFixedMLPL<std::remove_const_t<_TFixedMLPL>>
+__host__ __device__ bcuda::Span<std::conditional_t<std::is_const_v<_TFixedMLPL>, const typename _TFixedMLPL::element_t, typename _TFixedMLPL::element_t>> bcuda::ai::mlp::FixedMLPL_GetElementSpan(_TFixedMLPL* MLPL) {
     using element_t = std::conditional_t<std::is_const_v<_TFixedMLPL>, const typename _TFixedMLPL::element_t, typename _TFixedMLPL::element_t>;
     return Span<element_t>((element_t*)MLPL, sizeof(_TFixedMLPL) / sizeof(element_t));
 }
 template <typename _TFixedMLP>
-    requires brendancuda::ai::mlp::IsFixedMLP<std::remove_const_t<_TFixedMLP>>
-__host__ __device__ brendancuda::Span<std::conditional_t<std::is_const_v<_TFixedMLP>, const typename _TFixedMLP::element_t, typename _TFixedMLP::element_t>> brendancuda::ai::mlp::FixedMLP_GetElementSpan(_TFixedMLP* MLP) {
+    requires bcuda::ai::mlp::IsFixedMLP<std::remove_const_t<_TFixedMLP>>
+__host__ __device__ bcuda::Span<std::conditional_t<std::is_const_v<_TFixedMLP>, const typename _TFixedMLP::element_t, typename _TFixedMLP::element_t>> bcuda::ai::mlp::FixedMLP_GetElementSpan(_TFixedMLP* MLP) {
     using element_t = std::conditional_t<std::is_const_v<_TFixedMLP>, const typename _TFixedMLP::element_t, typename _TFixedMLP::element_t>;
     return Span<element_t>((element_t*)MLP, sizeof(_TFixedMLP) / sizeof(element_t));
 }
 
-template <brendancuda::ai::mlp::IsFixedMLPL _TFixedMLPL>
-void brendancuda::ai::mlp::FixedMLPL_FillWith0(_TFixedMLPL* MLPL) {
+template <bcuda::ai::mlp::IsFixedMLPL _TFixedMLPL>
+void bcuda::ai::mlp::FixedMLPL_FillWith0(_TFixedMLPL* MLPL) {
     using element_t = typename _TFixedMLPL::element_t;
 
     random::ClearArray<false, element_t>(FixedMLPL_GetElementSpan(MLPL));
 }
-template <brendancuda::ai::mlp::IsFixedMLPL _TFixedMLPL, std::uniform_random_bit_generator _TRNG>
-void brendancuda::ai::mlp::FixedMLPL_FillWithRandom(_TFixedMLPL* MLPL, _TRNG& RNG) {
+template <bcuda::ai::mlp::IsFixedMLPL _TFixedMLPL, std::uniform_random_bit_generator _TRNG>
+void bcuda::ai::mlp::FixedMLPL_FillWithRandom(_TFixedMLPL* MLPL, _TRNG& RNG) {
     using element_t = typename _TFixedMLPL::element_t;
 
     random::InitRandomArray<false, element_t, _TRNG>(FixedMLPL_GetElementSpan(MLPL), RNG);
 }
-template <brendancuda::ai::mlp::IsFixedMLPL _TFixedMLPL, std::uniform_random_bit_generator _TRNG>
-void brendancuda::ai::mlp::FixedMLPL_ChangeWithRandom(_TFixedMLPL* MLPL, typename _TFixedMLPL::element_t Scalar, _TRNG& RNG) {
+template <bcuda::ai::mlp::IsFixedMLPL _TFixedMLPL, std::uniform_random_bit_generator _TRNG>
+void bcuda::ai::mlp::FixedMLPL_ChangeWithRandom(_TFixedMLPL* MLPL, typename _TFixedMLPL::element_t Scalar, _TRNG& RNG) {
     using element_t = typename _TFixedMLPL::element_t;
 
     random::RandomizeArray<false, element_t, _TRNG>(FixedMLPL_GetElementSpan(MLPL), Scalar, RNG);
 }
-template <brendancuda::ai::mlp::IsFixedMLPL _TFixedMLPL, std::uniform_random_bit_generator _TRNG>
-void brendancuda::ai::mlp::FixedMLPL_ChangeWithRandom(_TFixedMLPL* MLPL, typename _TFixedMLPL::element_t Scalar, typename _TFixedMLPL::element_t LowerBound, typename _TFixedMLPL::element_t UpperBound, _TRNG& RNG) {
+template <bcuda::ai::mlp::IsFixedMLPL _TFixedMLPL, std::uniform_random_bit_generator _TRNG>
+void bcuda::ai::mlp::FixedMLPL_ChangeWithRandom(_TFixedMLPL* MLPL, typename _TFixedMLPL::element_t Scalar, typename _TFixedMLPL::element_t LowerBound, typename _TFixedMLPL::element_t UpperBound, _TRNG& RNG) {
     using element_t = typename _TFixedMLPL::element_t;
 
     random::RandomizeArray<false, element_t, _TRNG>(FixedMLPL_GetElementSpan(MLPL), Scalar, LowerBound, UpperBound, RNG);
 }
 
-template <brendancuda::ai::mlp::IsFixedMLP _TFixedMLP>
-void brendancuda::ai::mlp::FixedMLP_FillWith0(_TFixedMLP* MLP) {
+template <bcuda::ai::mlp::IsFixedMLP _TFixedMLP>
+void bcuda::ai::mlp::FixedMLP_FillWith0(_TFixedMLP* MLP) {
     using element_t = typename _TFixedMLP::element_t;
 
     random::ClearArray<false, element_t>(FixedMLP_GetElementSpan(MLP));
 }
-template <brendancuda::ai::mlp::IsFixedMLP _TFixedMLP, std::uniform_random_bit_generator _TRNG>
-void brendancuda::ai::mlp::FixedMLP_FillWithRandom(_TFixedMLP* MLP, _TRNG& RNG) {
+template <bcuda::ai::mlp::IsFixedMLP _TFixedMLP, std::uniform_random_bit_generator _TRNG>
+void bcuda::ai::mlp::FixedMLP_FillWithRandom(_TFixedMLP* MLP, _TRNG& RNG) {
     using element_t = typename _TFixedMLP::element_t;
 
     random::InitRandomArray<false, element_t, _TRNG>(FixedMLP_GetElementSpan(MLP), RNG);
 }
-template <brendancuda::ai::mlp::IsFixedMLP _TFixedMLP, std::uniform_random_bit_generator _TRNG>
-void brendancuda::ai::mlp::FixedMLP_ChangeWithRandom(_TFixedMLP* MLP, typename _TFixedMLP::element_t Scalar, _TRNG& RNG) {
+template <bcuda::ai::mlp::IsFixedMLP _TFixedMLP, std::uniform_random_bit_generator _TRNG>
+void bcuda::ai::mlp::FixedMLP_ChangeWithRandom(_TFixedMLP* MLP, typename _TFixedMLP::element_t Scalar, _TRNG& RNG) {
     using element_t = typename _TFixedMLP::element_t;
 
     random::RandomizeArray<false, element_t, _TRNG>(FixedMLP_GetElementSpan(MLP), Scalar, RNG);
 }
-template <brendancuda::ai::mlp::IsFixedMLP _TFixedMLP, std::uniform_random_bit_generator _TRNG>
-void brendancuda::ai::mlp::FixedMLP_ChangeWithRandom(_TFixedMLP* MLP, typename _TFixedMLP::element_t Scalar, typename _TFixedMLP::element_t LowerBound, typename _TFixedMLP::element_t UpperBound, _TRNG& RNG) {
+template <bcuda::ai::mlp::IsFixedMLP _TFixedMLP, std::uniform_random_bit_generator _TRNG>
+void bcuda::ai::mlp::FixedMLP_ChangeWithRandom(_TFixedMLP* MLP, typename _TFixedMLP::element_t Scalar, typename _TFixedMLP::element_t LowerBound, typename _TFixedMLP::element_t UpperBound, _TRNG& RNG) {
     using element_t = typename _TFixedMLP::element_t;
 
     random::RandomizeArray<false, element_t, _TRNG>(FixedMLP_GetElementSpan(MLP), Scalar, LowerBound, UpperBound, RNG);

--- a/ai_mlp_fixedmlp.h
+++ b/ai_mlp_fixedmlp.h
@@ -798,48 +798,48 @@ template <brendancuda::ai::mlp::IsFixedMLPL _TFixedMLPL>
 void brendancuda::ai::mlp::FixedMLPL_FillWith0(_TFixedMLPL* MLPL) {
     using element_t = typename _TFixedMLPL::element_t;
 
-    Random::ClearArray<false, element_t>(FixedMLPL_GetElementSpan(MLPL));
+    random::ClearArray<false, element_t>(FixedMLPL_GetElementSpan(MLPL));
 }
 template <brendancuda::ai::mlp::IsFixedMLPL _TFixedMLPL, std::uniform_random_bit_generator _TRNG>
 void brendancuda::ai::mlp::FixedMLPL_FillWithRandom(_TFixedMLPL* MLPL, _TRNG& RNG) {
     using element_t = typename _TFixedMLPL::element_t;
 
-    Random::InitRandomArray<false, element_t, _TRNG>(FixedMLPL_GetElementSpan(MLPL), RNG);
+    random::InitRandomArray<false, element_t, _TRNG>(FixedMLPL_GetElementSpan(MLPL), RNG);
 }
 template <brendancuda::ai::mlp::IsFixedMLPL _TFixedMLPL, std::uniform_random_bit_generator _TRNG>
 void brendancuda::ai::mlp::FixedMLPL_ChangeWithRandom(_TFixedMLPL* MLPL, typename _TFixedMLPL::element_t Scalar, _TRNG& RNG) {
     using element_t = typename _TFixedMLPL::element_t;
 
-    Random::RandomizeArray<false, element_t, _TRNG>(FixedMLPL_GetElementSpan(MLPL), Scalar, RNG);
+    random::RandomizeArray<false, element_t, _TRNG>(FixedMLPL_GetElementSpan(MLPL), Scalar, RNG);
 }
 template <brendancuda::ai::mlp::IsFixedMLPL _TFixedMLPL, std::uniform_random_bit_generator _TRNG>
 void brendancuda::ai::mlp::FixedMLPL_ChangeWithRandom(_TFixedMLPL* MLPL, typename _TFixedMLPL::element_t Scalar, typename _TFixedMLPL::element_t LowerBound, typename _TFixedMLPL::element_t UpperBound, _TRNG& RNG) {
     using element_t = typename _TFixedMLPL::element_t;
 
-    Random::RandomizeArray<false, element_t, _TRNG>(FixedMLPL_GetElementSpan(MLPL), Scalar, LowerBound, UpperBound, RNG);
+    random::RandomizeArray<false, element_t, _TRNG>(FixedMLPL_GetElementSpan(MLPL), Scalar, LowerBound, UpperBound, RNG);
 }
 
 template <brendancuda::ai::mlp::IsFixedMLP _TFixedMLP>
 void brendancuda::ai::mlp::FixedMLP_FillWith0(_TFixedMLP* MLP) {
     using element_t = typename _TFixedMLP::element_t;
 
-    Random::ClearArray<false, element_t>(FixedMLP_GetElementSpan(MLP));
+    random::ClearArray<false, element_t>(FixedMLP_GetElementSpan(MLP));
 }
 template <brendancuda::ai::mlp::IsFixedMLP _TFixedMLP, std::uniform_random_bit_generator _TRNG>
 void brendancuda::ai::mlp::FixedMLP_FillWithRandom(_TFixedMLP* MLP, _TRNG& RNG) {
     using element_t = typename _TFixedMLP::element_t;
 
-    Random::InitRandomArray<false, element_t, _TRNG>(FixedMLP_GetElementSpan(MLP), RNG);
+    random::InitRandomArray<false, element_t, _TRNG>(FixedMLP_GetElementSpan(MLP), RNG);
 }
 template <brendancuda::ai::mlp::IsFixedMLP _TFixedMLP, std::uniform_random_bit_generator _TRNG>
 void brendancuda::ai::mlp::FixedMLP_ChangeWithRandom(_TFixedMLP* MLP, typename _TFixedMLP::element_t Scalar, _TRNG& RNG) {
     using element_t = typename _TFixedMLP::element_t;
 
-    Random::RandomizeArray<false, element_t, _TRNG>(FixedMLP_GetElementSpan(MLP), Scalar, RNG);
+    random::RandomizeArray<false, element_t, _TRNG>(FixedMLP_GetElementSpan(MLP), Scalar, RNG);
 }
 template <brendancuda::ai::mlp::IsFixedMLP _TFixedMLP, std::uniform_random_bit_generator _TRNG>
 void brendancuda::ai::mlp::FixedMLP_ChangeWithRandom(_TFixedMLP* MLP, typename _TFixedMLP::element_t Scalar, typename _TFixedMLP::element_t LowerBound, typename _TFixedMLP::element_t UpperBound, _TRNG& RNG) {
     using element_t = typename _TFixedMLP::element_t;
 
-    Random::RandomizeArray<false, element_t, _TRNG>(FixedMLP_GetElementSpan(MLP), Scalar, LowerBound, UpperBound, RNG);
+    random::RandomizeArray<false, element_t, _TRNG>(FixedMLP_GetElementSpan(MLP), Scalar, LowerBound, UpperBound, RNG);
 }

--- a/ai_mlp_fixedmlp.h
+++ b/ai_mlp_fixedmlp.h
@@ -345,10 +345,10 @@ __host__ void brendancuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCou
     for (size_t i = 0; i < _OutputCount; ++i) {
         for (size_t j = 0; j < _InputCount; ++j) {
             _T& v = weights[i][j];
-            v = Math::clamp(v + dis(RNG), LowerBound, UpperBound);
+            v = math::clamp(v + dis(RNG), LowerBound, UpperBound);
         }
         _T& v = bias[i];
-        v = Math::clamp(v + dis(RNG), LowerBound, UpperBound);
+        v = math::clamp(v + dis(RNG), LowerBound, UpperBound);
     }
 }
 
@@ -360,20 +360,20 @@ __device__ void brendancuda::ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputC
         for (size_t i = 0; i < _OutputCount; ++i) {
             for (size_t j = 0; j < _InputCount; ++j) {
                 _T& v = weights[i][j];
-                v = Math::clamp(v + curand_uniform(&RNG), LowerBound, UpperBound);
+                v = math::clamp(v + curand_uniform(&RNG), LowerBound, UpperBound);
             }
             _T& v = bias[i];
-            v = Math::clamp(v + curand_uniform(&RNG), LowerBound, UpperBound);
+            v = math::clamp(v + curand_uniform(&RNG), LowerBound, UpperBound);
         }
     }
     else {
         for (size_t i = 0; i < _OutputCount; ++i) {
             for (size_t j = 0; j < _InputCount; ++j) {
                 _T& v = weights[i][j];
-                v = Math::clamp(v + curand_uniform_double(&RNG), LowerBound, UpperBound);
+                v = math::clamp(v + curand_uniform_double(&RNG), LowerBound, UpperBound);
             }
             _T& v = bias[i];
-            v = Math::clamp(v + curand_uniform_double(&RNG), LowerBound, UpperBound);
+            v = math::clamp(v + curand_uniform_double(&RNG), LowerBound, UpperBound);
         }
     }
 }

--- a/ai_mlp_fixedmlp.h
+++ b/ai_mlp_fixedmlp.h
@@ -12,7 +12,7 @@
 #include <random>
 #include <type_traits>
 
-namespace BrendanCUDA {
+namespace brendancuda {
     namespace AI {
         namespace MLP {
             template <std::floating_point _T, activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
@@ -255,8 +255,8 @@ namespace BrendanCUDA {
     }
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
-__host__ __device__ void BrendanCUDA::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::FillWith0() {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+__host__ __device__ void brendancuda::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::FillWith0() {
     for (size_t i = 0; i < _OutputCount; ++i) {
         for (size_t j = 0; j < _InputCount; ++j) {
             weights[i][j] = 0.;
@@ -265,9 +265,9 @@ __host__ __device__ void BrendanCUDA::AI::MLP::FixedMLPL<_T, _ActivationFunction
     }
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void BrendanCUDA::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::FillWithRandom(_TRNG& RNG) {
+__host__ void brendancuda::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::FillWithRandom(_TRNG& RNG) {
     std::uniform_real_distribution<_T> dis(-1., 1.);
 
     for (size_t i = 0; i < _OutputCount; ++i) {
@@ -279,9 +279,9 @@ __host__ void BrendanCUDA::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCou
 }
 
 #ifdef __CUDACC__
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ void BrendanCUDA::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::FillWithRandom(_TRNG& RNG) {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+template <brendancuda::KernelCurandState _TRNG>
+__device__ void brendancuda::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::FillWithRandom(_TRNG& RNG) {
     if constexpr (std::same_as<_T, float>) {
         for (size_t i = 0; i < _OutputCount; ++i) {
             for (size_t j = 0; j < _InputCount; ++j) {
@@ -301,9 +301,9 @@ __device__ void BrendanCUDA::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputC
 }
 #endif
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void BrendanCUDA::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
+__host__ void brendancuda::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
     std::uniform_real_distribution<_T> dis(-Scalar, Scalar);
 
     for (size_t i = 0; i < _OutputCount; ++i) {
@@ -315,9 +315,9 @@ __host__ void BrendanCUDA::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCou
 }
 
 #ifdef __CUDACC__
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ void BrendanCUDA::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+template <brendancuda::KernelCurandState _TRNG>
+__device__ void brendancuda::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
     if constexpr (std::same_as<_T, float>) {
         for (size_t i = 0; i < _OutputCount; ++i) {
             for (size_t j = 0; j < _InputCount; ++j) {
@@ -337,9 +337,9 @@ __device__ void BrendanCUDA::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputC
 }
 #endif
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void BrendanCUDA::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__host__ void brendancuda::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     std::uniform_real_distribution<_T> dis(-Scalar, Scalar);
 
     for (size_t i = 0; i < _OutputCount; ++i) {
@@ -353,9 +353,9 @@ __host__ void BrendanCUDA::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCou
 }
 
 #ifdef __CUDACC__
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ void BrendanCUDA::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+template <brendancuda::KernelCurandState _TRNG>
+__device__ void brendancuda::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     if constexpr (std::same_as<_T, float>) {
         for (size_t i = 0; i < _OutputCount; ++i) {
             for (size_t j = 0; j < _InputCount; ++j) {
@@ -379,8 +379,8 @@ __device__ void BrendanCUDA::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputC
 }
 #endif
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
-__host__ __device__ void BrendanCUDA::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::Run(const _T* Input, _T* Output) const {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+__host__ __device__ void brendancuda::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::Run(const _T* Input, _T* Output) const {
     if (Input == Output) {
         _T* secondOutput = new _T[_OutputCount];
         for (size_t j = 0; j < _OutputCount; ++j) {
@@ -403,139 +403,139 @@ __host__ __device__ void BrendanCUDA::AI::MLP::FixedMLPL<_T, _ActivationFunction
     }
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
-size_t BrendanCUDA::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::SerializedSize() const {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+size_t brendancuda::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::SerializedSize() const {
     return sizeof(this_t);
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
-void BrendanCUDA::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::Serialize(void*& Data) const {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+void brendancuda::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::Serialize(void*& Data) const {
     BSerializer::SerializeArray(Data, weights, _InputCount * _OutputCount);
     BSerializer::SerializeArray(Data, bias, _OutputCount);
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
-auto BrendanCUDA::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::Deserialize(const void*& Data) -> this_t {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+auto brendancuda::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::Deserialize(const void*& Data) -> this_t {
     uint8_t bytes[sizeof(this_t)];
     Deserialize(Data, &bytes);
     return *(this_t*)&bytes;
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
-void BrendanCUDA::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::Deserialize(const void*& Data, void* ObjMem) {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+void brendancuda::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::Deserialize(const void*& Data, void* ObjMem) {
     this_t& obj = &(this_t*)ObjMem;
     BSerializer::DeserializeArray(Data, obj.weights, _InputCount * _OutputCount);
     BSerializer::DeserializeArray(Data, obj.bias, _OutputCount);
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-__host__ __device__ void BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::FillWith0() {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+__host__ __device__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::FillWith0() {
     layer.FillWith0();
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::FillWithRandom(_TRNG& RNG) {
+__host__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::FillWithRandom(_TRNG& RNG) {
     layer.FillWithRandom(RNG);
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
+__host__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
     layer.ChangeWithRandom(Scalar, RNG);
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__host__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     layer.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
 }
 
 #ifdef __CUDACC__
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ void BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::FillWithRandom(_TRNG& RNG) {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+template <brendancuda::KernelCurandState _TRNG>
+__device__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::FillWithRandom(_TRNG& RNG) {
     layer.FillWithRandom(RNG);
 }
 #endif
 
 #ifdef __CUDACC__
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ void BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+template <brendancuda::KernelCurandState _TRNG>
+__device__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
     layer.ChangeWithRandom(Scalar, RNG);
 }
 #endif
 
 #ifdef __CUDACC__
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ void BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+template <brendancuda::KernelCurandState _TRNG>
+__device__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     layer.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
 }
 #endif
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-__host__ __device__ void BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::FillWith0() {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+__host__ __device__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::FillWith0() {
     layer.FillWith0();
     nextLayers.FillWith0();
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::FillWithRandom(_TRNG& RNG) {
+__host__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::FillWithRandom(_TRNG& RNG) {
     layer.FillWithRandom(RNG);
     nextLayers.FillWithRandom(RNG);
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
+__host__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
     layer.ChangeWithRandom(Scalar, RNG);
     nextLayers.ChangeWithRandom(Scalar, RNG);
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__host__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     layer.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
     nextLayers.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
 }
 
 #ifdef __CUDACC__
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ void BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::FillWithRandom(_TRNG& RNG) {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+template <brendancuda::KernelCurandState _TRNG>
+__device__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::FillWithRandom(_TRNG& RNG) {
     layer.FillWithRandom(RNG);
     nextLayers.FillWithRandom(RNG);
 }
 #endif
 
 #ifdef __CUDACC__
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ void BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+template <brendancuda::KernelCurandState _TRNG>
+__device__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
     layer.ChangeWithRandom(Scalar, RNG);
     nextLayers.ChangeWithRandom(Scalar, RNG);
 }
 #endif
 
 #ifdef __CUDACC__
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ void BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+template <brendancuda::KernelCurandState _TRNG>
+__device__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     layer.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
     nextLayers.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
 }
 #endif
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-__host__ __device__ void BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Run(const _T* Input, _T* Output) const {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+__host__ __device__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Run(const _T* Input, _T* Output) const {
     Run(Input, 0, 0, Output);
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-__host__ __device__ void BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Run(const _T* Input, _T* Intermediate1, _T* Intermediate2, _T* Output) const {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+__host__ __device__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Run(const _T* Input, _T* Intermediate1, _T* Intermediate2, _T* Output) const {
     _T* i1 = Intermediate1 ? Intermediate1 : new _T[Intermediate0Count()];
     _T* i2 = Intermediate2 ? Intermediate2 : new _T[Intermediate1Count()];
 
@@ -546,9 +546,9 @@ __host__ __device__ void BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction,
     if (!Intermediate2) delete[] i2;
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
 template <size_t _Index>
-__host__ __device__ BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::layerType_t<_Index>& BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Layer() {
+__host__ __device__ brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::layerType_t<_Index>& brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Layer() {
     if constexpr (_Index) {
         return nextLayers.Layer<_Index - 1>();
     }
@@ -557,133 +557,133 @@ __host__ __device__ BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _Inp
     }
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-__host__ __device__ void BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Run(const _T* Input, _T* Output) const {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+__host__ __device__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Run(const _T* Input, _T* Output) const {
     layer.Run(Input, Output);
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-__host__ __device__ void BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Run(const _T* Input, _T* Intermediate1, _T* Intermediate2, _T* Output) const {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+__host__ __device__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Run(const _T* Input, _T* Intermediate1, _T* Intermediate2, _T* Output) const {
     layer.Run(Input, Output);
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
 template <size_t _Index>
-__host__ __device__ BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::layerType_t<_Index>& BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Layer() {
+__host__ __device__ brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::layerType_t<_Index>& brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Layer() {
     static_assert(!_Index, "_Index is out of bounds.");
     return layer;
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-constexpr size_t BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::InputCount() {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+constexpr size_t brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::InputCount() {
     return _InputCount;
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-constexpr size_t BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::InputCount() {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+constexpr size_t brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::InputCount() {
     return _InputCount;
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-constexpr size_t BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::OutputCount() {
-    return BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::OutputCount();
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+constexpr size_t brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::OutputCount() {
+    return brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::OutputCount();
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-constexpr size_t BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::OutputCount() {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+constexpr size_t brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::OutputCount() {
     return _Output1Count;
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-constexpr size_t BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Intermediate0Count() {
-    return std::max(_Output1Count, BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Intermediate1Count());
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+constexpr size_t brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Intermediate0Count() {
+    return std::max(_Output1Count, brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Intermediate1Count());
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-constexpr size_t BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Intermediate0Count() {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+constexpr size_t brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Intermediate0Count() {
     return 0;
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-constexpr size_t BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Intermediate1Count() {
-    return BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Intermediate0Count();
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+constexpr size_t brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Intermediate1Count() {
+    return brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Intermediate0Count();
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-constexpr size_t BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Intermediate1Count() {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+constexpr size_t brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Intermediate1Count() {
     return 0;
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-constexpr size_t BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::MaxLayerOutputCount() {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+constexpr size_t brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::MaxLayerOutputCount() {
     constexpr size_t maxNextLayers = FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::MaxLayerOutputCount();
     return _Output1Count > maxNextLayers ? _Output1Count : maxNextLayers;
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-constexpr size_t BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::LayerCount() {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+constexpr size_t brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::LayerCount() {
     return FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::LayerCount() + 1;
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-size_t BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::SerializedSize() const {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+size_t brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::SerializedSize() const {
     return sizeof(this_t);
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-void BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Serialize(void*& Data) const {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Serialize(void*& Data) const {
     layer.Serialize(Data);
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-auto BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Deserialize(const void*& Data) -> this_t {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+auto brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Deserialize(const void*& Data) -> this_t {
     uint8_t bytes[sizeof(this_t)];
     Deserialize(Data, &bytes);
     return *(this_t*)&bytes;
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-void BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Deserialize(const void*& Data, void* ObjMem) {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Deserialize(const void*& Data, void* ObjMem) {
     this_t& obj = &(this_t*)ObjMem;
     BSerializer::Deserialize(Data, &obj.layer);
     BSerializer::Deserialize(Data, &obj.nextLayers);
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-constexpr size_t BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::MaxLayerOutputCount() {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+constexpr size_t brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::MaxLayerOutputCount() {
     return _Output1Count;
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-constexpr size_t BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::LayerCount() {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+constexpr size_t brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::LayerCount() {
     return 1;
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-size_t BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::SerializedSize() const {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+size_t brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::SerializedSize() const {
     return sizeof(this_t);
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-void BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Serialize(void*& Data) const {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Serialize(void*& Data) const {
     layer.Serialize(Data);
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-auto BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Deserialize(const void*& Data) -> this_t {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+auto brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Deserialize(const void*& Data) -> this_t {
     uint8_t bytes[sizeof(this_t)];
     Deserialize(Data, &bytes);
     return *(this_t*)&bytes;
 }
 
-template <std::floating_point _T, BrendanCUDA::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-void BrendanCUDA::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Deserialize(const void*& Data, void* ObjMem) {
+template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Deserialize(const void*& Data, void* ObjMem) {
     this_t& obj = &(this_t*)ObjMem;
     BSerializer::Deserialize(Data, &obj.layer);
 }
 
-template <BrendanCUDA::AI::MLP::IsFixedMLPL _TFixedMLPL, bool _InputOnHost, bool _OutputOnHost>
-void BrendanCUDA::AI::MLP::FixedMLPL_Run(const _TFixedMLPL* MLPL, const typename _TFixedMLPL::element_t* Inputs, typename _TFixedMLPL::element_t* Outputs) {
+template <brendancuda::AI::MLP::IsFixedMLPL _TFixedMLPL, bool _InputOnHost, bool _OutputOnHost>
+void brendancuda::AI::MLP::FixedMLPL_Run(const _TFixedMLPL* MLPL, const typename _TFixedMLPL::element_t* Inputs, typename _TFixedMLPL::element_t* Outputs) {
     using element_t = typename _TFixedMLPL::element_t;
     if constexpr (_InputOnHost) {
         if constexpr (_OutputOnHost) {
@@ -724,8 +724,8 @@ void BrendanCUDA::AI::MLP::FixedMLPL_Run(const _TFixedMLPL* MLPL, const typename
     }
 }
 
-template <BrendanCUDA::AI::MLP::IsFixedMLP _TFixedMLP, bool _InputOnHost, bool _OutputOnHost>
-void BrendanCUDA::AI::MLP::FixedMLP_Run(const _TFixedMLP* MLP, const typename _TFixedMLP::element_t* Inputs, typename _TFixedMLP::element_t* Outputs) {
+template <brendancuda::AI::MLP::IsFixedMLP _TFixedMLP, bool _InputOnHost, bool _OutputOnHost>
+void brendancuda::AI::MLP::FixedMLP_Run(const _TFixedMLP* MLP, const typename _TFixedMLP::element_t* Inputs, typename _TFixedMLP::element_t* Outputs) {
     using element_t = typename _TFixedMLP::element_t;
     if constexpr (_InputOnHost) {
         if constexpr (_OutputOnHost) {
@@ -768,8 +768,8 @@ void BrendanCUDA::AI::MLP::FixedMLP_Run(const _TFixedMLP* MLP, const typename _T
     }
 }
 
-template <BrendanCUDA::AI::MLP::IsFixedMLP _TFixedMLP>
-void BrendanCUDA::details::FixedMLP_Run(const _TFixedMLP* MLP, const typename _TFixedMLP::element_t* Inputs, typename _TFixedMLP::element_t* Intermediate0, typename _TFixedMLP::element_t* Intermediate1, typename _TFixedMLP::element_t* Outputs) {
+template <brendancuda::AI::MLP::IsFixedMLP _TFixedMLP>
+void brendancuda::details::FixedMLP_Run(const _TFixedMLP* MLP, const typename _TFixedMLP::element_t* Inputs, typename _TFixedMLP::element_t* Intermediate0, typename _TFixedMLP::element_t* Intermediate1, typename _TFixedMLP::element_t* Outputs) {
     using element_t = typename _TFixedMLP::element_t;
 
     if constexpr (_TFixedMLP::LayerCount() == 1) {
@@ -782,63 +782,63 @@ void BrendanCUDA::details::FixedMLP_Run(const _TFixedMLP* MLP, const typename _T
 }
 
 template <typename _TFixedMLPL>
-    requires BrendanCUDA::AI::MLP::IsFixedMLPL<std::remove_const_t<_TFixedMLPL>>
-__host__ __device__ BrendanCUDA::Span<std::conditional_t<std::is_const_v<_TFixedMLPL>, const typename _TFixedMLPL::element_t, typename _TFixedMLPL::element_t>> BrendanCUDA::AI::MLP::FixedMLPL_GetElementSpan(_TFixedMLPL* MLPL) {
+    requires brendancuda::AI::MLP::IsFixedMLPL<std::remove_const_t<_TFixedMLPL>>
+__host__ __device__ brendancuda::Span<std::conditional_t<std::is_const_v<_TFixedMLPL>, const typename _TFixedMLPL::element_t, typename _TFixedMLPL::element_t>> brendancuda::AI::MLP::FixedMLPL_GetElementSpan(_TFixedMLPL* MLPL) {
     using element_t = std::conditional_t<std::is_const_v<_TFixedMLPL>, const typename _TFixedMLPL::element_t, typename _TFixedMLPL::element_t>;
     return Span<element_t>((element_t*)MLPL, sizeof(_TFixedMLPL) / sizeof(element_t));
 }
 template <typename _TFixedMLP>
-    requires BrendanCUDA::AI::MLP::IsFixedMLP<std::remove_const_t<_TFixedMLP>>
-__host__ __device__ BrendanCUDA::Span<std::conditional_t<std::is_const_v<_TFixedMLP>, const typename _TFixedMLP::element_t, typename _TFixedMLP::element_t>> BrendanCUDA::AI::MLP::FixedMLP_GetElementSpan(_TFixedMLP* MLP) {
+    requires brendancuda::AI::MLP::IsFixedMLP<std::remove_const_t<_TFixedMLP>>
+__host__ __device__ brendancuda::Span<std::conditional_t<std::is_const_v<_TFixedMLP>, const typename _TFixedMLP::element_t, typename _TFixedMLP::element_t>> brendancuda::AI::MLP::FixedMLP_GetElementSpan(_TFixedMLP* MLP) {
     using element_t = std::conditional_t<std::is_const_v<_TFixedMLP>, const typename _TFixedMLP::element_t, typename _TFixedMLP::element_t>;
     return Span<element_t>((element_t*)MLP, sizeof(_TFixedMLP) / sizeof(element_t));
 }
 
-template <BrendanCUDA::AI::MLP::IsFixedMLPL _TFixedMLPL>
-void BrendanCUDA::AI::MLP::FixedMLPL_FillWith0(_TFixedMLPL* MLPL) {
+template <brendancuda::AI::MLP::IsFixedMLPL _TFixedMLPL>
+void brendancuda::AI::MLP::FixedMLPL_FillWith0(_TFixedMLPL* MLPL) {
     using element_t = typename _TFixedMLPL::element_t;
 
     Random::ClearArray<false, element_t>(FixedMLPL_GetElementSpan(MLPL));
 }
-template <BrendanCUDA::AI::MLP::IsFixedMLPL _TFixedMLPL, std::uniform_random_bit_generator _TRNG>
-void BrendanCUDA::AI::MLP::FixedMLPL_FillWithRandom(_TFixedMLPL* MLPL, _TRNG& RNG) {
+template <brendancuda::AI::MLP::IsFixedMLPL _TFixedMLPL, std::uniform_random_bit_generator _TRNG>
+void brendancuda::AI::MLP::FixedMLPL_FillWithRandom(_TFixedMLPL* MLPL, _TRNG& RNG) {
     using element_t = typename _TFixedMLPL::element_t;
 
     Random::InitRandomArray<false, element_t, _TRNG>(FixedMLPL_GetElementSpan(MLPL), RNG);
 }
-template <BrendanCUDA::AI::MLP::IsFixedMLPL _TFixedMLPL, std::uniform_random_bit_generator _TRNG>
-void BrendanCUDA::AI::MLP::FixedMLPL_ChangeWithRandom(_TFixedMLPL* MLPL, typename _TFixedMLPL::element_t Scalar, _TRNG& RNG) {
+template <brendancuda::AI::MLP::IsFixedMLPL _TFixedMLPL, std::uniform_random_bit_generator _TRNG>
+void brendancuda::AI::MLP::FixedMLPL_ChangeWithRandom(_TFixedMLPL* MLPL, typename _TFixedMLPL::element_t Scalar, _TRNG& RNG) {
     using element_t = typename _TFixedMLPL::element_t;
 
     Random::RandomizeArray<false, element_t, _TRNG>(FixedMLPL_GetElementSpan(MLPL), Scalar, RNG);
 }
-template <BrendanCUDA::AI::MLP::IsFixedMLPL _TFixedMLPL, std::uniform_random_bit_generator _TRNG>
-void BrendanCUDA::AI::MLP::FixedMLPL_ChangeWithRandom(_TFixedMLPL* MLPL, typename _TFixedMLPL::element_t Scalar, typename _TFixedMLPL::element_t LowerBound, typename _TFixedMLPL::element_t UpperBound, _TRNG& RNG) {
+template <brendancuda::AI::MLP::IsFixedMLPL _TFixedMLPL, std::uniform_random_bit_generator _TRNG>
+void brendancuda::AI::MLP::FixedMLPL_ChangeWithRandom(_TFixedMLPL* MLPL, typename _TFixedMLPL::element_t Scalar, typename _TFixedMLPL::element_t LowerBound, typename _TFixedMLPL::element_t UpperBound, _TRNG& RNG) {
     using element_t = typename _TFixedMLPL::element_t;
 
     Random::RandomizeArray<false, element_t, _TRNG>(FixedMLPL_GetElementSpan(MLPL), Scalar, LowerBound, UpperBound, RNG);
 }
 
-template <BrendanCUDA::AI::MLP::IsFixedMLP _TFixedMLP>
-void BrendanCUDA::AI::MLP::FixedMLP_FillWith0(_TFixedMLP* MLP) {
+template <brendancuda::AI::MLP::IsFixedMLP _TFixedMLP>
+void brendancuda::AI::MLP::FixedMLP_FillWith0(_TFixedMLP* MLP) {
     using element_t = typename _TFixedMLP::element_t;
 
     Random::ClearArray<false, element_t>(FixedMLP_GetElementSpan(MLP));
 }
-template <BrendanCUDA::AI::MLP::IsFixedMLP _TFixedMLP, std::uniform_random_bit_generator _TRNG>
-void BrendanCUDA::AI::MLP::FixedMLP_FillWithRandom(_TFixedMLP* MLP, _TRNG& RNG) {
+template <brendancuda::AI::MLP::IsFixedMLP _TFixedMLP, std::uniform_random_bit_generator _TRNG>
+void brendancuda::AI::MLP::FixedMLP_FillWithRandom(_TFixedMLP* MLP, _TRNG& RNG) {
     using element_t = typename _TFixedMLP::element_t;
 
     Random::InitRandomArray<false, element_t, _TRNG>(FixedMLP_GetElementSpan(MLP), RNG);
 }
-template <BrendanCUDA::AI::MLP::IsFixedMLP _TFixedMLP, std::uniform_random_bit_generator _TRNG>
-void BrendanCUDA::AI::MLP::FixedMLP_ChangeWithRandom(_TFixedMLP* MLP, typename _TFixedMLP::element_t Scalar, _TRNG& RNG) {
+template <brendancuda::AI::MLP::IsFixedMLP _TFixedMLP, std::uniform_random_bit_generator _TRNG>
+void brendancuda::AI::MLP::FixedMLP_ChangeWithRandom(_TFixedMLP* MLP, typename _TFixedMLP::element_t Scalar, _TRNG& RNG) {
     using element_t = typename _TFixedMLP::element_t;
 
     Random::RandomizeArray<false, element_t, _TRNG>(FixedMLP_GetElementSpan(MLP), Scalar, RNG);
 }
-template <BrendanCUDA::AI::MLP::IsFixedMLP _TFixedMLP, std::uniform_random_bit_generator _TRNG>
-void BrendanCUDA::AI::MLP::FixedMLP_ChangeWithRandom(_TFixedMLP* MLP, typename _TFixedMLP::element_t Scalar, typename _TFixedMLP::element_t LowerBound, typename _TFixedMLP::element_t UpperBound, _TRNG& RNG) {
+template <brendancuda::AI::MLP::IsFixedMLP _TFixedMLP, std::uniform_random_bit_generator _TRNG>
+void brendancuda::AI::MLP::FixedMLP_ChangeWithRandom(_TFixedMLP* MLP, typename _TFixedMLP::element_t Scalar, typename _TFixedMLP::element_t LowerBound, typename _TFixedMLP::element_t UpperBound, _TRNG& RNG) {
     using element_t = typename _TFixedMLP::element_t;
 
     Random::RandomizeArray<false, element_t, _TRNG>(FixedMLP_GetElementSpan(MLP), Scalar, LowerBound, UpperBound, RNG);

--- a/ai_mlp_fixedmlp.h
+++ b/ai_mlp_fixedmlp.h
@@ -13,30 +13,30 @@
 #include <type_traits>
 
 namespace brendancuda {
-    namespace AI {
+    namespace ai {
         namespace MLP {
             template <std::floating_point _T, activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
             struct FixedMLPL;
         }
     }
     namespace details {
-        template <size_t _Index, std::floating_point _T, AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _ContinuedOutputCounts>
+        template <size_t _Index, std::floating_point _T, ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _ContinuedOutputCounts>
         struct MLPLayerType;
-        template <size_t _Index, std::floating_point _T, AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+        template <size_t _Index, std::floating_point _T, ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
         struct MLPLayerType<_Index, _T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...> {
             using type = typename MLPLayerType<_Index - 1, _T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::type;
         };
-        template <std::floating_point _T, AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+        template <std::floating_point _T, ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
         struct MLPLayerType<0, _T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...> {
-            using type = AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _Output1Count>;
+            using type = ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _Output1Count>;
         };
-        template <size_t _Index, std::floating_point _T, AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+        template <size_t _Index, std::floating_point _T, ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
         struct MLPLayerType<_Index, _T, _ActivationFunction, _InputCount, _Output1Count> {
             static_assert(!_Index, "_Index is out of bounds.");
-            using type = AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _Output1Count>;
+            using type = ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _Output1Count>;
         };
 
-        template <size_t _Index, std::floating_point _T, AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _ContinuedOutputCounts>
+        template <size_t _Index, std::floating_point _T, ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _ContinuedOutputCounts>
         using mlpLayerType_t = MLPLayerType<_Index, _T, _ActivationFunction, _InputCount, _Output1Count, _ContinuedOutputCounts...>;
 
         template <uintmax_t _Idx, size_t... _Ints>
@@ -50,7 +50,7 @@ namespace brendancuda {
             static constexpr size_t value = getIntsByIndex<_Idx - 1, _ContinuedInts...>::value;
         };
     }
-    namespace AI {
+    namespace ai {
         namespace MLP {
             template <std::floating_point _T, activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
             struct FixedMLPL {
@@ -201,14 +201,14 @@ namespace brendancuda {
     namespace details {
         template <typename _T>
         struct isFixedMLPL : std::false_type { };
-        template <std::floating_point _T, AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
-        struct isFixedMLPL<AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>> : std::true_type { };
+        template <std::floating_point _T, ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+        struct isFixedMLPL<ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>> : std::true_type { };
         template <typename _T>
         struct isFixedMLP : std::false_type { };
-        template <std::floating_point _T, AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-        struct isFixedMLP<AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>> : std::true_type { };
+        template <std::floating_point _T, ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+        struct isFixedMLP<ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>> : std::true_type { };
     }
-    namespace AI {
+    namespace ai {
         namespace MLP {
             template <typename _T>
             concept IsFixedMLPL = details::isFixedMLPL<_T>::value;
@@ -217,10 +217,10 @@ namespace brendancuda {
         }
     }
     namespace details {
-        template <AI::MLP::IsFixedMLP _TFixedMLP>
+        template <ai::MLP::IsFixedMLP _TFixedMLP>
         void FixedMLP_Run(const _TFixedMLP* MLP, const typename _TFixedMLP::element_t* Inputs, typename _TFixedMLP::element_t* Intermediate0, typename _TFixedMLP::element_t* Intermediate1, typename _TFixedMLP::element_t* Outputs);
     }
-    namespace AI {
+    namespace ai {
         namespace MLP {
             template <typename _TFixedMLPL>
                 requires IsFixedMLPL<std::remove_const_t<_TFixedMLPL>>
@@ -255,8 +255,8 @@ namespace brendancuda {
     }
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
-__host__ __device__ void brendancuda::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::FillWith0() {
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+__host__ __device__ void brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::FillWith0() {
     for (size_t i = 0; i < _OutputCount; ++i) {
         for (size_t j = 0; j < _InputCount; ++j) {
             weights[i][j] = 0.;
@@ -265,9 +265,9 @@ __host__ __device__ void brendancuda::AI::MLP::FixedMLPL<_T, _ActivationFunction
     }
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::FillWithRandom(_TRNG& RNG) {
+__host__ void brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::FillWithRandom(_TRNG& RNG) {
     std::uniform_real_distribution<_T> dis(-1., 1.);
 
     for (size_t i = 0; i < _OutputCount; ++i) {
@@ -279,9 +279,9 @@ __host__ void brendancuda::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCou
 }
 
 #ifdef __CUDACC__
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::FillWithRandom(_TRNG& RNG) {
+__device__ void brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::FillWithRandom(_TRNG& RNG) {
     if constexpr (std::same_as<_T, float>) {
         for (size_t i = 0; i < _OutputCount; ++i) {
             for (size_t j = 0; j < _InputCount; ++j) {
@@ -301,9 +301,9 @@ __device__ void brendancuda::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputC
 }
 #endif
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
+__host__ void brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
     std::uniform_real_distribution<_T> dis(-Scalar, Scalar);
 
     for (size_t i = 0; i < _OutputCount; ++i) {
@@ -315,9 +315,9 @@ __host__ void brendancuda::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCou
 }
 
 #ifdef __CUDACC__
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
+__device__ void brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
     if constexpr (std::same_as<_T, float>) {
         for (size_t i = 0; i < _OutputCount; ++i) {
             for (size_t j = 0; j < _InputCount; ++j) {
@@ -337,9 +337,9 @@ __device__ void brendancuda::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputC
 }
 #endif
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__host__ void brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     std::uniform_real_distribution<_T> dis(-Scalar, Scalar);
 
     for (size_t i = 0; i < _OutputCount; ++i) {
@@ -353,9 +353,9 @@ __host__ void brendancuda::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCou
 }
 
 #ifdef __CUDACC__
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__device__ void brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     if constexpr (std::same_as<_T, float>) {
         for (size_t i = 0; i < _OutputCount; ++i) {
             for (size_t j = 0; j < _InputCount; ++j) {
@@ -379,8 +379,8 @@ __device__ void brendancuda::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputC
 }
 #endif
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
-__host__ __device__ void brendancuda::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::Run(const _T* Input, _T* Output) const {
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+__host__ __device__ void brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::Run(const _T* Input, _T* Output) const {
     if (Input == Output) {
         _T* secondOutput = new _T[_OutputCount];
         for (size_t j = 0; j < _OutputCount; ++j) {
@@ -403,139 +403,139 @@ __host__ __device__ void brendancuda::AI::MLP::FixedMLPL<_T, _ActivationFunction
     }
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
-size_t brendancuda::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::SerializedSize() const {
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+size_t brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::SerializedSize() const {
     return sizeof(this_t);
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
-void brendancuda::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::Serialize(void*& Data) const {
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+void brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::Serialize(void*& Data) const {
     BSerializer::SerializeArray(Data, weights, _InputCount * _OutputCount);
     BSerializer::SerializeArray(Data, bias, _OutputCount);
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
-auto brendancuda::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::Deserialize(const void*& Data) -> this_t {
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+auto brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::Deserialize(const void*& Data) -> this_t {
     uint8_t bytes[sizeof(this_t)];
     Deserialize(Data, &bytes);
     return *(this_t*)&bytes;
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
-void brendancuda::AI::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::Deserialize(const void*& Data, void* ObjMem) {
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+void brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::Deserialize(const void*& Data, void* ObjMem) {
     this_t& obj = &(this_t*)ObjMem;
     BSerializer::DeserializeArray(Data, obj.weights, _InputCount * _OutputCount);
     BSerializer::DeserializeArray(Data, obj.bias, _OutputCount);
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-__host__ __device__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::FillWith0() {
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+__host__ __device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::FillWith0() {
     layer.FillWith0();
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::FillWithRandom(_TRNG& RNG) {
+__host__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::FillWithRandom(_TRNG& RNG) {
     layer.FillWithRandom(RNG);
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
+__host__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
     layer.ChangeWithRandom(Scalar, RNG);
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__host__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     layer.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
 }
 
 #ifdef __CUDACC__
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::FillWithRandom(_TRNG& RNG) {
+__device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::FillWithRandom(_TRNG& RNG) {
     layer.FillWithRandom(RNG);
 }
 #endif
 
 #ifdef __CUDACC__
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
+__device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
     layer.ChangeWithRandom(Scalar, RNG);
 }
 #endif
 
 #ifdef __CUDACC__
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     layer.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
 }
 #endif
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-__host__ __device__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::FillWith0() {
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+__host__ __device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::FillWith0() {
     layer.FillWith0();
     nextLayers.FillWith0();
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::FillWithRandom(_TRNG& RNG) {
+__host__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::FillWithRandom(_TRNG& RNG) {
     layer.FillWithRandom(RNG);
     nextLayers.FillWithRandom(RNG);
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
+__host__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
     layer.ChangeWithRandom(Scalar, RNG);
     nextLayers.ChangeWithRandom(Scalar, RNG);
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__host__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     layer.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
     nextLayers.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
 }
 
 #ifdef __CUDACC__
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::FillWithRandom(_TRNG& RNG) {
+__device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::FillWithRandom(_TRNG& RNG) {
     layer.FillWithRandom(RNG);
     nextLayers.FillWithRandom(RNG);
 }
 #endif
 
 #ifdef __CUDACC__
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
+__device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::ChangeWithRandom(_T Scalar, _TRNG& RNG) {
     layer.ChangeWithRandom(Scalar, RNG);
     nextLayers.ChangeWithRandom(Scalar, RNG);
 }
 #endif
 
 #ifdef __CUDACC__
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     layer.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
     nextLayers.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
 }
 #endif
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-__host__ __device__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Run(const _T* Input, _T* Output) const {
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+__host__ __device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Run(const _T* Input, _T* Output) const {
     Run(Input, 0, 0, Output);
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-__host__ __device__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Run(const _T* Input, _T* Intermediate1, _T* Intermediate2, _T* Output) const {
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+__host__ __device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Run(const _T* Input, _T* Intermediate1, _T* Intermediate2, _T* Output) const {
     _T* i1 = Intermediate1 ? Intermediate1 : new _T[Intermediate0Count()];
     _T* i2 = Intermediate2 ? Intermediate2 : new _T[Intermediate1Count()];
 
@@ -546,9 +546,9 @@ __host__ __device__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction,
     if (!Intermediate2) delete[] i2;
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
 template <size_t _Index>
-__host__ __device__ brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::layerType_t<_Index>& brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Layer() {
+__host__ __device__ brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::layerType_t<_Index>& brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Layer() {
     if constexpr (_Index) {
         return nextLayers.Layer<_Index - 1>();
     }
@@ -557,133 +557,133 @@ __host__ __device__ brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _Inp
     }
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-__host__ __device__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Run(const _T* Input, _T* Output) const {
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+__host__ __device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Run(const _T* Input, _T* Output) const {
     layer.Run(Input, Output);
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-__host__ __device__ void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Run(const _T* Input, _T* Intermediate1, _T* Intermediate2, _T* Output) const {
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+__host__ __device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Run(const _T* Input, _T* Intermediate1, _T* Intermediate2, _T* Output) const {
     layer.Run(Input, Output);
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
 template <size_t _Index>
-__host__ __device__ brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::layerType_t<_Index>& brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Layer() {
+__host__ __device__ brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::layerType_t<_Index>& brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Layer() {
     static_assert(!_Index, "_Index is out of bounds.");
     return layer;
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-constexpr size_t brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::InputCount() {
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+constexpr size_t brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::InputCount() {
     return _InputCount;
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-constexpr size_t brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::InputCount() {
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+constexpr size_t brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::InputCount() {
     return _InputCount;
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-constexpr size_t brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::OutputCount() {
-    return brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::OutputCount();
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+constexpr size_t brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::OutputCount() {
+    return brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::OutputCount();
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-constexpr size_t brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::OutputCount() {
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+constexpr size_t brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::OutputCount() {
     return _Output1Count;
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-constexpr size_t brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Intermediate0Count() {
-    return std::max(_Output1Count, brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Intermediate1Count());
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+constexpr size_t brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Intermediate0Count() {
+    return std::max(_Output1Count, brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Intermediate1Count());
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-constexpr size_t brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Intermediate0Count() {
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+constexpr size_t brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Intermediate0Count() {
     return 0;
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-constexpr size_t brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Intermediate1Count() {
-    return brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Intermediate0Count();
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+constexpr size_t brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Intermediate1Count() {
+    return brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Intermediate0Count();
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-constexpr size_t brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Intermediate1Count() {
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+constexpr size_t brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Intermediate1Count() {
     return 0;
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-constexpr size_t brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::MaxLayerOutputCount() {
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+constexpr size_t brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::MaxLayerOutputCount() {
     constexpr size_t maxNextLayers = FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::MaxLayerOutputCount();
     return _Output1Count > maxNextLayers ? _Output1Count : maxNextLayers;
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-constexpr size_t brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::LayerCount() {
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+constexpr size_t brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::LayerCount() {
     return FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::LayerCount() + 1;
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-size_t brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::SerializedSize() const {
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+size_t brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::SerializedSize() const {
     return sizeof(this_t);
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Serialize(void*& Data) const {
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Serialize(void*& Data) const {
     layer.Serialize(Data);
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-auto brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Deserialize(const void*& Data) -> this_t {
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+auto brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Deserialize(const void*& Data) -> this_t {
     uint8_t bytes[sizeof(this_t)];
     Deserialize(Data, &bytes);
     return *(this_t*)&bytes;
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Deserialize(const void*& Data, void* ObjMem) {
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Deserialize(const void*& Data, void* ObjMem) {
     this_t& obj = &(this_t*)ObjMem;
     BSerializer::Deserialize(Data, &obj.layer);
     BSerializer::Deserialize(Data, &obj.nextLayers);
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-constexpr size_t brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::MaxLayerOutputCount() {
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+constexpr size_t brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::MaxLayerOutputCount() {
     return _Output1Count;
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-constexpr size_t brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::LayerCount() {
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+constexpr size_t brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::LayerCount() {
     return 1;
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-size_t brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::SerializedSize() const {
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+size_t brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::SerializedSize() const {
     return sizeof(this_t);
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Serialize(void*& Data) const {
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Serialize(void*& Data) const {
     layer.Serialize(Data);
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-auto brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Deserialize(const void*& Data) -> this_t {
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+auto brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Deserialize(const void*& Data) -> this_t {
     uint8_t bytes[sizeof(this_t)];
     Deserialize(Data, &bytes);
     return *(this_t*)&bytes;
 }
 
-template <std::floating_point _T, brendancuda::AI::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-void brendancuda::AI::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Deserialize(const void*& Data, void* ObjMem) {
+template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Deserialize(const void*& Data, void* ObjMem) {
     this_t& obj = &(this_t*)ObjMem;
     BSerializer::Deserialize(Data, &obj.layer);
 }
 
-template <brendancuda::AI::MLP::IsFixedMLPL _TFixedMLPL, bool _InputOnHost, bool _OutputOnHost>
-void brendancuda::AI::MLP::FixedMLPL_Run(const _TFixedMLPL* MLPL, const typename _TFixedMLPL::element_t* Inputs, typename _TFixedMLPL::element_t* Outputs) {
+template <brendancuda::ai::MLP::IsFixedMLPL _TFixedMLPL, bool _InputOnHost, bool _OutputOnHost>
+void brendancuda::ai::MLP::FixedMLPL_Run(const _TFixedMLPL* MLPL, const typename _TFixedMLPL::element_t* Inputs, typename _TFixedMLPL::element_t* Outputs) {
     using element_t = typename _TFixedMLPL::element_t;
     if constexpr (_InputOnHost) {
         if constexpr (_OutputOnHost) {
@@ -724,8 +724,8 @@ void brendancuda::AI::MLP::FixedMLPL_Run(const _TFixedMLPL* MLPL, const typename
     }
 }
 
-template <brendancuda::AI::MLP::IsFixedMLP _TFixedMLP, bool _InputOnHost, bool _OutputOnHost>
-void brendancuda::AI::MLP::FixedMLP_Run(const _TFixedMLP* MLP, const typename _TFixedMLP::element_t* Inputs, typename _TFixedMLP::element_t* Outputs) {
+template <brendancuda::ai::MLP::IsFixedMLP _TFixedMLP, bool _InputOnHost, bool _OutputOnHost>
+void brendancuda::ai::MLP::FixedMLP_Run(const _TFixedMLP* MLP, const typename _TFixedMLP::element_t* Inputs, typename _TFixedMLP::element_t* Outputs) {
     using element_t = typename _TFixedMLP::element_t;
     if constexpr (_InputOnHost) {
         if constexpr (_OutputOnHost) {
@@ -768,7 +768,7 @@ void brendancuda::AI::MLP::FixedMLP_Run(const _TFixedMLP* MLP, const typename _T
     }
 }
 
-template <brendancuda::AI::MLP::IsFixedMLP _TFixedMLP>
+template <brendancuda::ai::MLP::IsFixedMLP _TFixedMLP>
 void brendancuda::details::FixedMLP_Run(const _TFixedMLP* MLP, const typename _TFixedMLP::element_t* Inputs, typename _TFixedMLP::element_t* Intermediate0, typename _TFixedMLP::element_t* Intermediate1, typename _TFixedMLP::element_t* Outputs) {
     using element_t = typename _TFixedMLP::element_t;
 
@@ -776,69 +776,69 @@ void brendancuda::details::FixedMLP_Run(const _TFixedMLP* MLP, const typename _T
         FixedMLPL_Run<decltype(MLP->layer), false, false>(&MLP->layer, Inputs, Outputs);
     }
     else {
-        AI::MLP::FixedMLPL_Run<decltype(MLP->layer), false, false>(&MLP->layer, Inputs, Intermediate0);
+        ai::MLP::FixedMLPL_Run<decltype(MLP->layer), false, false>(&MLP->layer, Inputs, Intermediate0);
         FixedMLP_Run(&MLP->nextLayers, Intermediate0, Intermediate1, Intermediate0, Outputs);
     }
 }
 
 template <typename _TFixedMLPL>
-    requires brendancuda::AI::MLP::IsFixedMLPL<std::remove_const_t<_TFixedMLPL>>
-__host__ __device__ brendancuda::Span<std::conditional_t<std::is_const_v<_TFixedMLPL>, const typename _TFixedMLPL::element_t, typename _TFixedMLPL::element_t>> brendancuda::AI::MLP::FixedMLPL_GetElementSpan(_TFixedMLPL* MLPL) {
+    requires brendancuda::ai::MLP::IsFixedMLPL<std::remove_const_t<_TFixedMLPL>>
+__host__ __device__ brendancuda::Span<std::conditional_t<std::is_const_v<_TFixedMLPL>, const typename _TFixedMLPL::element_t, typename _TFixedMLPL::element_t>> brendancuda::ai::MLP::FixedMLPL_GetElementSpan(_TFixedMLPL* MLPL) {
     using element_t = std::conditional_t<std::is_const_v<_TFixedMLPL>, const typename _TFixedMLPL::element_t, typename _TFixedMLPL::element_t>;
     return Span<element_t>((element_t*)MLPL, sizeof(_TFixedMLPL) / sizeof(element_t));
 }
 template <typename _TFixedMLP>
-    requires brendancuda::AI::MLP::IsFixedMLP<std::remove_const_t<_TFixedMLP>>
-__host__ __device__ brendancuda::Span<std::conditional_t<std::is_const_v<_TFixedMLP>, const typename _TFixedMLP::element_t, typename _TFixedMLP::element_t>> brendancuda::AI::MLP::FixedMLP_GetElementSpan(_TFixedMLP* MLP) {
+    requires brendancuda::ai::MLP::IsFixedMLP<std::remove_const_t<_TFixedMLP>>
+__host__ __device__ brendancuda::Span<std::conditional_t<std::is_const_v<_TFixedMLP>, const typename _TFixedMLP::element_t, typename _TFixedMLP::element_t>> brendancuda::ai::MLP::FixedMLP_GetElementSpan(_TFixedMLP* MLP) {
     using element_t = std::conditional_t<std::is_const_v<_TFixedMLP>, const typename _TFixedMLP::element_t, typename _TFixedMLP::element_t>;
     return Span<element_t>((element_t*)MLP, sizeof(_TFixedMLP) / sizeof(element_t));
 }
 
-template <brendancuda::AI::MLP::IsFixedMLPL _TFixedMLPL>
-void brendancuda::AI::MLP::FixedMLPL_FillWith0(_TFixedMLPL* MLPL) {
+template <brendancuda::ai::MLP::IsFixedMLPL _TFixedMLPL>
+void brendancuda::ai::MLP::FixedMLPL_FillWith0(_TFixedMLPL* MLPL) {
     using element_t = typename _TFixedMLPL::element_t;
 
     Random::ClearArray<false, element_t>(FixedMLPL_GetElementSpan(MLPL));
 }
-template <brendancuda::AI::MLP::IsFixedMLPL _TFixedMLPL, std::uniform_random_bit_generator _TRNG>
-void brendancuda::AI::MLP::FixedMLPL_FillWithRandom(_TFixedMLPL* MLPL, _TRNG& RNG) {
+template <brendancuda::ai::MLP::IsFixedMLPL _TFixedMLPL, std::uniform_random_bit_generator _TRNG>
+void brendancuda::ai::MLP::FixedMLPL_FillWithRandom(_TFixedMLPL* MLPL, _TRNG& RNG) {
     using element_t = typename _TFixedMLPL::element_t;
 
     Random::InitRandomArray<false, element_t, _TRNG>(FixedMLPL_GetElementSpan(MLPL), RNG);
 }
-template <brendancuda::AI::MLP::IsFixedMLPL _TFixedMLPL, std::uniform_random_bit_generator _TRNG>
-void brendancuda::AI::MLP::FixedMLPL_ChangeWithRandom(_TFixedMLPL* MLPL, typename _TFixedMLPL::element_t Scalar, _TRNG& RNG) {
+template <brendancuda::ai::MLP::IsFixedMLPL _TFixedMLPL, std::uniform_random_bit_generator _TRNG>
+void brendancuda::ai::MLP::FixedMLPL_ChangeWithRandom(_TFixedMLPL* MLPL, typename _TFixedMLPL::element_t Scalar, _TRNG& RNG) {
     using element_t = typename _TFixedMLPL::element_t;
 
     Random::RandomizeArray<false, element_t, _TRNG>(FixedMLPL_GetElementSpan(MLPL), Scalar, RNG);
 }
-template <brendancuda::AI::MLP::IsFixedMLPL _TFixedMLPL, std::uniform_random_bit_generator _TRNG>
-void brendancuda::AI::MLP::FixedMLPL_ChangeWithRandom(_TFixedMLPL* MLPL, typename _TFixedMLPL::element_t Scalar, typename _TFixedMLPL::element_t LowerBound, typename _TFixedMLPL::element_t UpperBound, _TRNG& RNG) {
+template <brendancuda::ai::MLP::IsFixedMLPL _TFixedMLPL, std::uniform_random_bit_generator _TRNG>
+void brendancuda::ai::MLP::FixedMLPL_ChangeWithRandom(_TFixedMLPL* MLPL, typename _TFixedMLPL::element_t Scalar, typename _TFixedMLPL::element_t LowerBound, typename _TFixedMLPL::element_t UpperBound, _TRNG& RNG) {
     using element_t = typename _TFixedMLPL::element_t;
 
     Random::RandomizeArray<false, element_t, _TRNG>(FixedMLPL_GetElementSpan(MLPL), Scalar, LowerBound, UpperBound, RNG);
 }
 
-template <brendancuda::AI::MLP::IsFixedMLP _TFixedMLP>
-void brendancuda::AI::MLP::FixedMLP_FillWith0(_TFixedMLP* MLP) {
+template <brendancuda::ai::MLP::IsFixedMLP _TFixedMLP>
+void brendancuda::ai::MLP::FixedMLP_FillWith0(_TFixedMLP* MLP) {
     using element_t = typename _TFixedMLP::element_t;
 
     Random::ClearArray<false, element_t>(FixedMLP_GetElementSpan(MLP));
 }
-template <brendancuda::AI::MLP::IsFixedMLP _TFixedMLP, std::uniform_random_bit_generator _TRNG>
-void brendancuda::AI::MLP::FixedMLP_FillWithRandom(_TFixedMLP* MLP, _TRNG& RNG) {
+template <brendancuda::ai::MLP::IsFixedMLP _TFixedMLP, std::uniform_random_bit_generator _TRNG>
+void brendancuda::ai::MLP::FixedMLP_FillWithRandom(_TFixedMLP* MLP, _TRNG& RNG) {
     using element_t = typename _TFixedMLP::element_t;
 
     Random::InitRandomArray<false, element_t, _TRNG>(FixedMLP_GetElementSpan(MLP), RNG);
 }
-template <brendancuda::AI::MLP::IsFixedMLP _TFixedMLP, std::uniform_random_bit_generator _TRNG>
-void brendancuda::AI::MLP::FixedMLP_ChangeWithRandom(_TFixedMLP* MLP, typename _TFixedMLP::element_t Scalar, _TRNG& RNG) {
+template <brendancuda::ai::MLP::IsFixedMLP _TFixedMLP, std::uniform_random_bit_generator _TRNG>
+void brendancuda::ai::MLP::FixedMLP_ChangeWithRandom(_TFixedMLP* MLP, typename _TFixedMLP::element_t Scalar, _TRNG& RNG) {
     using element_t = typename _TFixedMLP::element_t;
 
     Random::RandomizeArray<false, element_t, _TRNG>(FixedMLP_GetElementSpan(MLP), Scalar, RNG);
 }
-template <brendancuda::AI::MLP::IsFixedMLP _TFixedMLP, std::uniform_random_bit_generator _TRNG>
-void brendancuda::AI::MLP::FixedMLP_ChangeWithRandom(_TFixedMLP* MLP, typename _TFixedMLP::element_t Scalar, typename _TFixedMLP::element_t LowerBound, typename _TFixedMLP::element_t UpperBound, _TRNG& RNG) {
+template <brendancuda::ai::MLP::IsFixedMLP _TFixedMLP, std::uniform_random_bit_generator _TRNG>
+void brendancuda::ai::MLP::FixedMLP_ChangeWithRandom(_TFixedMLP* MLP, typename _TFixedMLP::element_t Scalar, typename _TFixedMLP::element_t LowerBound, typename _TFixedMLP::element_t UpperBound, _TRNG& RNG) {
     using element_t = typename _TFixedMLP::element_t;
 
     Random::RandomizeArray<false, element_t, _TRNG>(FixedMLP_GetElementSpan(MLP), Scalar, LowerBound, UpperBound, RNG);

--- a/ai_mlp_fixedmlp.h
+++ b/ai_mlp_fixedmlp.h
@@ -86,7 +86,7 @@ namespace brendancuda {
                 template <KernelCurandState _TRNG>
                 __device__ void ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG);
 #endif
-                __host__ __device__ void Run(const _T* Input, _T* Output) const;
+                __host__ __device__ void Run(const _T* Input, _T* output) const;
 
                 size_t SerializedSize() const;
                 void Serialize(void*& Data) const;
@@ -129,8 +129,8 @@ namespace brendancuda {
                 template <KernelCurandState _TRNG>
                 __device__ void ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG);
 #endif
-                __host__ __device__ void Run(const _T* Input, _T* Output) const;
-                __host__ __device__ void Run(const _T* Input, _T* Intermediate1, _T* Intermediate2, _T* Output) const;
+                __host__ __device__ void Run(const _T* Input, _T* output) const;
+                __host__ __device__ void Run(const _T* Input, _T* Intermediate1, _T* Intermediate2, _T* output) const;
                 template <size_t _Index>
                 __host__ __device__ layerType_t<_Index>& Layer();
 
@@ -179,8 +179,8 @@ namespace brendancuda {
                 template <KernelCurandState _TRNG>
                 __device__ void ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG);
 #endif
-                __host__ __device__ void Run(const _T* Input, _T* Output) const;
-                __host__ __device__ void Run(const _T* Input, _T* Intermediate1, _T* Intermediate2, _T* Output) const;
+                __host__ __device__ void Run(const _T* Input, _T* output) const;
+                __host__ __device__ void Run(const _T* Input, _T* Intermediate1, _T* Intermediate2, _T* output) const;
                 template <size_t _Index>
                 __host__ __device__ layerType_t<_Index>& Layer();
 
@@ -380,8 +380,8 @@ __device__ void brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputC
 #endif
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
-__host__ __device__ void brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::Run(const _T* Input, _T* Output) const {
-    if (Input == Output) {
+__host__ __device__ void brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>::Run(const _T* Input, _T* output) const {
+    if (Input == output) {
         _T* secondOutput = new _T[_OutputCount];
         for (size_t j = 0; j < _OutputCount; ++j) {
             float v = bias[j];
@@ -390,7 +390,7 @@ __host__ __device__ void brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction
             }
             secondOutput[j] = _ActivationFunction(v);
         }
-        memcpy(Output, secondOutput, sizeof(_T) * _OutputCount);
+        memcpy(output, secondOutput, sizeof(_T) * _OutputCount);
     }
     else {
         for (size_t j = 0; j < _OutputCount; ++j) {
@@ -398,7 +398,7 @@ __host__ __device__ void brendancuda::ai::MLP::FixedMLPL<_T, _ActivationFunction
             for (size_t i = 0; i < _InputCount; ++i) {
                 v += weights[i][j] * Input[i];
             }
-            Output[j] = _ActivationFunction(v);
+            output[j] = _ActivationFunction(v);
         }
     }
 }
@@ -530,17 +530,17 @@ __device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCo
 #endif
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-__host__ __device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Run(const _T* Input, _T* Output) const {
-    Run(Input, 0, 0, Output);
+__host__ __device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Run(const _T* Input, _T* output) const {
+    Run(Input, 0, 0, output);
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
-__host__ __device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Run(const _T* Input, _T* Intermediate1, _T* Intermediate2, _T* Output) const {
+__host__ __device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Run(const _T* Input, _T* Intermediate1, _T* Intermediate2, _T* output) const {
     _T* i1 = Intermediate1 ? Intermediate1 : new _T[Intermediate0Count()];
     _T* i2 = Intermediate2 ? Intermediate2 : new _T[Intermediate1Count()];
 
     layer.Run(Input, i1);
-    nextLayers.Run(i1, i2, i1, Output);
+    nextLayers.Run(i1, i2, i1, output);
 
     if (!Intermediate1) delete[] i1;
     if (!Intermediate2) delete[] i2;
@@ -558,13 +558,13 @@ __host__ __device__ brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _Inp
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-__host__ __device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Run(const _T* Input, _T* Output) const {
-    layer.Run(Input, Output);
+__host__ __device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Run(const _T* Input, _T* output) const {
+    layer.Run(Input, output);
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
-__host__ __device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Run(const _T* Input, _T* Intermediate1, _T* Intermediate2, _T* Output) const {
-    layer.Run(Input, Output);
+__host__ __device__ void brendancuda::ai::MLP::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Run(const _T* Input, _T* Intermediate1, _T* Intermediate2, _T* output) const {
+    layer.Run(Input, output);
 }
 
 template <std::floating_point _T, brendancuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>

--- a/ai_mlpb_fixedmlpb.h
+++ b/ai_mlpb_fixedmlpb.h
@@ -12,7 +12,7 @@
 #include <type_traits>
 
 namespace brendancuda {
-    namespace AI {
+    namespace ai {
         namespace MLPB {
             template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
             struct FixedMLPBL;
@@ -27,12 +27,12 @@ namespace brendancuda {
         };
         template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
         struct MLPBLayerType<0, _TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...> {
-            using type = AI::MLPB::FixedMLPBL<_TInput, _TOutput1>;
+            using type = ai::MLPB::FixedMLPBL<_TInput, _TOutput1>;
         };
         template <size_t _Index, std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
         struct MLPBLayerType<_Index, _TInput, _TOutput1> {
             static_assert(!_Index, "_Index is out of bounds.");
-            using type = AI::MLPB::FixedMLPBL<_TInput, _TOutput1>;
+            using type = ai::MLPB::FixedMLPBL<_TInput, _TOutput1>;
         };
 
         template <size_t _Index, std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral... _TsContinuedOutputs>
@@ -41,7 +41,7 @@ namespace brendancuda {
         template <std::integral _T>
         constexpr size_t BitCount = sizeof(_T) << 3;
     }
-    namespace AI {
+    namespace ai {
         namespace MLPB {
             template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
             struct FixedMLPBL {
@@ -192,7 +192,7 @@ namespace brendancuda {
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-__host__ __device__ void brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::FillWith0() {
+__host__ __device__ void brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>::FillWith0() {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i) {
         weights[i] = (_TInput)0;
     }
@@ -201,7 +201,7 @@ __host__ __device__ void brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::F
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::FillWithRandom(_TRNG& RNG) {
+__host__ void brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>::FillWithRandom(_TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i) {
         weights[i] = details::GetIntBin<_TInput>(RNG);
     }
@@ -211,7 +211,7 @@ __host__ void brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::FillWithRand
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::FillWithRandom(_TRNG& RNG) {
+__device__ void brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>::FillWithRandom(_TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i) {
         weights[i] = details::GetIntBin<_TInput>(RNG);
     }
@@ -221,7 +221,7 @@ __device__ void brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::FillWithRa
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
         weights[i] = brendancuda::Random::RandomizeWFlips(weights[i], WeightsFlipProb, RNG);
     bias = brendancuda::Random::RandomizeWFlips(bias, BiasFlipProb, RNG);
@@ -230,7 +230,7 @@ __host__ __forceinline void brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__device__ __forceinline void brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
         weights[i] = brendancuda::Random::RandomizeWFlips(weights[i], WeightsFlipProb, RNG);
     bias = brendancuda::Random::RandomizeWFlips(bias, BiasFlipProb, RNG);
@@ -239,7 +239,7 @@ __device__ __forceinline void brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutpu
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
         weights[i] = brendancuda::Random::RandomizeWTargets(weights[i], WeightsFlipProb, RNG);
     bias = brendancuda::Random::RandomizeWTargets(bias, BiasFlipProb, RNG);
@@ -248,7 +248,7 @@ __host__ __forceinline void brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__device__ __forceinline void brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
         weights[i] = brendancuda::Random::RandomizeWTargets(weights[i], WeightsFlipProb, RNG);
     bias = brendancuda::Random::RandomizeWTargets(bias, BiasFlipProb, RNG);
@@ -257,7 +257,7 @@ __device__ __forceinline void brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutpu
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
         weights[i] = brendancuda::Random::RandomizeWMutations(weights[i], WeightsProbOf1, RNG);
     bias = brendancuda::Random::RandomizeWMutations(bias, BiasProbOf1, RNG);
@@ -266,7 +266,7 @@ __host__ __forceinline void brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
+__device__ __forceinline void brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
         weights[i] = brendancuda::Random::RandomizeWMutations(weights[i], WeightsProbOf1, RNG);
     bias = brendancuda::Random::RandomizeWMutations(bias, BiasProbOf1, RNG);
@@ -274,7 +274,7 @@ __device__ __forceinline void brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutpu
 #endif
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-__host__ __device__ _TOutput brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::Run(_TInput Input) const {
+__host__ __device__ _TOutput brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>::Run(_TInput Input) const {
     _TOutput o = bias;
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i) {
         if (Input & weights[i]) o |= ((_TOutput)1) << i;
@@ -283,116 +283,116 @@ __host__ __device__ _TOutput brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-__host__ __device__ uint64_t brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::RunG(uint64_t Input) const {
+__host__ __device__ uint64_t brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>::RunG(uint64_t Input) const {
     return (uint64_t)Run((_TInput)Input);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-size_t brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::SerializedSize() const {
+size_t brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>::SerializedSize() const {
     return sizeof(this_t);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-void brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::Serialize(void*& Data) const {
+void brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>::Serialize(void*& Data) const {
     BSerializer::SerializeArray(Data, weights, details::BitCount<_TOutput>);
     BSerializer::Serialize(Data, bias);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput> brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::Deserialize(const void*& Data) {
+brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput> brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>::Deserialize(const void*& Data) {
     uint8_t bytes[sizeof(this_t)];
     Deserialize(Data, &bytes);
     return *(this_t*)&bytes;
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-void brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::Deserialize(const void*& Data, void* ObjMem) {
+void brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>::Deserialize(const void*& Data, void* ObjMem) {
     this_t& obj = *(this_t*)ObjMem;
     BSerializer::DeserializeArray(Data, obj.weights, details::BitCount<_TOutput>);
     BSerializer::Deserialize(Data, &obj.bias);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-__host__ __device__ void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::FillWith0() {
+__host__ __device__ void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::FillWith0() {
     layer.FillWith0();
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::FillWithRandom(_TRNG& RNG) {
+__host__ void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::FillWithRandom(_TRNG& RNG) {
     layer.FillWithRandom(RNG);
 }
 
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::FillWithRandom(_TRNG& RNG) {
+__device__ void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::FillWithRandom(_TRNG& RNG) {
     layer.FillWithRandom(RNG);
 }
 #endif
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     layer.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
 }
 
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__device__ __forceinline void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     layer.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
 }
 #endif
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     layer.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
 }
 
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__device__ __forceinline void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     layer.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
 }
 #endif
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
     layer.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
 }
 
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
+__device__ __forceinline void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
     layer.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
 }
 #endif
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-__host__ __device__ auto brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::Run(_TInput Input) const -> output_t {
+__host__ __device__ auto brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::Run(_TInput Input) const -> output_t {
     return (output_t)RunG((uint64_t)Input);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-__host__ __device__ uint64_t brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::RunG(uint64_t Input) const {
+__host__ __device__ uint64_t brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::RunG(uint64_t Input) const {
     Input = layer.RunG(Input);
     return Input;
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-__host__ __device__ void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::FillWith0() {
+__host__ __device__ void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::FillWith0() {
     layer.FillWith0();
     nextLayers.FillWith0();
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::FillWithRandom(_TRNG& RNG) {
+__host__ void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::FillWithRandom(_TRNG& RNG) {
     layer.FillWithRandom(RNG);
     nextLayers.FillWithRandom(RNG);
 }
@@ -400,7 +400,7 @@ __host__ void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _T
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::FillWithRandom(_TRNG& RNG) {
+__device__ void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::FillWithRandom(_TRNG& RNG) {
     layer.FillWithRandom(RNG);
     nextLayers.FillWithRandom(RNG);
 }
@@ -408,7 +408,7 @@ __device__ void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, 
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     layer.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
     nextLayers.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
 }
@@ -416,7 +416,7 @@ __host__ __forceinline void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1,
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__device__ __forceinline void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     layer.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
     nextLayers.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
 }
@@ -424,7 +424,7 @@ __device__ __forceinline void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     layer.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
     nextLayers.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
 }
@@ -432,7 +432,7 @@ __host__ __forceinline void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1,
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__device__ __forceinline void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     layer.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
     nextLayers.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
 }
@@ -440,7 +440,7 @@ __device__ __forceinline void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
     layer.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
     nextLayers.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
 }
@@ -448,19 +448,19 @@ __host__ __forceinline void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1,
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
+__device__ __forceinline void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
     layer.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
     nextLayers.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
 }
 #endif
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-__host__ __device__ auto brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Run(_TInput Input) const -> output_t {
+__host__ __device__ auto brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Run(_TInput Input) const -> output_t {
     return (output_t)RunG((uint64_t)Input);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-__host__ __device__ uint64_t brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RunG(uint64_t Input) const {
+__host__ __device__ uint64_t brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RunG(uint64_t Input) const {
     Input = layer.RunG(Input);
     Input = nextLayers.RunG(Input);
     return Input;
@@ -468,7 +468,7 @@ __host__ __device__ uint64_t brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
 template <size_t _Index>
-__host__ __device__ brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::layerType_t<_Index>& brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Layer() {
+__host__ __device__ brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::layerType_t<_Index>& brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Layer() {
     if constexpr (_Index) {
         return nextLayers.Layer<_Index - 1>();
     }
@@ -479,65 +479,65 @@ __host__ __device__ brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutpu
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
 template <size_t _Index>
-__host__ __device__ brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::layerType_t<_Index>& brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::Layer() {
+__host__ __device__ brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::layerType_t<_Index>& brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::Layer() {
     static_assert(!_Index, "_Index is out of bounds.");
     return layer;
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-constexpr size_t brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::LayerCount() {
+constexpr size_t brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::LayerCount() {
     return FixedMLPB<_TOutput1, _TOutput2, _TsContinuedOutputs...>::LayerCount() + 1;
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-size_t brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::SerializedSize() const {
+size_t brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::SerializedSize() const {
     return sizeof(this_t);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Serialize(void*& Data) const {
+void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Serialize(void*& Data) const {
     layer.Serialize(Data);
     nextLayers.Serialize(Data);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...> brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Deserialize(const void*& Data) {
+brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...> brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Deserialize(const void*& Data) {
     uint8_t bytes[sizeof(this_t)];
     Deserialize(Data, &bytes);
     return *(this_t*)&bytes;
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Deserialize(const void*& Data, void* ObjMem) {
+void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Deserialize(const void*& Data, void* ObjMem) {
     this_t& obj = &(this_t*)ObjMem;
     BSerializer::Deserialize(Data, &obj.layer);
     BSerializer::Deserialize(Data, &obj.nextLayers);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-constexpr size_t brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::LayerCount() {
+constexpr size_t brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::LayerCount() {
     return 1;
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-size_t brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::SerializedSize() const {
+size_t brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::SerializedSize() const {
     return sizeof(this_t);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::Serialize(void*& Data) const {
+void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::Serialize(void*& Data) const {
     layer.Serialize(Data);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1> brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::Deserialize(const void*& Data) {
+brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1> brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::Deserialize(const void*& Data) {
     uint8_t bytes[sizeof(this_t)];
     Deserialize(Data, &bytes);
     return *(this_t*)&bytes;
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::Deserialize(const void*& Data, void* ObjMem) {
+void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::Deserialize(const void*& Data, void* ObjMem) {
     this_t& obj = &(this_t*)ObjMem;
     BSerializer::Deserialize(Data, &obj.layer);
 }

--- a/ai_mlpb_fixedmlpb.h
+++ b/ai_mlpb_fixedmlpb.h
@@ -11,7 +11,7 @@
 #include <random>
 #include <type_traits>
 
-namespace brendancuda {
+namespace bcuda {
     namespace ai {
         namespace mlpb {
             template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
@@ -192,7 +192,7 @@ namespace brendancuda {
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-__host__ __device__ void brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::FillWith0() {
+__host__ __device__ void bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::FillWith0() {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i) {
         weights[i] = (_TInput)0;
     }
@@ -201,7 +201,7 @@ __host__ __device__ void brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::F
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::FillWithRandom(_TRNG& RNG) {
+__host__ void bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::FillWithRandom(_TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i) {
         weights[i] = details::GetIntBin<_TInput>(RNG);
     }
@@ -210,8 +210,8 @@ __host__ void brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::FillWithRand
 
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::FillWithRandom(_TRNG& RNG) {
+template <bcuda::KernelCurandState _TRNG>
+__device__ void bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::FillWithRandom(_TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i) {
         weights[i] = details::GetIntBin<_TInput>(RNG);
     }
@@ -221,60 +221,60 @@ __device__ void brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::FillWithRa
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__host__ __forceinline void bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
-        weights[i] = brendancuda::random::RandomizeWFlips(weights[i], WeightsFlipProb, RNG);
-    bias = brendancuda::random::RandomizeWFlips(bias, BiasFlipProb, RNG);
+        weights[i] = bcuda::random::RandomizeWFlips(weights[i], WeightsFlipProb, RNG);
+    bias = bcuda::random::RandomizeWFlips(bias, BiasFlipProb, RNG);
 }
 
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+template <bcuda::KernelCurandState _TRNG>
+__device__ __forceinline void bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
-        weights[i] = brendancuda::random::RandomizeWFlips(weights[i], WeightsFlipProb, RNG);
-    bias = brendancuda::random::RandomizeWFlips(bias, BiasFlipProb, RNG);
+        weights[i] = bcuda::random::RandomizeWFlips(weights[i], WeightsFlipProb, RNG);
+    bias = bcuda::random::RandomizeWFlips(bias, BiasFlipProb, RNG);
 }
 #endif
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__host__ __forceinline void bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
-        weights[i] = brendancuda::random::RandomizeWTargets(weights[i], WeightsFlipProb, RNG);
-    bias = brendancuda::random::RandomizeWTargets(bias, BiasFlipProb, RNG);
+        weights[i] = bcuda::random::RandomizeWTargets(weights[i], WeightsFlipProb, RNG);
+    bias = bcuda::random::RandomizeWTargets(bias, BiasFlipProb, RNG);
 }
 
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+template <bcuda::KernelCurandState _TRNG>
+__device__ __forceinline void bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
-        weights[i] = brendancuda::random::RandomizeWTargets(weights[i], WeightsFlipProb, RNG);
-    bias = brendancuda::random::RandomizeWTargets(bias, BiasFlipProb, RNG);
+        weights[i] = bcuda::random::RandomizeWTargets(weights[i], WeightsFlipProb, RNG);
+    bias = bcuda::random::RandomizeWTargets(bias, BiasFlipProb, RNG);
 }
 #endif
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
+__host__ __forceinline void bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
-        weights[i] = brendancuda::random::RandomizeWMutations(weights[i], WeightsProbOf1, RNG);
-    bias = brendancuda::random::RandomizeWMutations(bias, BiasProbOf1, RNG);
+        weights[i] = bcuda::random::RandomizeWMutations(weights[i], WeightsProbOf1, RNG);
+    bias = bcuda::random::RandomizeWMutations(bias, BiasProbOf1, RNG);
 }
 
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
+template <bcuda::KernelCurandState _TRNG>
+__device__ __forceinline void bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
-        weights[i] = brendancuda::random::RandomizeWMutations(weights[i], WeightsProbOf1, RNG);
-    bias = brendancuda::random::RandomizeWMutations(bias, BiasProbOf1, RNG);
+        weights[i] = bcuda::random::RandomizeWMutations(weights[i], WeightsProbOf1, RNG);
+    bias = bcuda::random::RandomizeWMutations(bias, BiasProbOf1, RNG);
 }
 #endif
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-__host__ __device__ _TOutput brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::Run(_TInput Input) const {
+__host__ __device__ _TOutput bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::Run(_TInput Input) const {
     _TOutput o = bias;
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i) {
         if (Input & weights[i]) o |= ((_TOutput)1) << i;
@@ -283,124 +283,124 @@ __host__ __device__ _TOutput brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-__host__ __device__ uint64_t brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RunG(uint64_t Input) const {
+__host__ __device__ uint64_t bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RunG(uint64_t Input) const {
     return (uint64_t)Run((_TInput)Input);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-size_t brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::SerializedSize() const {
+size_t bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::SerializedSize() const {
     return sizeof(this_t);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-void brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::Serialize(void*& Data) const {
+void bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::Serialize(void*& Data) const {
     BSerializer::SerializeArray(Data, weights, details::BitCount<_TOutput>);
     BSerializer::Serialize(Data, bias);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput> brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::Deserialize(const void*& Data) {
+bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput> bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::Deserialize(const void*& Data) {
     uint8_t bytes[sizeof(this_t)];
     Deserialize(Data, &bytes);
     return *(this_t*)&bytes;
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-void brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::Deserialize(const void*& Data, void* ObjMem) {
+void bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::Deserialize(const void*& Data, void* ObjMem) {
     this_t& obj = *(this_t*)ObjMem;
     BSerializer::DeserializeArray(Data, obj.weights, details::BitCount<_TOutput>);
     BSerializer::Deserialize(Data, &obj.bias);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-__host__ __device__ void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::FillWith0() {
+__host__ __device__ void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::FillWith0() {
     layer.FillWith0();
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::FillWithRandom(_TRNG& RNG) {
+__host__ void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::FillWithRandom(_TRNG& RNG) {
     layer.FillWithRandom(RNG);
 }
 
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::FillWithRandom(_TRNG& RNG) {
+template <bcuda::KernelCurandState _TRNG>
+__device__ void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::FillWithRandom(_TRNG& RNG) {
     layer.FillWithRandom(RNG);
 }
 #endif
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__host__ __forceinline void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     layer.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
 }
 
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+template <bcuda::KernelCurandState _TRNG>
+__device__ __forceinline void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     layer.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
 }
 #endif
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__host__ __forceinline void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     layer.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
 }
 
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+template <bcuda::KernelCurandState _TRNG>
+__device__ __forceinline void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     layer.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
 }
 #endif
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
+__host__ __forceinline void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
     layer.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
 }
 
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
+template <bcuda::KernelCurandState _TRNG>
+__device__ __forceinline void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
     layer.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
 }
 #endif
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-__host__ __device__ auto brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::Run(_TInput Input) const -> output_t {
+__host__ __device__ auto bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::Run(_TInput Input) const -> output_t {
     return (output_t)RunG((uint64_t)Input);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-__host__ __device__ uint64_t brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::RunG(uint64_t Input) const {
+__host__ __device__ uint64_t bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::RunG(uint64_t Input) const {
     Input = layer.RunG(Input);
     return Input;
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-__host__ __device__ void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::FillWith0() {
+__host__ __device__ void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::FillWith0() {
     layer.FillWith0();
     nextLayers.FillWith0();
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::FillWithRandom(_TRNG& RNG) {
+__host__ void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::FillWithRandom(_TRNG& RNG) {
     layer.FillWithRandom(RNG);
     nextLayers.FillWithRandom(RNG);
 }
 
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::FillWithRandom(_TRNG& RNG) {
+template <bcuda::KernelCurandState _TRNG>
+__device__ void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::FillWithRandom(_TRNG& RNG) {
     layer.FillWithRandom(RNG);
     nextLayers.FillWithRandom(RNG);
 }
@@ -408,15 +408,15 @@ __device__ void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, 
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__host__ __forceinline void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     layer.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
     nextLayers.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
 }
 
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+template <bcuda::KernelCurandState _TRNG>
+__device__ __forceinline void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     layer.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
     nextLayers.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
 }
@@ -424,15 +424,15 @@ __device__ __forceinline void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__host__ __forceinline void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     layer.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
     nextLayers.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
 }
 
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+template <bcuda::KernelCurandState _TRNG>
+__device__ __forceinline void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     layer.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
     nextLayers.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
 }
@@ -440,27 +440,27 @@ __device__ __forceinline void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
+__host__ __forceinline void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
     layer.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
     nextLayers.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
 }
 
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
+template <bcuda::KernelCurandState _TRNG>
+__device__ __forceinline void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
     layer.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
     nextLayers.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
 }
 #endif
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-__host__ __device__ auto brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Run(_TInput Input) const -> output_t {
+__host__ __device__ auto bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Run(_TInput Input) const -> output_t {
     return (output_t)RunG((uint64_t)Input);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-__host__ __device__ uint64_t brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RunG(uint64_t Input) const {
+__host__ __device__ uint64_t bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RunG(uint64_t Input) const {
     Input = layer.RunG(Input);
     Input = nextLayers.RunG(Input);
     return Input;
@@ -468,7 +468,7 @@ __host__ __device__ uint64_t brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
 template <size_t _Index>
-__host__ __device__ brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::layerType_t<_Index>& brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Layer() {
+__host__ __device__ bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::layerType_t<_Index>& bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Layer() {
     if constexpr (_Index) {
         return nextLayers.Layer<_Index - 1>();
     }
@@ -479,65 +479,65 @@ __host__ __device__ brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutpu
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
 template <size_t _Index>
-__host__ __device__ brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::layerType_t<_Index>& brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::Layer() {
+__host__ __device__ bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::layerType_t<_Index>& bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::Layer() {
     static_assert(!_Index, "_Index is out of bounds.");
     return layer;
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-constexpr size_t brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::LayerCount() {
+constexpr size_t bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::LayerCount() {
     return FixedMLPB<_TOutput1, _TOutput2, _TsContinuedOutputs...>::LayerCount() + 1;
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-size_t brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::SerializedSize() const {
+size_t bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::SerializedSize() const {
     return sizeof(this_t);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Serialize(void*& Data) const {
+void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Serialize(void*& Data) const {
     layer.Serialize(Data);
     nextLayers.Serialize(Data);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...> brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Deserialize(const void*& Data) {
+bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...> bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Deserialize(const void*& Data) {
     uint8_t bytes[sizeof(this_t)];
     Deserialize(Data, &bytes);
     return *(this_t*)&bytes;
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Deserialize(const void*& Data, void* ObjMem) {
+void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Deserialize(const void*& Data, void* ObjMem) {
     this_t& obj = &(this_t*)ObjMem;
     BSerializer::Deserialize(Data, &obj.layer);
     BSerializer::Deserialize(Data, &obj.nextLayers);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-constexpr size_t brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::LayerCount() {
+constexpr size_t bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::LayerCount() {
     return 1;
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-size_t brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::SerializedSize() const {
+size_t bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::SerializedSize() const {
     return sizeof(this_t);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::Serialize(void*& Data) const {
+void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::Serialize(void*& Data) const {
     layer.Serialize(Data);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1> brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::Deserialize(const void*& Data) {
+bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1> bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::Deserialize(const void*& Data) {
     uint8_t bytes[sizeof(this_t)];
     Deserialize(Data, &bytes);
     return *(this_t*)&bytes;
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::Deserialize(const void*& Data, void* ObjMem) {
+void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::Deserialize(const void*& Data, void* ObjMem) {
     this_t& obj = &(this_t*)ObjMem;
     BSerializer::Deserialize(Data, &obj.layer);
 }

--- a/ai_mlpb_fixedmlpb.h
+++ b/ai_mlpb_fixedmlpb.h
@@ -11,7 +11,7 @@
 #include <random>
 #include <type_traits>
 
-namespace BrendanCUDA {
+namespace brendancuda {
     namespace AI {
         namespace MLPB {
             template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
@@ -192,7 +192,7 @@ namespace BrendanCUDA {
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-__host__ __device__ void BrendanCUDA::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::FillWith0() {
+__host__ __device__ void brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::FillWith0() {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i) {
         weights[i] = (_TInput)0;
     }
@@ -201,7 +201,7 @@ __host__ __device__ void BrendanCUDA::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::F
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void BrendanCUDA::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::FillWithRandom(_TRNG& RNG) {
+__host__ void brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::FillWithRandom(_TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i) {
         weights[i] = details::GetIntBin<_TInput>(RNG);
     }
@@ -210,8 +210,8 @@ __host__ void BrendanCUDA::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::FillWithRand
 
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ void BrendanCUDA::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::FillWithRandom(_TRNG& RNG) {
+template <brendancuda::KernelCurandState _TRNG>
+__device__ void brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::FillWithRandom(_TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i) {
         weights[i] = details::GetIntBin<_TInput>(RNG);
     }
@@ -221,60 +221,60 @@ __device__ void BrendanCUDA::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::FillWithRa
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void BrendanCUDA::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
-        weights[i] = BrendanCUDA::Random::RandomizeWFlips(weights[i], WeightsFlipProb, RNG);
-    bias = BrendanCUDA::Random::RandomizeWFlips(bias, BiasFlipProb, RNG);
+        weights[i] = brendancuda::Random::RandomizeWFlips(weights[i], WeightsFlipProb, RNG);
+    bias = brendancuda::Random::RandomizeWFlips(bias, BiasFlipProb, RNG);
 }
 
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ __forceinline void BrendanCUDA::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+template <brendancuda::KernelCurandState _TRNG>
+__device__ __forceinline void brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
-        weights[i] = BrendanCUDA::Random::RandomizeWFlips(weights[i], WeightsFlipProb, RNG);
-    bias = BrendanCUDA::Random::RandomizeWFlips(bias, BiasFlipProb, RNG);
+        weights[i] = brendancuda::Random::RandomizeWFlips(weights[i], WeightsFlipProb, RNG);
+    bias = brendancuda::Random::RandomizeWFlips(bias, BiasFlipProb, RNG);
 }
 #endif
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void BrendanCUDA::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
-        weights[i] = BrendanCUDA::Random::RandomizeWTargets(weights[i], WeightsFlipProb, RNG);
-    bias = BrendanCUDA::Random::RandomizeWTargets(bias, BiasFlipProb, RNG);
+        weights[i] = brendancuda::Random::RandomizeWTargets(weights[i], WeightsFlipProb, RNG);
+    bias = brendancuda::Random::RandomizeWTargets(bias, BiasFlipProb, RNG);
 }
 
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ __forceinline void BrendanCUDA::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+template <brendancuda::KernelCurandState _TRNG>
+__device__ __forceinline void brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
-        weights[i] = BrendanCUDA::Random::RandomizeWTargets(weights[i], WeightsFlipProb, RNG);
-    bias = BrendanCUDA::Random::RandomizeWTargets(bias, BiasFlipProb, RNG);
+        weights[i] = brendancuda::Random::RandomizeWTargets(weights[i], WeightsFlipProb, RNG);
+    bias = brendancuda::Random::RandomizeWTargets(bias, BiasFlipProb, RNG);
 }
 #endif
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void BrendanCUDA::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
-        weights[i] = BrendanCUDA::Random::RandomizeWMutations(weights[i], WeightsProbOf1, RNG);
-    bias = BrendanCUDA::Random::RandomizeWMutations(bias, BiasProbOf1, RNG);
+        weights[i] = brendancuda::Random::RandomizeWMutations(weights[i], WeightsProbOf1, RNG);
+    bias = brendancuda::Random::RandomizeWMutations(bias, BiasProbOf1, RNG);
 }
 
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ __forceinline void BrendanCUDA::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
+template <brendancuda::KernelCurandState _TRNG>
+__device__ __forceinline void brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
-        weights[i] = BrendanCUDA::Random::RandomizeWMutations(weights[i], WeightsProbOf1, RNG);
-    bias = BrendanCUDA::Random::RandomizeWMutations(bias, BiasProbOf1, RNG);
+        weights[i] = brendancuda::Random::RandomizeWMutations(weights[i], WeightsProbOf1, RNG);
+    bias = brendancuda::Random::RandomizeWMutations(bias, BiasProbOf1, RNG);
 }
 #endif
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-__host__ __device__ _TOutput BrendanCUDA::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::Run(_TInput Input) const {
+__host__ __device__ _TOutput brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::Run(_TInput Input) const {
     _TOutput o = bias;
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i) {
         if (Input & weights[i]) o |= ((_TOutput)1) << i;
@@ -283,124 +283,124 @@ __host__ __device__ _TOutput BrendanCUDA::AI::MLPB::FixedMLPBL<_TInput, _TOutput
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-__host__ __device__ uint64_t BrendanCUDA::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::RunG(uint64_t Input) const {
+__host__ __device__ uint64_t brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::RunG(uint64_t Input) const {
     return (uint64_t)Run((_TInput)Input);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-size_t BrendanCUDA::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::SerializedSize() const {
+size_t brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::SerializedSize() const {
     return sizeof(this_t);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-void BrendanCUDA::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::Serialize(void*& Data) const {
+void brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::Serialize(void*& Data) const {
     BSerializer::SerializeArray(Data, weights, details::BitCount<_TOutput>);
     BSerializer::Serialize(Data, bias);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-BrendanCUDA::AI::MLPB::FixedMLPBL<_TInput, _TOutput> BrendanCUDA::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::Deserialize(const void*& Data) {
+brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput> brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::Deserialize(const void*& Data) {
     uint8_t bytes[sizeof(this_t)];
     Deserialize(Data, &bytes);
     return *(this_t*)&bytes;
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-void BrendanCUDA::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::Deserialize(const void*& Data, void* ObjMem) {
+void brendancuda::AI::MLPB::FixedMLPBL<_TInput, _TOutput>::Deserialize(const void*& Data, void* ObjMem) {
     this_t& obj = *(this_t*)ObjMem;
     BSerializer::DeserializeArray(Data, obj.weights, details::BitCount<_TOutput>);
     BSerializer::Deserialize(Data, &obj.bias);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-__host__ __device__ void BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::FillWith0() {
+__host__ __device__ void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::FillWith0() {
     layer.FillWith0();
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::FillWithRandom(_TRNG& RNG) {
+__host__ void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::FillWithRandom(_TRNG& RNG) {
     layer.FillWithRandom(RNG);
 }
 
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ void BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::FillWithRandom(_TRNG& RNG) {
+template <brendancuda::KernelCurandState _TRNG>
+__device__ void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::FillWithRandom(_TRNG& RNG) {
     layer.FillWithRandom(RNG);
 }
 #endif
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     layer.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
 }
 
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ __forceinline void BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+template <brendancuda::KernelCurandState _TRNG>
+__device__ __forceinline void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     layer.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
 }
 #endif
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     layer.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
 }
 
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ __forceinline void BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+template <brendancuda::KernelCurandState _TRNG>
+__device__ __forceinline void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     layer.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
 }
 #endif
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
     layer.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
 }
 
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ __forceinline void BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
+template <brendancuda::KernelCurandState _TRNG>
+__device__ __forceinline void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
     layer.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
 }
 #endif
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-__host__ __device__ auto BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::Run(_TInput Input) const -> output_t {
+__host__ __device__ auto brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::Run(_TInput Input) const -> output_t {
     return (output_t)RunG((uint64_t)Input);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-__host__ __device__ uint64_t BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::RunG(uint64_t Input) const {
+__host__ __device__ uint64_t brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::RunG(uint64_t Input) const {
     Input = layer.RunG(Input);
     return Input;
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-__host__ __device__ void BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::FillWith0() {
+__host__ __device__ void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::FillWith0() {
     layer.FillWith0();
     nextLayers.FillWith0();
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::FillWithRandom(_TRNG& RNG) {
+__host__ void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::FillWithRandom(_TRNG& RNG) {
     layer.FillWithRandom(RNG);
     nextLayers.FillWithRandom(RNG);
 }
 
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ void BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::FillWithRandom(_TRNG& RNG) {
+template <brendancuda::KernelCurandState _TRNG>
+__device__ void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::FillWithRandom(_TRNG& RNG) {
     layer.FillWithRandom(RNG);
     nextLayers.FillWithRandom(RNG);
 }
@@ -408,15 +408,15 @@ __device__ void BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, 
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     layer.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
     nextLayers.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
 }
 
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ __forceinline void BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+template <brendancuda::KernelCurandState _TRNG>
+__device__ __forceinline void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     layer.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
     nextLayers.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
 }
@@ -424,15 +424,15 @@ __device__ __forceinline void BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     layer.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
     nextLayers.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
 }
 
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ __forceinline void BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+template <brendancuda::KernelCurandState _TRNG>
+__device__ __forceinline void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     layer.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
     nextLayers.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
 }
@@ -440,27 +440,27 @@ __device__ __forceinline void BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
     layer.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
     nextLayers.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
 }
 
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ __forceinline void BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
+template <brendancuda::KernelCurandState _TRNG>
+__device__ __forceinline void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
     layer.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
     nextLayers.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
 }
 #endif
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-__host__ __device__ auto BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Run(_TInput Input) const -> output_t {
+__host__ __device__ auto brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Run(_TInput Input) const -> output_t {
     return (output_t)RunG((uint64_t)Input);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-__host__ __device__ uint64_t BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RunG(uint64_t Input) const {
+__host__ __device__ uint64_t brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RunG(uint64_t Input) const {
     Input = layer.RunG(Input);
     Input = nextLayers.RunG(Input);
     return Input;
@@ -468,7 +468,7 @@ __host__ __device__ uint64_t BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
 template <size_t _Index>
-__host__ __device__ BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::layerType_t<_Index>& BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Layer() {
+__host__ __device__ brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::layerType_t<_Index>& brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Layer() {
     if constexpr (_Index) {
         return nextLayers.Layer<_Index - 1>();
     }
@@ -479,65 +479,65 @@ __host__ __device__ BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutpu
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
 template <size_t _Index>
-__host__ __device__ BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::layerType_t<_Index>& BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::Layer() {
+__host__ __device__ brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::layerType_t<_Index>& brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::Layer() {
     static_assert(!_Index, "_Index is out of bounds.");
     return layer;
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-constexpr size_t BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::LayerCount() {
+constexpr size_t brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::LayerCount() {
     return FixedMLPB<_TOutput1, _TOutput2, _TsContinuedOutputs...>::LayerCount() + 1;
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-size_t BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::SerializedSize() const {
+size_t brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::SerializedSize() const {
     return sizeof(this_t);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-void BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Serialize(void*& Data) const {
+void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Serialize(void*& Data) const {
     layer.Serialize(Data);
     nextLayers.Serialize(Data);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...> BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Deserialize(const void*& Data) {
+brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...> brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Deserialize(const void*& Data) {
     uint8_t bytes[sizeof(this_t)];
     Deserialize(Data, &bytes);
     return *(this_t*)&bytes;
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-void BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Deserialize(const void*& Data, void* ObjMem) {
+void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Deserialize(const void*& Data, void* ObjMem) {
     this_t& obj = &(this_t*)ObjMem;
     BSerializer::Deserialize(Data, &obj.layer);
     BSerializer::Deserialize(Data, &obj.nextLayers);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-constexpr size_t BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::LayerCount() {
+constexpr size_t brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::LayerCount() {
     return 1;
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-size_t BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::SerializedSize() const {
+size_t brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::SerializedSize() const {
     return sizeof(this_t);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-void BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::Serialize(void*& Data) const {
+void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::Serialize(void*& Data) const {
     layer.Serialize(Data);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1> BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::Deserialize(const void*& Data) {
+brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1> brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::Deserialize(const void*& Data) {
     uint8_t bytes[sizeof(this_t)];
     Deserialize(Data, &bytes);
     return *(this_t*)&bytes;
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-void BrendanCUDA::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::Deserialize(const void*& Data, void* ObjMem) {
+void brendancuda::AI::MLPB::FixedMLPB<_TInput, _TOutput1>::Deserialize(const void*& Data, void* ObjMem) {
     this_t& obj = &(this_t*)ObjMem;
     BSerializer::Deserialize(Data, &obj.layer);
 }

--- a/ai_mlpb_fixedmlpb.h
+++ b/ai_mlpb_fixedmlpb.h
@@ -13,7 +13,7 @@
 
 namespace brendancuda {
     namespace ai {
-        namespace MLPB {
+        namespace mlpb {
             template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
             struct FixedMLPBL;
         }
@@ -27,12 +27,12 @@ namespace brendancuda {
         };
         template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
         struct MLPBLayerType<0, _TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...> {
-            using type = ai::MLPB::FixedMLPBL<_TInput, _TOutput1>;
+            using type = ai::mlpb::FixedMLPBL<_TInput, _TOutput1>;
         };
         template <size_t _Index, std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
         struct MLPBLayerType<_Index, _TInput, _TOutput1> {
             static_assert(!_Index, "_Index is out of bounds.");
-            using type = ai::MLPB::FixedMLPBL<_TInput, _TOutput1>;
+            using type = ai::mlpb::FixedMLPBL<_TInput, _TOutput1>;
         };
 
         template <size_t _Index, std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral... _TsContinuedOutputs>
@@ -42,7 +42,7 @@ namespace brendancuda {
         constexpr size_t BitCount = sizeof(_T) << 3;
     }
     namespace ai {
-        namespace MLPB {
+        namespace mlpb {
             template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
             struct FixedMLPBL {
             private:
@@ -192,7 +192,7 @@ namespace brendancuda {
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-__host__ __device__ void brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>::FillWith0() {
+__host__ __device__ void brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::FillWith0() {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i) {
         weights[i] = (_TInput)0;
     }
@@ -201,7 +201,7 @@ __host__ __device__ void brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>::F
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>::FillWithRandom(_TRNG& RNG) {
+__host__ void brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::FillWithRandom(_TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i) {
         weights[i] = details::GetIntBin<_TInput>(RNG);
     }
@@ -211,7 +211,7 @@ __host__ void brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>::FillWithRand
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>::FillWithRandom(_TRNG& RNG) {
+__device__ void brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::FillWithRandom(_TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i) {
         weights[i] = details::GetIntBin<_TInput>(RNG);
     }
@@ -221,7 +221,7 @@ __device__ void brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>::FillWithRa
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
         weights[i] = brendancuda::Random::RandomizeWFlips(weights[i], WeightsFlipProb, RNG);
     bias = brendancuda::Random::RandomizeWFlips(bias, BiasFlipProb, RNG);
@@ -230,7 +230,7 @@ __host__ __forceinline void brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__device__ __forceinline void brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
         weights[i] = brendancuda::Random::RandomizeWFlips(weights[i], WeightsFlipProb, RNG);
     bias = brendancuda::Random::RandomizeWFlips(bias, BiasFlipProb, RNG);
@@ -239,7 +239,7 @@ __device__ __forceinline void brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutpu
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
         weights[i] = brendancuda::Random::RandomizeWTargets(weights[i], WeightsFlipProb, RNG);
     bias = brendancuda::Random::RandomizeWTargets(bias, BiasFlipProb, RNG);
@@ -248,7 +248,7 @@ __host__ __forceinline void brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__device__ __forceinline void brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
         weights[i] = brendancuda::Random::RandomizeWTargets(weights[i], WeightsFlipProb, RNG);
     bias = brendancuda::Random::RandomizeWTargets(bias, BiasFlipProb, RNG);
@@ -257,7 +257,7 @@ __device__ __forceinline void brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutpu
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
         weights[i] = brendancuda::Random::RandomizeWMutations(weights[i], WeightsProbOf1, RNG);
     bias = brendancuda::Random::RandomizeWMutations(bias, BiasProbOf1, RNG);
@@ -266,7 +266,7 @@ __host__ __forceinline void brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
+__device__ __forceinline void brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
         weights[i] = brendancuda::Random::RandomizeWMutations(weights[i], WeightsProbOf1, RNG);
     bias = brendancuda::Random::RandomizeWMutations(bias, BiasProbOf1, RNG);
@@ -274,7 +274,7 @@ __device__ __forceinline void brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutpu
 #endif
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-__host__ __device__ _TOutput brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>::Run(_TInput Input) const {
+__host__ __device__ _TOutput brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::Run(_TInput Input) const {
     _TOutput o = bias;
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i) {
         if (Input & weights[i]) o |= ((_TOutput)1) << i;
@@ -283,116 +283,116 @@ __host__ __device__ _TOutput brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-__host__ __device__ uint64_t brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>::RunG(uint64_t Input) const {
+__host__ __device__ uint64_t brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RunG(uint64_t Input) const {
     return (uint64_t)Run((_TInput)Input);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-size_t brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>::SerializedSize() const {
+size_t brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::SerializedSize() const {
     return sizeof(this_t);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-void brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>::Serialize(void*& Data) const {
+void brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::Serialize(void*& Data) const {
     BSerializer::SerializeArray(Data, weights, details::BitCount<_TOutput>);
     BSerializer::Serialize(Data, bias);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput> brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>::Deserialize(const void*& Data) {
+brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput> brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::Deserialize(const void*& Data) {
     uint8_t bytes[sizeof(this_t)];
     Deserialize(Data, &bytes);
     return *(this_t*)&bytes;
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-void brendancuda::ai::MLPB::FixedMLPBL<_TInput, _TOutput>::Deserialize(const void*& Data, void* ObjMem) {
+void brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::Deserialize(const void*& Data, void* ObjMem) {
     this_t& obj = *(this_t*)ObjMem;
     BSerializer::DeserializeArray(Data, obj.weights, details::BitCount<_TOutput>);
     BSerializer::Deserialize(Data, &obj.bias);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-__host__ __device__ void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::FillWith0() {
+__host__ __device__ void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::FillWith0() {
     layer.FillWith0();
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::FillWithRandom(_TRNG& RNG) {
+__host__ void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::FillWithRandom(_TRNG& RNG) {
     layer.FillWithRandom(RNG);
 }
 
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::FillWithRandom(_TRNG& RNG) {
+__device__ void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::FillWithRandom(_TRNG& RNG) {
     layer.FillWithRandom(RNG);
 }
 #endif
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     layer.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
 }
 
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__device__ __forceinline void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     layer.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
 }
 #endif
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     layer.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
 }
 
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__device__ __forceinline void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     layer.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
 }
 #endif
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
     layer.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
 }
 
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
+__device__ __forceinline void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
     layer.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
 }
 #endif
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-__host__ __device__ auto brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::Run(_TInput Input) const -> output_t {
+__host__ __device__ auto brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::Run(_TInput Input) const -> output_t {
     return (output_t)RunG((uint64_t)Input);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-__host__ __device__ uint64_t brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::RunG(uint64_t Input) const {
+__host__ __device__ uint64_t brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::RunG(uint64_t Input) const {
     Input = layer.RunG(Input);
     return Input;
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-__host__ __device__ void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::FillWith0() {
+__host__ __device__ void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::FillWith0() {
     layer.FillWith0();
     nextLayers.FillWith0();
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::FillWithRandom(_TRNG& RNG) {
+__host__ void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::FillWithRandom(_TRNG& RNG) {
     layer.FillWithRandom(RNG);
     nextLayers.FillWithRandom(RNG);
 }
@@ -400,7 +400,7 @@ __host__ void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _T
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::FillWithRandom(_TRNG& RNG) {
+__device__ void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::FillWithRandom(_TRNG& RNG) {
     layer.FillWithRandom(RNG);
     nextLayers.FillWithRandom(RNG);
 }
@@ -408,7 +408,7 @@ __device__ void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, 
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     layer.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
     nextLayers.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
 }
@@ -416,7 +416,7 @@ __host__ __forceinline void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1,
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__device__ __forceinline void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     layer.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
     nextLayers.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
 }
@@ -424,7 +424,7 @@ __device__ __forceinline void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     layer.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
     nextLayers.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
 }
@@ -432,7 +432,7 @@ __host__ __forceinline void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1,
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+__device__ __forceinline void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     layer.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
     nextLayers.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
 }
@@ -440,7 +440,7 @@ __device__ __forceinline void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
     layer.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
     nextLayers.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
 }
@@ -448,19 +448,19 @@ __host__ __forceinline void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1,
 #ifdef __CUDACC__
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
 template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
+__device__ __forceinline void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
     layer.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
     nextLayers.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
 }
 #endif
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-__host__ __device__ auto brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Run(_TInput Input) const -> output_t {
+__host__ __device__ auto brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Run(_TInput Input) const -> output_t {
     return (output_t)RunG((uint64_t)Input);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-__host__ __device__ uint64_t brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RunG(uint64_t Input) const {
+__host__ __device__ uint64_t brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RunG(uint64_t Input) const {
     Input = layer.RunG(Input);
     Input = nextLayers.RunG(Input);
     return Input;
@@ -468,7 +468,7 @@ __host__ __device__ uint64_t brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
 template <size_t _Index>
-__host__ __device__ brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::layerType_t<_Index>& brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Layer() {
+__host__ __device__ brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::layerType_t<_Index>& brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Layer() {
     if constexpr (_Index) {
         return nextLayers.Layer<_Index - 1>();
     }
@@ -479,65 +479,65 @@ __host__ __device__ brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutpu
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
 template <size_t _Index>
-__host__ __device__ brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::layerType_t<_Index>& brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::Layer() {
+__host__ __device__ brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::layerType_t<_Index>& brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::Layer() {
     static_assert(!_Index, "_Index is out of bounds.");
     return layer;
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-constexpr size_t brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::LayerCount() {
+constexpr size_t brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::LayerCount() {
     return FixedMLPB<_TOutput1, _TOutput2, _TsContinuedOutputs...>::LayerCount() + 1;
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-size_t brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::SerializedSize() const {
+size_t brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::SerializedSize() const {
     return sizeof(this_t);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Serialize(void*& Data) const {
+void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Serialize(void*& Data) const {
     layer.Serialize(Data);
     nextLayers.Serialize(Data);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...> brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Deserialize(const void*& Data) {
+brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...> brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Deserialize(const void*& Data) {
     uint8_t bytes[sizeof(this_t)];
     Deserialize(Data, &bytes);
     return *(this_t*)&bytes;
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Deserialize(const void*& Data, void* ObjMem) {
+void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Deserialize(const void*& Data, void* ObjMem) {
     this_t& obj = &(this_t*)ObjMem;
     BSerializer::Deserialize(Data, &obj.layer);
     BSerializer::Deserialize(Data, &obj.nextLayers);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-constexpr size_t brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::LayerCount() {
+constexpr size_t brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::LayerCount() {
     return 1;
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-size_t brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::SerializedSize() const {
+size_t brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::SerializedSize() const {
     return sizeof(this_t);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::Serialize(void*& Data) const {
+void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::Serialize(void*& Data) const {
     layer.Serialize(Data);
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1> brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::Deserialize(const void*& Data) {
+brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1> brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::Deserialize(const void*& Data) {
     uint8_t bytes[sizeof(this_t)];
     Deserialize(Data, &bytes);
     return *(this_t*)&bytes;
 }
 
 template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-void brendancuda::ai::MLPB::FixedMLPB<_TInput, _TOutput1>::Deserialize(const void*& Data, void* ObjMem) {
+void brendancuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::Deserialize(const void*& Data, void* ObjMem) {
     this_t& obj = &(this_t*)ObjMem;
     BSerializer::Deserialize(Data, &obj.layer);
 }

--- a/ai_mlpb_fixedmlpb.h
+++ b/ai_mlpb_fixedmlpb.h
@@ -223,8 +223,8 @@ template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <std::uniform_random_bit_generator _TRNG>
 __host__ __forceinline void brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
-        weights[i] = brendancuda::Random::RandomizeWFlips(weights[i], WeightsFlipProb, RNG);
-    bias = brendancuda::Random::RandomizeWFlips(bias, BiasFlipProb, RNG);
+        weights[i] = brendancuda::random::RandomizeWFlips(weights[i], WeightsFlipProb, RNG);
+    bias = brendancuda::random::RandomizeWFlips(bias, BiasFlipProb, RNG);
 }
 
 #ifdef __CUDACC__
@@ -232,8 +232,8 @@ template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <brendancuda::KernelCurandState _TRNG>
 __device__ __forceinline void brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
-        weights[i] = brendancuda::Random::RandomizeWFlips(weights[i], WeightsFlipProb, RNG);
-    bias = brendancuda::Random::RandomizeWFlips(bias, BiasFlipProb, RNG);
+        weights[i] = brendancuda::random::RandomizeWFlips(weights[i], WeightsFlipProb, RNG);
+    bias = brendancuda::random::RandomizeWFlips(bias, BiasFlipProb, RNG);
 }
 #endif
 
@@ -241,8 +241,8 @@ template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <std::uniform_random_bit_generator _TRNG>
 __host__ __forceinline void brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
-        weights[i] = brendancuda::Random::RandomizeWTargets(weights[i], WeightsFlipProb, RNG);
-    bias = brendancuda::Random::RandomizeWTargets(bias, BiasFlipProb, RNG);
+        weights[i] = brendancuda::random::RandomizeWTargets(weights[i], WeightsFlipProb, RNG);
+    bias = brendancuda::random::RandomizeWTargets(bias, BiasFlipProb, RNG);
 }
 
 #ifdef __CUDACC__
@@ -250,8 +250,8 @@ template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <brendancuda::KernelCurandState _TRNG>
 __device__ __forceinline void brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
-        weights[i] = brendancuda::Random::RandomizeWTargets(weights[i], WeightsFlipProb, RNG);
-    bias = brendancuda::Random::RandomizeWTargets(bias, BiasFlipProb, RNG);
+        weights[i] = brendancuda::random::RandomizeWTargets(weights[i], WeightsFlipProb, RNG);
+    bias = brendancuda::random::RandomizeWTargets(bias, BiasFlipProb, RNG);
 }
 #endif
 
@@ -259,8 +259,8 @@ template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <std::uniform_random_bit_generator _TRNG>
 __host__ __forceinline void brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
-        weights[i] = brendancuda::Random::RandomizeWMutations(weights[i], WeightsProbOf1, RNG);
-    bias = brendancuda::Random::RandomizeWMutations(bias, BiasProbOf1, RNG);
+        weights[i] = brendancuda::random::RandomizeWMutations(weights[i], WeightsProbOf1, RNG);
+    bias = brendancuda::random::RandomizeWMutations(bias, BiasProbOf1, RNG);
 }
 
 #ifdef __CUDACC__
@@ -268,8 +268,8 @@ template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <brendancuda::KernelCurandState _TRNG>
 __device__ __forceinline void brendancuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
-        weights[i] = brendancuda::Random::RandomizeWMutations(weights[i], WeightsProbOf1, RNG);
-    bias = brendancuda::Random::RandomizeWMutations(bias, BiasProbOf1, RNG);
+        weights[i] = brendancuda::random::RandomizeWMutations(weights[i], WeightsProbOf1, RNG);
+    bias = brendancuda::random::RandomizeWMutations(bias, BiasProbOf1, RNG);
 }
 #endif
 

--- a/arrays.h
+++ b/arrays.h
@@ -4,7 +4,7 @@
 #include <cuda_runtime.h>
 #include <vector>
 
-namespace brendancuda {
+namespace bcuda {
     template <typename _T>
     struct Span;
 

--- a/arrays.h
+++ b/arrays.h
@@ -4,7 +4,7 @@
 #include <cuda_runtime.h>
 #include <vector>
 
-namespace BrendanCUDA {
+namespace brendancuda {
     template <typename _T>
     struct Span;
 

--- a/binary_basic.cu
+++ b/binary_basic.cu
@@ -1,6 +1,6 @@
 #include "binary_basic.h"
 
-__host__ __device__ uint32_t brendancuda::Binary::CountBitsF(uint64_t n) {
+__host__ __device__ uint32_t brendancuda::binary::CountBitsF(uint64_t n) {
     if (n >> 32) {
         if (n >> 48) {
             if (n >> 56) {
@@ -323,7 +323,7 @@ __host__ __device__ uint32_t brendancuda::Binary::CountBitsF(uint64_t n) {
         }
     }
 }
-__host__ __device__ uint32_t brendancuda::Binary::CountBitsF(uint32_t n) {
+__host__ __device__ uint32_t brendancuda::binary::CountBitsF(uint32_t n) {
     if (n >> 16) {
         if (n >> 24) {
             if (n >> 28) {
@@ -486,7 +486,7 @@ __host__ __device__ uint32_t brendancuda::Binary::CountBitsF(uint32_t n) {
         }
     }
 }
-__host__ __device__ uint32_t brendancuda::Binary::CountBitsF(uint16_t n) {
+__host__ __device__ uint32_t brendancuda::binary::CountBitsF(uint16_t n) {
     uint32_t ni = (uint32_t)n;
     if (ni >> 8) {
         if (ni >> 12) {
@@ -570,7 +570,7 @@ __host__ __device__ uint32_t brendancuda::Binary::CountBitsF(uint16_t n) {
         }
     }
 }
-__host__ __device__ uint32_t brendancuda::Binary::CountBitsF(uint8_t n) {
+__host__ __device__ uint32_t brendancuda::binary::CountBitsF(uint8_t n) {
     uint32_t ni = (uint32_t)n;
     if (ni >> 4) {
         if (ni >> 6) {
@@ -614,7 +614,7 @@ __host__ __device__ uint32_t brendancuda::Binary::CountBitsF(uint8_t n) {
         }
     }
 }
-__host__ __device__ uint32_t brendancuda::Binary::CountBitsB(uint64_t n) {
+__host__ __device__ uint32_t brendancuda::binary::CountBitsB(uint64_t n) {
     if (n << 32) {
         if (n << 48) {
             if (n << 56) {
@@ -937,7 +937,7 @@ __host__ __device__ uint32_t brendancuda::Binary::CountBitsB(uint64_t n) {
         }
     }
 }
-__host__ __device__ uint32_t brendancuda::Binary::CountBitsB(uint32_t n) {
+__host__ __device__ uint32_t brendancuda::binary::CountBitsB(uint32_t n) {
     if (n << 16) {
         if (n << 24) {
             if (n << 28) {
@@ -1100,7 +1100,7 @@ __host__ __device__ uint32_t brendancuda::Binary::CountBitsB(uint32_t n) {
         }
     }
 }
-__host__ __device__ uint32_t brendancuda::Binary::CountBitsB(uint16_t n) {
+__host__ __device__ uint32_t brendancuda::binary::CountBitsB(uint16_t n) {
     uint32_t ni = (uint32_t)n;
     if (ni << 8) {
         if (ni << 12) {
@@ -1184,7 +1184,7 @@ __host__ __device__ uint32_t brendancuda::Binary::CountBitsB(uint16_t n) {
         }
     }
 }
-__host__ __device__ uint32_t brendancuda::Binary::CountBitsB(uint8_t n) {
+__host__ __device__ uint32_t brendancuda::binary::CountBitsB(uint8_t n) {
     uint32_t ni = (uint32_t)n;
     if (ni << 4) {
         if (ni << 6) {

--- a/binary_basic.cu
+++ b/binary_basic.cu
@@ -1,6 +1,6 @@
 #include "binary_basic.h"
 
-__host__ __device__ uint32_t BrendanCUDA::Binary::CountBitsF(uint64_t n) {
+__host__ __device__ uint32_t brendancuda::Binary::CountBitsF(uint64_t n) {
     if (n >> 32) {
         if (n >> 48) {
             if (n >> 56) {
@@ -323,7 +323,7 @@ __host__ __device__ uint32_t BrendanCUDA::Binary::CountBitsF(uint64_t n) {
         }
     }
 }
-__host__ __device__ uint32_t BrendanCUDA::Binary::CountBitsF(uint32_t n) {
+__host__ __device__ uint32_t brendancuda::Binary::CountBitsF(uint32_t n) {
     if (n >> 16) {
         if (n >> 24) {
             if (n >> 28) {
@@ -486,7 +486,7 @@ __host__ __device__ uint32_t BrendanCUDA::Binary::CountBitsF(uint32_t n) {
         }
     }
 }
-__host__ __device__ uint32_t BrendanCUDA::Binary::CountBitsF(uint16_t n) {
+__host__ __device__ uint32_t brendancuda::Binary::CountBitsF(uint16_t n) {
     uint32_t ni = (uint32_t)n;
     if (ni >> 8) {
         if (ni >> 12) {
@@ -570,7 +570,7 @@ __host__ __device__ uint32_t BrendanCUDA::Binary::CountBitsF(uint16_t n) {
         }
     }
 }
-__host__ __device__ uint32_t BrendanCUDA::Binary::CountBitsF(uint8_t n) {
+__host__ __device__ uint32_t brendancuda::Binary::CountBitsF(uint8_t n) {
     uint32_t ni = (uint32_t)n;
     if (ni >> 4) {
         if (ni >> 6) {
@@ -614,7 +614,7 @@ __host__ __device__ uint32_t BrendanCUDA::Binary::CountBitsF(uint8_t n) {
         }
     }
 }
-__host__ __device__ uint32_t BrendanCUDA::Binary::CountBitsB(uint64_t n) {
+__host__ __device__ uint32_t brendancuda::Binary::CountBitsB(uint64_t n) {
     if (n << 32) {
         if (n << 48) {
             if (n << 56) {
@@ -937,7 +937,7 @@ __host__ __device__ uint32_t BrendanCUDA::Binary::CountBitsB(uint64_t n) {
         }
     }
 }
-__host__ __device__ uint32_t BrendanCUDA::Binary::CountBitsB(uint32_t n) {
+__host__ __device__ uint32_t brendancuda::Binary::CountBitsB(uint32_t n) {
     if (n << 16) {
         if (n << 24) {
             if (n << 28) {
@@ -1100,7 +1100,7 @@ __host__ __device__ uint32_t BrendanCUDA::Binary::CountBitsB(uint32_t n) {
         }
     }
 }
-__host__ __device__ uint32_t BrendanCUDA::Binary::CountBitsB(uint16_t n) {
+__host__ __device__ uint32_t brendancuda::Binary::CountBitsB(uint16_t n) {
     uint32_t ni = (uint32_t)n;
     if (ni << 8) {
         if (ni << 12) {
@@ -1184,7 +1184,7 @@ __host__ __device__ uint32_t BrendanCUDA::Binary::CountBitsB(uint16_t n) {
         }
     }
 }
-__host__ __device__ uint32_t BrendanCUDA::Binary::CountBitsB(uint8_t n) {
+__host__ __device__ uint32_t brendancuda::Binary::CountBitsB(uint8_t n) {
     uint32_t ni = (uint32_t)n;
     if (ni << 4) {
         if (ni << 6) {

--- a/binary_basic.cu
+++ b/binary_basic.cu
@@ -1,6 +1,6 @@
 #include "binary_basic.h"
 
-__host__ __device__ uint32_t brendancuda::binary::CountBitsF(uint64_t n) {
+__host__ __device__ uint32_t bcuda::binary::CountBitsF(uint64_t n) {
     if (n >> 32) {
         if (n >> 48) {
             if (n >> 56) {
@@ -323,7 +323,7 @@ __host__ __device__ uint32_t brendancuda::binary::CountBitsF(uint64_t n) {
         }
     }
 }
-__host__ __device__ uint32_t brendancuda::binary::CountBitsF(uint32_t n) {
+__host__ __device__ uint32_t bcuda::binary::CountBitsF(uint32_t n) {
     if (n >> 16) {
         if (n >> 24) {
             if (n >> 28) {
@@ -486,7 +486,7 @@ __host__ __device__ uint32_t brendancuda::binary::CountBitsF(uint32_t n) {
         }
     }
 }
-__host__ __device__ uint32_t brendancuda::binary::CountBitsF(uint16_t n) {
+__host__ __device__ uint32_t bcuda::binary::CountBitsF(uint16_t n) {
     uint32_t ni = (uint32_t)n;
     if (ni >> 8) {
         if (ni >> 12) {
@@ -570,7 +570,7 @@ __host__ __device__ uint32_t brendancuda::binary::CountBitsF(uint16_t n) {
         }
     }
 }
-__host__ __device__ uint32_t brendancuda::binary::CountBitsF(uint8_t n) {
+__host__ __device__ uint32_t bcuda::binary::CountBitsF(uint8_t n) {
     uint32_t ni = (uint32_t)n;
     if (ni >> 4) {
         if (ni >> 6) {
@@ -614,7 +614,7 @@ __host__ __device__ uint32_t brendancuda::binary::CountBitsF(uint8_t n) {
         }
     }
 }
-__host__ __device__ uint32_t brendancuda::binary::CountBitsB(uint64_t n) {
+__host__ __device__ uint32_t bcuda::binary::CountBitsB(uint64_t n) {
     if (n << 32) {
         if (n << 48) {
             if (n << 56) {
@@ -937,7 +937,7 @@ __host__ __device__ uint32_t brendancuda::binary::CountBitsB(uint64_t n) {
         }
     }
 }
-__host__ __device__ uint32_t brendancuda::binary::CountBitsB(uint32_t n) {
+__host__ __device__ uint32_t bcuda::binary::CountBitsB(uint32_t n) {
     if (n << 16) {
         if (n << 24) {
             if (n << 28) {
@@ -1100,7 +1100,7 @@ __host__ __device__ uint32_t brendancuda::binary::CountBitsB(uint32_t n) {
         }
     }
 }
-__host__ __device__ uint32_t brendancuda::binary::CountBitsB(uint16_t n) {
+__host__ __device__ uint32_t bcuda::binary::CountBitsB(uint16_t n) {
     uint32_t ni = (uint32_t)n;
     if (ni << 8) {
         if (ni << 12) {
@@ -1184,7 +1184,7 @@ __host__ __device__ uint32_t brendancuda::binary::CountBitsB(uint16_t n) {
         }
     }
 }
-__host__ __device__ uint32_t brendancuda::binary::CountBitsB(uint8_t n) {
+__host__ __device__ uint32_t bcuda::binary::CountBitsB(uint8_t n) {
     uint32_t ni = (uint32_t)n;
     if (ni << 4) {
         if (ni << 6) {

--- a/binary_basic.h
+++ b/binary_basic.h
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <cuda_runtime.h>
 
-namespace BrendanCUDA {
+namespace brendancuda {
     namespace Binary {
         __host__ __device__ uint32_t CountBitsF(uint64_t Value);
         __host__ __device__ uint32_t CountBitsF(uint32_t Value);

--- a/binary_basic.h
+++ b/binary_basic.h
@@ -4,7 +4,7 @@
 #include <cuda_runtime.h>
 
 namespace brendancuda {
-    namespace Binary {
+    namespace binary {
         __host__ __device__ uint32_t CountBitsF(uint64_t Value);
         __host__ __device__ uint32_t CountBitsF(uint32_t Value);
         __host__ __device__ uint32_t CountBitsF(uint16_t Value);

--- a/binary_basic.h
+++ b/binary_basic.h
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <cuda_runtime.h>
 
-namespace brendancuda {
+namespace bcuda {
     namespace binary {
         __host__ __device__ uint32_t CountBitsF(uint64_t Value);
         __host__ __device__ uint32_t CountBitsF(uint32_t Value);

--- a/copyblock.cpp
+++ b/copyblock.cpp
@@ -1,7 +1,7 @@
 #include "copyblock.h"
 #include <vector>
 
-__host__ __device__ BrendanCUDA::ArrayV<BrendanCUDA::details::Landmark> BrendanCUDA::details::GetLandmarksInDirection(uint32_t InputLength, uint32_t OutputLength, uint32_t RangeLength, uint32_t InputIndex, uint32_t OutputIndex) {
+__host__ __device__ brendancuda::ArrayV<brendancuda::details::Landmark> brendancuda::details::GetLandmarksInDirection(uint32_t InputLength, uint32_t OutputLength, uint32_t RangeLength, uint32_t InputIndex, uint32_t OutputIndex) {
     std::vector<Landmark> landmarks;
     while (RangeLength) {
         uint32_t dInput = InputLength - InputIndex;

--- a/copyblock.cpp
+++ b/copyblock.cpp
@@ -1,7 +1,7 @@
 #include "copyblock.h"
 #include <vector>
 
-__host__ __device__ brendancuda::ArrayV<brendancuda::details::Landmark> brendancuda::details::GetLandmarksInDirection(uint32_t InputLength, uint32_t OutputLength, uint32_t RangeLength, uint32_t InputIndex, uint32_t OutputIndex) {
+__host__ __device__ bcuda::ArrayV<bcuda::details::Landmark> bcuda::details::GetLandmarksInDirection(uint32_t InputLength, uint32_t OutputLength, uint32_t RangeLength, uint32_t InputIndex, uint32_t OutputIndex) {
     std::vector<Landmark> landmarks;
     while (RangeLength) {
         uint32_t dInput = InputLength - InputIndex;

--- a/copyblock.h
+++ b/copyblock.h
@@ -6,7 +6,7 @@
 #include "points.h"
 #include <cuda_runtime.h>
 
-namespace BrendanCUDA {
+namespace brendancuda {
     namespace details {
         struct Landmark {
             uint32_t inputIndex;
@@ -36,7 +36,7 @@ namespace BrendanCUDA {
 }
 
 template <typename _T, size_t _VectorLength, bool _InputOnHost, bool _OutputOnHost, bool _Wrap>
-__host__ void BrendanCUDA::CopyBlock(const _T* Input, _T* Output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates) {
+__host__ void brendancuda::CopyBlock(const _T* Input, _T* Output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates) {
     using vector_t = FixedVector<uint32_t, _VectorLength>;
     
     if constexpr (_Wrap) {
@@ -112,7 +112,7 @@ __host__ void BrendanCUDA::CopyBlock(const _T* Input, _T* Output, const FixedVec
 }
 #ifdef __CUDACC__
 template <typename _T, size_t _VectorLength, bool _Wrap>
-__device__ void BrendanCUDA::CopyBlock(const _T* Input, _T* Output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates) {
+__device__ void brendancuda::CopyBlock(const _T* Input, _T* Output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates) {
     using vector_t = FixedVector<uint32_t, _VectorLength>;
 
     if constexpr (_Wrap) {
@@ -178,8 +178,8 @@ __device__ void BrendanCUDA::CopyBlock(const _T* Input, _T* Output, const FixedV
 }
 #endif
 
-template <typename _T, size_t _VectorLength, BrendanCUDA::copyValFunc_t<_T> _CopyValFunc, bool _Wrap>
-__host__ __device__ void BrendanCUDA::CopyBlock(const _T* Input, _T* Output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates) {
+template <typename _T, size_t _VectorLength, brendancuda::copyValFunc_t<_T> _CopyValFunc, bool _Wrap>
+__host__ __device__ void brendancuda::CopyBlock(const _T* Input, _T* Output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates) {
     using vector_t = FixedVector<uint32_t, _VectorLength>;
 
     if constexpr (_Wrap) {
@@ -245,8 +245,8 @@ __host__ __device__ void BrendanCUDA::CopyBlock(const _T* Input, _T* Output, con
     }
 }
 
-template <typename _T, size_t _VectorLength, BrendanCUDA::copyArrFunc_t<_T> _CopyArrFunc, bool _Wrap>
-__host__ __device__ void BrendanCUDA::CopyBlock(const _T* Input, _T* Output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates) {
+template <typename _T, size_t _VectorLength, brendancuda::copyArrFunc_t<_T> _CopyArrFunc, bool _Wrap>
+__host__ __device__ void brendancuda::CopyBlock(const _T* Input, _T* Output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates) {
     using vector_t = FixedVector<uint32_t, _VectorLength>;
 
     if constexpr (_Wrap) {

--- a/copyblock.h
+++ b/copyblock.h
@@ -6,7 +6,7 @@
 #include "points.h"
 #include <cuda_runtime.h>
 
-namespace brendancuda {
+namespace bcuda {
     namespace details {
         struct Landmark {
             uint32_t inputIndex;
@@ -36,7 +36,7 @@ namespace brendancuda {
 }
 
 template <typename _T, size_t _VectorLength, bool _InputOnHost, bool _OutputOnHost, bool _Wrap>
-__host__ void brendancuda::CopyBlock(const _T* Input, _T* output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates) {
+__host__ void bcuda::CopyBlock(const _T* Input, _T* output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates) {
     using vector_t = FixedVector<uint32_t, _VectorLength>;
     
     if constexpr (_Wrap) {
@@ -112,7 +112,7 @@ __host__ void brendancuda::CopyBlock(const _T* Input, _T* output, const FixedVec
 }
 #ifdef __CUDACC__
 template <typename _T, size_t _VectorLength, bool _Wrap>
-__device__ void brendancuda::CopyBlock(const _T* Input, _T* output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates) {
+__device__ void bcuda::CopyBlock(const _T* Input, _T* output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates) {
     using vector_t = FixedVector<uint32_t, _VectorLength>;
 
     if constexpr (_Wrap) {
@@ -178,8 +178,8 @@ __device__ void brendancuda::CopyBlock(const _T* Input, _T* output, const FixedV
 }
 #endif
 
-template <typename _T, size_t _VectorLength, brendancuda::copyValFunc_t<_T> _CopyValFunc, bool _Wrap>
-__host__ __device__ void brendancuda::CopyBlock(const _T* Input, _T* output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates) {
+template <typename _T, size_t _VectorLength, bcuda::copyValFunc_t<_T> _CopyValFunc, bool _Wrap>
+__host__ __device__ void bcuda::CopyBlock(const _T* Input, _T* output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates) {
     using vector_t = FixedVector<uint32_t, _VectorLength>;
 
     if constexpr (_Wrap) {
@@ -245,8 +245,8 @@ __host__ __device__ void brendancuda::CopyBlock(const _T* Input, _T* output, con
     }
 }
 
-template <typename _T, size_t _VectorLength, brendancuda::copyArrFunc_t<_T> _CopyArrFunc, bool _Wrap>
-__host__ __device__ void brendancuda::CopyBlock(const _T* Input, _T* output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates) {
+template <typename _T, size_t _VectorLength, bcuda::copyArrFunc_t<_T> _CopyArrFunc, bool _Wrap>
+__host__ __device__ void bcuda::CopyBlock(const _T* Input, _T* output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates) {
     using vector_t = FixedVector<uint32_t, _VectorLength>;
 
     if constexpr (_Wrap) {

--- a/copyblock.h
+++ b/copyblock.h
@@ -23,20 +23,20 @@ namespace brendancuda {
         __host__ __device__ ArrayV<Landmark> GetLandmarksInDirection(uint32_t InputLength, uint32_t OutputLength, uint32_t RangeLength, uint32_t InputIndex, uint32_t OutputIndex);
     }
     template <typename _T, size_t _VectorLength, bool _InputOnHost, bool _OutputOnHost, bool _Wrap = false>
-    __host__ static void CopyBlock(const _T* Input, _T* Output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates);
+    __host__ static void CopyBlock(const _T* Input, _T* output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates);
 #ifdef __CUDACC__
     template <typename _T, size_t _VectorLength, bool _Wrap = false>
-    __device__ static void CopyBlock(const _T* Input, _T* Output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates);
+    __device__ static void CopyBlock(const _T* Input, _T* output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates);
 #endif
 
     template <typename _T, size_t _VectorLength, copyValFunc_t<_T> _CopyValFunc, bool _Wrap = false>
-    __host__ __device__ static void CopyBlock(const _T* Input, _T* Output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates);
+    __host__ __device__ static void CopyBlock(const _T* Input, _T* output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates);
     template <typename _T, size_t _VectorLength, copyArrFunc_t<_T> _CopyArrFunc, bool _Wrap = false>
-    __host__ __device__ static void CopyBlock(const _T* Input, _T* Output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates);
+    __host__ __device__ static void CopyBlock(const _T* Input, _T* output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates);
 }
 
 template <typename _T, size_t _VectorLength, bool _InputOnHost, bool _OutputOnHost, bool _Wrap>
-__host__ void brendancuda::CopyBlock(const _T* Input, _T* Output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates) {
+__host__ void brendancuda::CopyBlock(const _T* Input, _T* output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates) {
     using vector_t = FixedVector<uint32_t, _VectorLength>;
     
     if constexpr (_Wrap) {
@@ -56,7 +56,7 @@ __host__ void brendancuda::CopyBlock(const _T* Input, _T* Output, const FixedVec
                 rangeInOutputCoordinates[j] = landmark.outputIndex;
             }
 
-            CopyBlock<_T, _VectorLength, _InputOnHost, _OutputOnHost, false>(Input, Output, InputDimensions, OutputDimensions, rangeDimensions, rangeInInputCoordinates, rangeInOutputCoordinates);
+            CopyBlock<_T, _VectorLength, _InputOnHost, _OutputOnHost, false>(Input, output, InputDimensions, OutputDimensions, rangeDimensions, rangeInInputCoordinates, rangeInOutputCoordinates);
             
             bool toBreak = true;
             for (size_t j = 0; j < _VectorLength; ++j) {
@@ -73,11 +73,11 @@ __host__ void brendancuda::CopyBlock(const _T* Input, _T* Output, const FixedVec
     else {
         if constexpr (_VectorLength == 1) {
             if constexpr (_InputOnHost)
-                if constexpr (_OutputOnHost) memcpy(Output + RangeInOutputsCoordinates.x, Input + RangeInInputsCoordinates.x, sizeof(_T) * RangeDimensions.x);
-                else cudaMemcpy(Output + RangeInOutputsCoordinates.x, Input + RangeInInputsCoordinates.x, sizeof(_T) * RangeDimensions.x, cudaMemcpyHostToDevice);
+                if constexpr (_OutputOnHost) memcpy(output + RangeInOutputsCoordinates.x, Input + RangeInInputsCoordinates.x, sizeof(_T) * RangeDimensions.x);
+                else cudaMemcpy(output + RangeInOutputsCoordinates.x, Input + RangeInInputsCoordinates.x, sizeof(_T) * RangeDimensions.x, cudaMemcpyHostToDevice);
             else
-                if constexpr (_OutputOnHost) cudaMemcpy(Output + RangeInOutputsCoordinates.x, Input + RangeInInputsCoordinates.x, sizeof(_T) * RangeDimensions.x, cudaMemcpyDeviceToHost);
-                else cudaMemcpy(Output + RangeInOutputsCoordinates.x, Input + RangeInInputsCoordinates.x, sizeof(_T) * RangeDimensions.x, cudaMemcpyDeviceToDevice);
+                if constexpr (_OutputOnHost) cudaMemcpy(output + RangeInOutputsCoordinates.x, Input + RangeInInputsCoordinates.x, sizeof(_T) * RangeDimensions.x, cudaMemcpyDeviceToHost);
+                else cudaMemcpy(output + RangeInOutputsCoordinates.x, Input + RangeInInputsCoordinates.x, sizeof(_T) * RangeDimensions.x, cudaMemcpyDeviceToDevice);
             return;
         }
         size_t elementNum = RangeDimensions[_VectorLength - 1];
@@ -88,7 +88,7 @@ __host__ void brendancuda::CopyBlock(const _T* Input, _T* Output, const FixedVec
             size_t optIdx = CoordinatesToIndex<size_t, uint32_t, _VectorLength, true>(OutputDimensions, RangeInOutputsCoordinates + i);
 
             _T* iptPtr = Input + iptIdx;
-            _T* optPtr = Output + optIdx;
+            _T* optPtr = output + optIdx;
 
             if constexpr (_InputOnHost)
                 if constexpr (_OutputOnHost) memcpy(optPtr, iptPtr, memcpySize);
@@ -112,7 +112,7 @@ __host__ void brendancuda::CopyBlock(const _T* Input, _T* Output, const FixedVec
 }
 #ifdef __CUDACC__
 template <typename _T, size_t _VectorLength, bool _Wrap>
-__device__ void brendancuda::CopyBlock(const _T* Input, _T* Output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates) {
+__device__ void brendancuda::CopyBlock(const _T* Input, _T* output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates) {
     using vector_t = FixedVector<uint32_t, _VectorLength>;
 
     if constexpr (_Wrap) {
@@ -132,7 +132,7 @@ __device__ void brendancuda::CopyBlock(const _T* Input, _T* Output, const FixedV
                 rangeInOutputCoordinates[j] = landmark.outputIndex;
             }
 
-            CopyBlock<_T, _VectorLength, false>(Input, Output, InputDimensions, OutputDimensions, rangeDimensions, rangeInInputCoordinates, rangeInOutputCoordinates);
+            CopyBlock<_T, _VectorLength, false>(Input, output, InputDimensions, OutputDimensions, rangeDimensions, rangeInInputCoordinates, rangeInOutputCoordinates);
 
             bool toBreak = true;
             for (size_t j = 0; j < _VectorLength; ++j) {
@@ -148,7 +148,7 @@ __device__ void brendancuda::CopyBlock(const _T* Input, _T* Output, const FixedV
     }
     else {
         if constexpr (_VectorLength == 1) {
-            memcpy(Output + RangeInOutputsCoordinates.x, Input + RangeInInputsCoordinates.x, sizeof(_T) * RangeDimensions.x);
+            memcpy(output + RangeInOutputsCoordinates.x, Input + RangeInInputsCoordinates.x, sizeof(_T) * RangeDimensions.x);
             return;
         }
         size_t elementNum = RangeDimensions[_VectorLength - 1];
@@ -159,7 +159,7 @@ __device__ void brendancuda::CopyBlock(const _T* Input, _T* Output, const FixedV
             size_t optIdx = CoordinatesToIndex<size_t, uint32_t, _VectorLength, true>(OutputDimensions, RangeInOutputsCoordinates + i);
 
             _T* iptPtr = Input + iptIdx;
-            _T* optPtr = Output + optIdx;
+            _T* optPtr = output + optIdx;
 
             memcpy(optPtr, iptPtr, memcpySize);
 
@@ -179,7 +179,7 @@ __device__ void brendancuda::CopyBlock(const _T* Input, _T* Output, const FixedV
 #endif
 
 template <typename _T, size_t _VectorLength, brendancuda::copyValFunc_t<_T> _CopyValFunc, bool _Wrap>
-__host__ __device__ void brendancuda::CopyBlock(const _T* Input, _T* Output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates) {
+__host__ __device__ void brendancuda::CopyBlock(const _T* Input, _T* output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates) {
     using vector_t = FixedVector<uint32_t, _VectorLength>;
 
     if constexpr (_Wrap) {
@@ -199,7 +199,7 @@ __host__ __device__ void brendancuda::CopyBlock(const _T* Input, _T* Output, con
                 rangeInOutputCoordinates[j] = landmark.outputIndex;
             }
 
-            CopyBlock<_T, _VectorLength, _CopyValFunc, false>(Input, Output, InputDimensions, OutputDimensions, rangeDimensions, rangeInInputCoordinates, rangeInOutputCoordinates);
+            CopyBlock<_T, _VectorLength, _CopyValFunc, false>(Input, output, InputDimensions, OutputDimensions, rangeDimensions, rangeInInputCoordinates, rangeInOutputCoordinates);
 
             bool toBreak = true;
             for (size_t j = 0; j < _VectorLength; ++j) {
@@ -215,8 +215,8 @@ __host__ __device__ void brendancuda::CopyBlock(const _T* Input, _T* Output, con
     }
     else {
         if constexpr (_VectorLength == 1) {
-            for (_T* ipu = Input + RangeDimensions.x; Input < ipu; ++Input, ++Output)
-                _CopyValFunc(Output + RangeInOutputsCoordinates.x, Input + RangeInInputsCoordinates.x);
+            for (_T* ipu = Input + RangeDimensions.x; Input < ipu; ++Input, ++output)
+                _CopyValFunc(output + RangeInOutputsCoordinates.x, Input + RangeInInputsCoordinates.x);
             return;
         }
         size_t elementNum = RangeDimensions[_VectorLength - 1];
@@ -226,7 +226,7 @@ __host__ __device__ void brendancuda::CopyBlock(const _T* Input, _T* Output, con
             size_t optIdx = CoordinatesToIndex<size_t, uint32_t, _VectorLength, true>(OutputDimensions, RangeInOutputsCoordinates + i);
 
             _T* iptPtr = Input + iptIdx;
-            _T* optPtr = Output + optIdx;
+            _T* optPtr = output + optIdx;
 
             for (_T* ipu = iptPtr + elementNum; iptPtr < ipu; ++iptPtr, ++optPtr)
                 _CopyValFunc(optPtr, iptPtr);
@@ -246,7 +246,7 @@ __host__ __device__ void brendancuda::CopyBlock(const _T* Input, _T* Output, con
 }
 
 template <typename _T, size_t _VectorLength, brendancuda::copyArrFunc_t<_T> _CopyArrFunc, bool _Wrap>
-__host__ __device__ void brendancuda::CopyBlock(const _T* Input, _T* Output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates) {
+__host__ __device__ void brendancuda::CopyBlock(const _T* Input, _T* output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates) {
     using vector_t = FixedVector<uint32_t, _VectorLength>;
 
     if constexpr (_Wrap) {
@@ -266,7 +266,7 @@ __host__ __device__ void brendancuda::CopyBlock(const _T* Input, _T* Output, con
                 rangeInOutputCoordinates[j] = landmark.outputIndex;
             }
 
-            CopyBlock<_T, _VectorLength, _CopyArrFunc, false>(Input, Output, InputDimensions, OutputDimensions, rangeDimensions, rangeInInputCoordinates, rangeInOutputCoordinates);
+            CopyBlock<_T, _VectorLength, _CopyArrFunc, false>(Input, output, InputDimensions, OutputDimensions, rangeDimensions, rangeInInputCoordinates, rangeInOutputCoordinates);
 
             bool toBreak = true;
             for (size_t j = 0; j < _VectorLength; ++j) {
@@ -282,7 +282,7 @@ __host__ __device__ void brendancuda::CopyBlock(const _T* Input, _T* Output, con
     }
     else {
         if constexpr (_VectorLength == 1) {
-            _CopyArrFunc(Output + RangeInOutputsCoordinates.x, Input + RangeInInputsCoordinates.x, RangeDimensions.x);
+            _CopyArrFunc(output + RangeInOutputsCoordinates.x, Input + RangeInInputsCoordinates.x, RangeDimensions.x);
             return;
         }
         size_t elementNum = RangeDimensions[_VectorLength - 1];
@@ -291,7 +291,7 @@ __host__ __device__ void brendancuda::CopyBlock(const _T* Input, _T* Output, con
             size_t iptIdx = CoordinatesToIndex<size_t, uint32_t, _VectorLength, true>(InputDimensions, RangeInInputsCoordinates + i);
             size_t optIdx = CoordinatesToIndex<size_t, uint32_t, _VectorLength, true>(OutputDimensions, RangeInOutputsCoordinates + i);
 
-            _CopyArrFunc(Output + optIdx, Input + iptIdx, elementNum);
+            _CopyArrFunc(output + optIdx, Input + iptIdx, elementNum);
 
             bool toBreak = true;
             for (size_t j = 1; j < _VectorLength; ++j) {

--- a/copyptr.h
+++ b/copyptr.h
@@ -3,7 +3,7 @@
 #include <memory>
 #include <type_traits>
 
-namespace BrendanCUDA {
+namespace brendancuda {
     template <typename _T>
     class CopyPtr {
         std::unique_ptr<_T> ptr;

--- a/copyptr.h
+++ b/copyptr.h
@@ -3,7 +3,7 @@
 #include <memory>
 #include <type_traits>
 
-namespace brendancuda {
+namespace bcuda {
     template <typename _T>
     class CopyPtr {
         std::unique_ptr<_T> ptr;

--- a/copytype.h
+++ b/copytype.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-namespace BrendanCUDA {
+namespace brendancuda {
     enum CopyType : uint32_t {
         copyTypeMemcpy,
         copyTypeCopyAssignment,

--- a/copytype.h
+++ b/copytype.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-namespace brendancuda {
+namespace bcuda {
     enum CopyType : uint32_t {
         copyTypeMemcpy,
         copyTypeCopyAssignment,

--- a/crossassigns.h
+++ b/crossassigns.h
@@ -3,7 +3,7 @@
 #include "errorhelp.h"
 #include <cuda_runtime.h>
 
-namespace brendancuda {
+namespace bcuda {
     template <typename _T>
     _T GetVR(_T* DevicePointer);
     template <typename _T>
@@ -11,13 +11,13 @@ namespace brendancuda {
 }
 
 template <typename _T>
-_T brendancuda::GetVR(_T* DevicePointer) {
+_T bcuda::GetVR(_T* DevicePointer) {
     _T v;
     ThrowIfBad(cudaMemcpy(&v, DevicePointer, sizeof(_T), cudaMemcpyDeviceToHost));
     return v;
 }
 
 template <typename _T>
-void brendancuda::SetVR(_T* DevicePointer, _T Value) {
+void bcuda::SetVR(_T* DevicePointer, _T Value) {
     ThrowIfBad(cudaMemcpy(DevicePointer, &Value, sizeof(_T), cudaMemcpyHostToDevice));
 }

--- a/crossassigns.h
+++ b/crossassigns.h
@@ -3,7 +3,7 @@
 #include "errorhelp.h"
 #include <cuda_runtime.h>
 
-namespace BrendanCUDA {
+namespace brendancuda {
     template <typename _T>
     _T GetVR(_T* DevicePointer);
     template <typename _T>
@@ -11,13 +11,13 @@ namespace BrendanCUDA {
 }
 
 template <typename _T>
-_T BrendanCUDA::GetVR(_T* DevicePointer) {
+_T brendancuda::GetVR(_T* DevicePointer) {
     _T v;
     ThrowIfBad(cudaMemcpy(&v, DevicePointer, sizeof(_T), cudaMemcpyDeviceToHost));
     return v;
 }
 
 template <typename _T>
-void BrendanCUDA::SetVR(_T* DevicePointer, _T Value) {
+void brendancuda::SetVR(_T* DevicePointer, _T Value) {
     ThrowIfBad(cudaMemcpy(DevicePointer, &Value, sizeof(_T), cudaMemcpyHostToDevice));
 }

--- a/cudaconstexpr.h
+++ b/cudaconstexpr.h
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace brendancuda {
+namespace bcuda {
 #ifdef __CUDA_ARCH__
     constexpr bool isCuda = true;
 #else

--- a/cudaconstexpr.h
+++ b/cudaconstexpr.h
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace BrendanCUDA {
+namespace brendancuda {
 #ifdef __CUDA_ARCH__
     constexpr bool isCuda = true;
 #else

--- a/curandkernelgens.h
+++ b/curandkernelgens.h
@@ -3,7 +3,7 @@
 #include <concepts>
 #include <curand_kernel.h>
 
-namespace brendancuda {
+namespace bcuda {
     template <typename _T>
     concept KernelCurandState =
         std::same_as<_T, curandStateMRG32k3a_t> ||

--- a/curandkernelgens.h
+++ b/curandkernelgens.h
@@ -3,7 +3,7 @@
 #include <concepts>
 #include <curand_kernel.h>
 
-namespace BrendanCUDA {
+namespace brendancuda {
     template <typename _T>
     concept KernelCurandState =
         std::same_as<_T, curandStateMRG32k3a_t> ||

--- a/details_dfieldbase.h
+++ b/details_dfieldbase.h
@@ -2,7 +2,7 @@
 
 #include "fields_field.h"
 
-namespace BrendanCUDA {
+namespace brendancuda {
     namespace details {
         template <typename _T, size_t _DimensionCount>
         class DFieldBase : public DimensionedBase<_DimensionCount> {

--- a/details_dfieldbase.h
+++ b/details_dfieldbase.h
@@ -40,17 +40,17 @@ namespace brendancuda {
             }
 
 #pragma region ProxyAccess
-            __host__ __device__ Fields::FieldProxy<_T, _DimensionCount> F() const {
-                return Fields::FieldProxy<_T, _DimensionCount>(this->Dimensions(), darrF);
+            __host__ __device__ fields::FieldProxy<_T, _DimensionCount> F() const {
+                return fields::FieldProxy<_T, _DimensionCount>(this->Dimensions(), darrF);
             }
-            __host__ __device__ Fields::FieldProxy<_T, _DimensionCount> B() const {
-                return Fields::FieldProxy<_T, _DimensionCount>(this->Dimensions(), darrB);
+            __host__ __device__ fields::FieldProxy<_T, _DimensionCount> B() const {
+                return fields::FieldProxy<_T, _DimensionCount>(this->Dimensions(), darrB);
             }
-            __host__ __device__ Fields::FieldProxyConst<_T, _DimensionCount> FConst() const {
-                return Fields::FieldProxyConst<_T, _DimensionCount>(this->Dimensions(), darrF);
+            __host__ __device__ fields::FieldProxyConst<_T, _DimensionCount> FConst() const {
+                return fields::FieldProxyConst<_T, _DimensionCount>(this->Dimensions(), darrF);
             }
-            __host__ __device__ Fields::FieldProxyConst<_T, _DimensionCount> BConst() const {
-                return Fields::FieldProxyConst<_T, _DimensionCount>(this->Dimensions(), darrB);
+            __host__ __device__ fields::FieldProxyConst<_T, _DimensionCount> BConst() const {
+                return fields::FieldProxyConst<_T, _DimensionCount>(this->Dimensions(), darrB);
             }
             __host__ __device__ _T* FData() const {
                 return darrF;

--- a/details_dfieldbase.h
+++ b/details_dfieldbase.h
@@ -2,7 +2,7 @@
 
 #include "fields_field.h"
 
-namespace brendancuda {
+namespace bcuda {
     namespace details {
         template <typename _T, size_t _DimensionCount>
         class DFieldBase : public DimensionedBase<_DimensionCount> {

--- a/details_dfieldbase.h
+++ b/details_dfieldbase.h
@@ -170,12 +170,12 @@ namespace brendancuda {
             }
 #endif
             template <bool _OutputOnHost>
-            __host__ __forceinline void CopyBlockOut(_T* Output, const this_t::vector_t& OutputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const {
-                F().CopyBlockOut<_OutputOnHost>(Output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
+            __host__ __forceinline void CopyBlockOut(_T* output, const this_t::vector_t& OutputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const {
+                F().CopyBlockOut<_OutputOnHost>(output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CopyBlockOut(_T* Output, const this_t::vector_t& OutputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const {
-                F().CopyBlockOut(Output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
+            __device__ __forceinline void CopyBlockOut(_T* output, const this_t::vector_t& OutputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const {
+                F().CopyBlockOut(output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #endif
 

--- a/details_fieldbase.h
+++ b/details_fieldbase.h
@@ -14,7 +14,7 @@
 #include <thrust/device_ptr.h>
 #include <type_traits>
 
-namespace BrendanCUDA {
+namespace brendancuda {
     namespace details {
         template <typename _T, size_t _DimensionCount>
         class FieldBase : public DimensionedBase<_DimensionCount> {
@@ -169,7 +169,7 @@ namespace BrendanCUDA {
 }
 
 template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline BrendanCUDA::details::FieldBase<_T, _DimensionCount>::FieldBase(const this_t::vector_t& Dimensions)
+__host__ __device__ __forceinline brendancuda::details::FieldBase<_T, _DimensionCount>::FieldBase(const this_t::vector_t& Dimensions)
     : basedb_t(Dimensions) {
     if (!(this->Length(0))) {
         darr = 0;
@@ -182,109 +182,109 @@ __host__ __device__ __forceinline BrendanCUDA::details::FieldBase<_T, _Dimension
 #endif
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline _T* BrendanCUDA::details::FieldBase<_T, _DimensionCount>::IdxToPtr(uint64_t Idx) const {
+__host__ __device__ __forceinline _T* brendancuda::details::FieldBase<_T, _DimensionCount>::IdxToPtr(uint64_t Idx) const {
     return darr + Idx;
 }
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline _T& BrendanCUDA::details::FieldBase<_T, _DimensionCount>::IdxToRef(uint64_t Idx) const {
+__device__ __forceinline _T& brendancuda::details::FieldBase<_T, _DimensionCount>::IdxToRef(uint64_t Idx) const {
     return darr[Idx];
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __forceinline thrust::device_reference<_T> BrendanCUDA::details::FieldBase<_T, _DimensionCount>::IdxToDRef(uint64_t Idx) const {
+__host__ __forceinline thrust::device_reference<_T> brendancuda::details::FieldBase<_T, _DimensionCount>::IdxToDRef(uint64_t Idx) const {
     return *thrust::device_ptr<_T>(darr + Idx);
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline _T* BrendanCUDA::details::FieldBase<_T, _DimensionCount>::CoordsToPtr(const this_t::vector_t& Coords) const {
+__host__ __device__ __forceinline _T* brendancuda::details::FieldBase<_T, _DimensionCount>::CoordsToPtr(const this_t::vector_t& Coords) const {
     return IdxToPtr(this->CoordsToIdx(Coords));
 }
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline _T& BrendanCUDA::details::FieldBase<_T, _DimensionCount>::CoordsToRef(const this_t::vector_t& Coords) const {
+__device__ __forceinline _T& brendancuda::details::FieldBase<_T, _DimensionCount>::CoordsToRef(const this_t::vector_t& Coords) const {
     return IdxToRef(this->CoordsToIdx(Coords));
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __forceinline thrust::device_reference<_T> BrendanCUDA::details::FieldBase<_T, _DimensionCount>::CoordsToDRef(const this_t::vector_t& Coords) const {
+__host__ __forceinline thrust::device_reference<_T> brendancuda::details::FieldBase<_T, _DimensionCount>::CoordsToDRef(const this_t::vector_t& Coords) const {
     return IdxToDRef(this->CoordsToIdx(Coords));
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline uint64_t BrendanCUDA::details::FieldBase<_T, _DimensionCount>::PtrToIdx(const _T* Ptr) const {
+__host__ __device__ __forceinline uint64_t brendancuda::details::FieldBase<_T, _DimensionCount>::PtrToIdx(const _T* Ptr) const {
     return Ptr - darr;
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline auto BrendanCUDA::details::FieldBase<_T, _DimensionCount>::PtrToCoords(const _T* Ptr) const -> this_t::vector_t {
+__host__ __device__ __forceinline auto brendancuda::details::FieldBase<_T, _DimensionCount>::PtrToCoords(const _T* Ptr) const -> this_t::vector_t {
     return this->IdxToCoords(PtrToIdx(Ptr));
 }
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline _T& BrendanCUDA::details::FieldBase<_T, _DimensionCount>::PtrToRef(const _T* Ptr) const {
+__device__ __forceinline _T& brendancuda::details::FieldBase<_T, _DimensionCount>::PtrToRef(const _T* Ptr) const {
     return *Ptr;
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __forceinline thrust::device_reference<_T> BrendanCUDA::details::FieldBase<_T, _DimensionCount>::PtrToDRef(const _T* Ptr) const {
+__host__ __forceinline thrust::device_reference<_T> brendancuda::details::FieldBase<_T, _DimensionCount>::PtrToDRef(const _T* Ptr) const {
     return *thrust::device_ptr<_T>(Ptr);
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __forceinline uint64_t BrendanCUDA::details::FieldBase<_T, _DimensionCount>::DRefToIdx(thrust::device_reference<const _T> Ref) const {
+__host__ __forceinline uint64_t brendancuda::details::FieldBase<_T, _DimensionCount>::DRefToIdx(thrust::device_reference<const _T> Ref) const {
     return PtrToIdx(RefToPtr(Ref));
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __forceinline uint64_t BrendanCUDA::details::FieldBase<_T, _DimensionCount>::DRefToIdx(thrust::device_reference<_T> Ref) const {
+__host__ __forceinline uint64_t brendancuda::details::FieldBase<_T, _DimensionCount>::DRefToIdx(thrust::device_reference<_T> Ref) const {
     return PtrToIdx(RefToPtr(Ref));
 }
 #ifdef __CUDACC__
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline uint64_t BrendanCUDA::details::FieldBase<_T, _DimensionCount>::RefToIdx(const _T& Ref) const {
+__device__ __forceinline uint64_t brendancuda::details::FieldBase<_T, _DimensionCount>::RefToIdx(const _T& Ref) const {
     return PtrToIdx(RefToPtr(Ref));
 }
 #endif
 template <typename _T, size_t _DimensionCount>
-__host__ __forceinline auto BrendanCUDA::details::FieldBase<_T, _DimensionCount>::DRefToCoords(thrust::device_reference<_T> Ref) const -> this_t::vector_t {
+__host__ __forceinline auto brendancuda::details::FieldBase<_T, _DimensionCount>::DRefToCoords(thrust::device_reference<_T> Ref) const -> this_t::vector_t {
     return PtrToCoords(RefToPtr(Ref));
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __forceinline auto BrendanCUDA::details::FieldBase<_T, _DimensionCount>::DRefToCoords(thrust::device_reference<const _T> Ref) const -> this_t::vector_t {
+__host__ __forceinline auto brendancuda::details::FieldBase<_T, _DimensionCount>::DRefToCoords(thrust::device_reference<const _T> Ref) const -> this_t::vector_t {
     return PtrToCoords(RefToPtr(Ref));
 }
 #ifdef __CUDACC__
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline auto BrendanCUDA::details::FieldBase<_T, _DimensionCount>::RefToCoords(const _T& Ref) const -> this_t::vector_t {
+__device__ __forceinline auto brendancuda::details::FieldBase<_T, _DimensionCount>::RefToCoords(const _T& Ref) const -> this_t::vector_t {
     return PtrToCoords(RefToPtr(Ref));
 }
 #endif
 template <typename _T, size_t _DimensionCount>
-__host__ __forceinline _T* BrendanCUDA::details::FieldBase<_T, _DimensionCount>::DRefToPtr(thrust::device_reference<_T> Ref) const {
+__host__ __forceinline _T* brendancuda::details::FieldBase<_T, _DimensionCount>::DRefToPtr(thrust::device_reference<_T> Ref) const {
     return (&Ref).get();
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __forceinline _T* BrendanCUDA::details::FieldBase<_T, _DimensionCount>::DRefToPtr(thrust::device_reference<const _T> Ref) const {
+__host__ __forceinline _T* brendancuda::details::FieldBase<_T, _DimensionCount>::DRefToPtr(thrust::device_reference<const _T> Ref) const {
     return (&Ref).get();
 }
 #ifdef __CUDACC__
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline _T* BrendanCUDA::details::FieldBase<_T, _DimensionCount>::RefToPtr(const _T& Ref) const {
+__device__ __forceinline _T* brendancuda::details::FieldBase<_T, _DimensionCount>::RefToPtr(const _T& Ref) const {
     return const_cast<_T*>(&Ref);
 }
 #endif
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline _T& BrendanCUDA::details::FieldBase<_T, _DimensionCount>::operator()(uint64_t Idx) const {
+__device__ __forceinline _T& brendancuda::details::FieldBase<_T, _DimensionCount>::operator()(uint64_t Idx) const {
     return IdxToRef(Idx);
 }
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline _T& BrendanCUDA::details::FieldBase<_T, _DimensionCount>::operator()(const this_t::vector_t& Coords) const {
+__device__ __forceinline _T& brendancuda::details::FieldBase<_T, _DimensionCount>::operator()(const this_t::vector_t& Coords) const {
     return CoordsToRef(Coords);
 }
 template <typename _T, size_t _DimensionCount>
 template <bool _CopyFromHost>
-__host__ __forceinline void BrendanCUDA::details::FieldBase<_T, _DimensionCount>::CpyAllIn(const _T* All) const {
+__host__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CpyAllIn(const _T* All) const {
     cudaMemcpy(darr, All, SizeOnGPU(), _CopyFromHost ? cudaMemcpyHostToDevice : cudaMemcpyDeviceToDevice);
 }
 #ifdef __CUDACC__
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline void BrendanCUDA::details::FieldBase<_T, _DimensionCount>::CpyAllIn(const _T* All) const {
+__device__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CpyAllIn(const _T* All) const {
     memcpy(darr, All, SizeOnGPU());
 }
 #endif
 template <typename _T, size_t _DimensionCount>
 template <bool _CopyToHost>
-__host__ __forceinline _T* BrendanCUDA::details::FieldBase<_T, _DimensionCount>::CpyAllOut() const {
+__host__ __forceinline _T* brendancuda::details::FieldBase<_T, _DimensionCount>::CpyAllOut() const {
     _T* all;
     if constexpr (_CopyToHost) cudaMalloc(&all, SizeOnGPU());
     else malloc(all);
@@ -295,7 +295,7 @@ __host__ __forceinline _T* BrendanCUDA::details::FieldBase<_T, _DimensionCount>:
 }
 #ifdef __CUDACC__
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline _T* BrendanCUDA::details::FieldBase<_T, _DimensionCount>::CpyAllOut() const {
+__device__ __forceinline _T* brendancuda::details::FieldBase<_T, _DimensionCount>::CpyAllOut() const {
     _T* all = malloc(SizeOnGPU());
 
     CpyAllOut(all);
@@ -305,17 +305,17 @@ __device__ __forceinline _T* BrendanCUDA::details::FieldBase<_T, _DimensionCount
 #endif
 template <typename _T, size_t _DimensionCount>
 template <bool _CopyToHost>
-__host__ __device__ __forceinline void BrendanCUDA::details::FieldBase<_T, _DimensionCount>::CpyAllOut(_T* All) const {
+__host__ __device__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CpyAllOut(_T* All) const {
     cudaMemcpy(All, darr, SizeOnGPU(), _CopyToHost ? cudaMemcpyDeviceToHost : cudaMemcpyDeviceToDevice);
 }
 #ifdef __CUDACC__
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline void BrendanCUDA::details::FieldBase<_T, _DimensionCount>::CpyAllOut(_T* All) const {
+__device__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CpyAllOut(_T* All) const {
     memcpy(All, darr, SizeOnGPU());
 }
 #endif
 template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline void BrendanCUDA::details::FieldBase<_T, _DimensionCount>::CpyValIn(uint64_t Idx, const _T& Val) const {
+__host__ __device__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CpyValIn(uint64_t Idx, const _T& Val) const {
 #ifdef __CUDA_ARCH__
     memcpy(IdxToPtr(Idx), &Val, sizeof(_T));
 #else
@@ -323,7 +323,7 @@ __host__ __device__ __forceinline void BrendanCUDA::details::FieldBase<_T, _Dime
 #endif
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline void BrendanCUDA::details::FieldBase<_T, _DimensionCount>::CpyValIn(const this_t::vector_t& Coords, const _T& Val) const {
+__host__ __device__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CpyValIn(const this_t::vector_t& Coords, const _T& Val) const {
 #ifdef __CUDA_ARCH__
     memcpy(CoordsToPtr(Coords), &Val, sizeof(_T));
 #else
@@ -332,28 +332,28 @@ __host__ __device__ __forceinline void BrendanCUDA::details::FieldBase<_T, _Dime
 }
 template <typename _T, size_t _DimensionCount>
 template <bool _CopyFromHost>
-__host__ __forceinline void BrendanCUDA::details::FieldBase<_T, _DimensionCount>::CpyValIn(uint64_t Idx, const _T* Val) const {
+__host__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CpyValIn(uint64_t Idx, const _T* Val) const {
     cudaMemcpy(IdxToPtr(Idx), Val, sizeof(_T), _CopyFromHost ? cudaMemcpyHostToDevice : cudaMemcpyDeviceToDevice);
 }
 #ifdef __CUDACC__
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline void BrendanCUDA::details::FieldBase<_T, _DimensionCount>::CpyValIn(uint64_t Idx, const _T* Val) const {
+__device__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CpyValIn(uint64_t Idx, const _T* Val) const {
     memcpy(IdxToPtr(Idx), Val, sizeof(_T));
 }
 #endif
 template <typename _T, size_t _DimensionCount>
 template <bool _CopyFromHost>
-__host__ __forceinline void BrendanCUDA::details::FieldBase<_T, _DimensionCount>::CpyValIn(const this_t::vector_t& Coords, const _T* Val) const {
+__host__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CpyValIn(const this_t::vector_t& Coords, const _T* Val) const {
     cudaMemcpy(CoordsToPtr(Coords), Val, sizeof(_T), _CopyFromHost ? cudaMemcpyHostToDevice : cudaMemcpyDeviceToDevice);
 }
 #ifdef __CUDACC__
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline void BrendanCUDA::details::FieldBase<_T, _DimensionCount>::CpyValIn(const this_t::vector_t& Coords, const _T* Val) const {
+__device__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CpyValIn(const this_t::vector_t& Coords, const _T* Val) const {
     memcpy(CoordsToPtr(Coords), &Val, sizeof(_T));
 }
 #endif
 template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline void BrendanCUDA::details::FieldBase<_T, _DimensionCount>::CpyValOut(uint64_t Idx, _T& Val) const {
+__host__ __device__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(uint64_t Idx, _T& Val) const {
 #ifdef __CUDA_ARCH__
     memcpy(&Val, IdxToPtr(Idx), sizeof(_T));
 #else
@@ -361,7 +361,7 @@ __host__ __device__ __forceinline void BrendanCUDA::details::FieldBase<_T, _Dime
 #endif
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline void BrendanCUDA::details::FieldBase<_T, _DimensionCount>::CpyValOut(const this_t::vector_t& Coords, _T& Val) const {
+__host__ __device__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(const this_t::vector_t& Coords, _T& Val) const {
 #ifdef __CUDA_ARCH__
     memcpy(&Val, CoordsToPtr(Coords), sizeof(_T));
 #else
@@ -370,40 +370,40 @@ __host__ __device__ __forceinline void BrendanCUDA::details::FieldBase<_T, _Dime
 }
 template <typename _T, size_t _DimensionCount>
 template <bool _CopyToHost>
-__host__ __forceinline void BrendanCUDA::details::FieldBase<_T, _DimensionCount>::CpyValOut(uint64_t Idx, _T* Val) const {
+__host__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(uint64_t Idx, _T* Val) const {
     cudaMemcpy(Val, IdxToPtr(Idx), sizeof(_T), _CopyToHost ? cudaMemcpyDeviceToHost : cudaMemcpyDeviceToDevice);
 }
 #ifdef __CUDACC__
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline void BrendanCUDA::details::FieldBase<_T, _DimensionCount>::CpyValOut(uint64_t Idx, _T* Val) const {
+__device__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(uint64_t Idx, _T* Val) const {
     memcpy(Val, IdxToPtr(Idx), sizeof(_T));
 }
 #endif
 template <typename _T, size_t _DimensionCount>
 template <bool _CopyToHost>
-__host__ __forceinline void BrendanCUDA::details::FieldBase<_T, _DimensionCount>::CpyValOut(const this_t::vector_t& Coords, _T* Val) const {
+__host__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(const this_t::vector_t& Coords, _T* Val) const {
     cudaMemcpy(Val, CoordsToPtr(Coords), sizeof(_T), _CopyToHost ? cudaMemcpyDeviceToHost : cudaMemcpyDeviceToDevice);
 }
 #ifdef __CUDACC__
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline void BrendanCUDA::details::FieldBase<_T, _DimensionCount>::CpyValOut(const this_t::vector_t& Coords, _T* Val) const {
+__device__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(const this_t::vector_t& Coords, _T* Val) const {
     memcpy(Val, CoordsToPtr(Coords), sizeof(_T));
 }
 #endif
 template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline _T BrendanCUDA::details::FieldBase<_T, _DimensionCount>::CpyValOut(uint64_t Idx) const {
+__host__ __device__ __forceinline _T brendancuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(uint64_t Idx) const {
     _T val;
     CpyValOut(Idx, val);
     return val;
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline _T BrendanCUDA::details::FieldBase<_T, _DimensionCount>::CpyValOut(const this_t::vector_t& Coords) const {
+__host__ __device__ __forceinline _T brendancuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(const this_t::vector_t& Coords) const {
     _T val;
     CpyValOut(Coords, val);
     return val;
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline void BrendanCUDA::details::FieldBase<_T, _DimensionCount>::Dispose() {
+__host__ __device__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::Dispose() {
 #ifdef __CUDA_ARCH__
     free(darr);
 #else
@@ -411,37 +411,37 @@ __host__ __device__ __forceinline void BrendanCUDA::details::FieldBase<_T, _Dime
 #endif
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline _T* BrendanCUDA::details::FieldBase<_T, _DimensionCount>::Data() const {
+__host__ __device__ __forceinline _T* brendancuda::details::FieldBase<_T, _DimensionCount>::Data() const {
     return darr;
 }
 template <typename _T, size_t _DimensionCount>
 template <bool _InputOnHost>
-__host__ __forceinline void BrendanCUDA::details::FieldBase<_T, _DimensionCount>::CopyBlockIn(const _T* Input, const this_t::vector_t& InputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const {
+__host__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CopyBlockIn(const _T* Input, const this_t::vector_t& InputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const {
     CopyBlock<_T, _DimensionCount, _InputOnHost, false, true>(Input, darr, InputDimensions, this->Dimensions(), RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
 }
 #ifdef __CUDACC__
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline void BrendanCUDA::details::FieldBase<_T, _DimensionCount>::CopyBlockIn(const _T* Input, const this_t::vector_t& InputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const {
+__device__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CopyBlockIn(const _T* Input, const this_t::vector_t& InputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const {
     CopyBlock<_T, _DimensionCount, true>(Input, darr, InputDimensions, this->Dimensions(), RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
 }
 #endif
 template <typename _T, size_t _DimensionCount>
 template <bool _OutputOnHost>
-__host__ __forceinline void BrendanCUDA::details::FieldBase<_T, _DimensionCount>::CopyBlockOut(_T* Output, const this_t::vector_t& OutputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const {
+__host__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CopyBlockOut(_T* Output, const this_t::vector_t& OutputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const {
     CopyBlock<_T, _DimensionCount, false, _OutputOnHost, true>(darr, Output, this->Dimensions(), OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
 }
 #ifdef __CUDACC__
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline void BrendanCUDA::details::FieldBase<_T, _DimensionCount>::CopyBlockOut(_T* Output, const this_t::vector_t& OutputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const {
+__device__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CopyBlockOut(_T* Output, const this_t::vector_t& OutputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const {
     CopyBlock<_T, _DimensionCount, true>(darr, Output, this->Dimensions(), OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
 }
 #endif
 template <typename _T, size_t _DimensionCount>
-__host__ __device__ auto BrendanCUDA::details::FieldBase<_T, _DimensionCount>::Clone() const -> this_t {
+__host__ __device__ auto brendancuda::details::FieldBase<_T, _DimensionCount>::Clone() const -> this_t {
     return FieldBase<_T, _DimensionCount>(this->Dimensions(), darr);
 }
 template <typename _T, size_t _DimensionCount>
-__forceinline size_t BrendanCUDA::details::FieldBase<_T, _DimensionCount>::SerializedSize() const requires BSerializer::Serializable<_T> {
+__forceinline size_t brendancuda::details::FieldBase<_T, _DimensionCount>::SerializedSize() const requires BSerializer::Serializable<_T> {
     size_t t = sizeof(uint32_t) * _DimensionCount;
     size_t l = this->ValueCount();
     for (size_t i = 0; i < l; ++i)
@@ -449,14 +449,14 @@ __forceinline size_t BrendanCUDA::details::FieldBase<_T, _DimensionCount>::Seria
     return t;
 }
 template <typename _T, size_t _DimensionCount>
-__forceinline void BrendanCUDA::details::FieldBase<_T, _DimensionCount>::Serialize(void*& Data) const requires BSerializer::Serializable<_T> {
+__forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::Serialize(void*& Data) const requires BSerializer::Serializable<_T> {
     BSerializer::Serialize<this_t::vector_t>(Data, this->Dimensions());
     size_t l = this->ValueCount();
     for (size_t i = 0; i < l; ++i)
         BSerializer::Serialize(Data, CpyValOut(i));
 }
 template <typename _T, size_t _DimensionCount>
-__forceinline auto BrendanCUDA::details::FieldBase<_T, _DimensionCount>::Deserialize(const void*& Data) -> this_t requires BSerializer::Serializable<_T> {
+__forceinline auto brendancuda::details::FieldBase<_T, _DimensionCount>::Deserialize(const void*& Data) -> this_t requires BSerializer::Serializable<_T> {
     typename basedb_t::vector_t dimensions = BSerializer::Deserialize<typename basedb_t::vector_t>(Data);
     FieldBase<_T, _DimensionCount> field(dimensions);
     size_t l = field.ValueCount();
@@ -465,6 +465,6 @@ __forceinline auto BrendanCUDA::details::FieldBase<_T, _DimensionCount>::Deseria
     return field;
 }
 template <typename _T, size_t _DimensionCount>
-__forceinline void BrendanCUDA::details::FieldBase<_T, _DimensionCount>::Deserialize(const void*& Data, void* Value) requires BSerializer::Serializable<_T> {
+__forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::Deserialize(const void*& Data, void* Value) requires BSerializer::Serializable<_T> {
     new (Value) FieldBase<_T, _DimensionCount>(Deserialize(Data));
 }

--- a/details_fieldbase.h
+++ b/details_fieldbase.h
@@ -151,9 +151,9 @@ namespace brendancuda {
             __device__ __forceinline void CopyBlockIn(const _T* Input, const this_t::vector_t& InputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const;
 #endif
             template <bool _OutputOnHost>
-            __host__ __forceinline void CopyBlockOut(_T* Output, const this_t::vector_t& OutputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const;
+            __host__ __forceinline void CopyBlockOut(_T* output, const this_t::vector_t& OutputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const;
 #ifdef __CUDACC__
-            __device__ __forceinline void CopyBlockOut(_T* Output, const this_t::vector_t& OutputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const;
+            __device__ __forceinline void CopyBlockOut(_T* output, const this_t::vector_t& OutputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const;
 #endif
             
             __host__ __device__ this_t Clone() const;
@@ -427,13 +427,13 @@ __device__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCoun
 #endif
 template <typename _T, size_t _DimensionCount>
 template <bool _OutputOnHost>
-__host__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CopyBlockOut(_T* Output, const this_t::vector_t& OutputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const {
-    CopyBlock<_T, _DimensionCount, false, _OutputOnHost, true>(darr, Output, this->Dimensions(), OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
+__host__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CopyBlockOut(_T* output, const this_t::vector_t& OutputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const {
+    CopyBlock<_T, _DimensionCount, false, _OutputOnHost, true>(darr, output, this->Dimensions(), OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
 }
 #ifdef __CUDACC__
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CopyBlockOut(_T* Output, const this_t::vector_t& OutputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const {
-    CopyBlock<_T, _DimensionCount, true>(darr, Output, this->Dimensions(), OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
+__device__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CopyBlockOut(_T* output, const this_t::vector_t& OutputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const {
+    CopyBlock<_T, _DimensionCount, true>(darr, output, this->Dimensions(), OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
 }
 #endif
 template <typename _T, size_t _DimensionCount>

--- a/details_fieldbase.h
+++ b/details_fieldbase.h
@@ -14,7 +14,7 @@
 #include <thrust/device_ptr.h>
 #include <type_traits>
 
-namespace brendancuda {
+namespace bcuda {
     namespace details {
         template <typename _T, size_t _DimensionCount>
         class FieldBase : public DimensionedBase<_DimensionCount> {
@@ -169,7 +169,7 @@ namespace brendancuda {
 }
 
 template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline brendancuda::details::FieldBase<_T, _DimensionCount>::FieldBase(const this_t::vector_t& Dimensions)
+__host__ __device__ __forceinline bcuda::details::FieldBase<_T, _DimensionCount>::FieldBase(const this_t::vector_t& Dimensions)
     : basedb_t(Dimensions) {
     if (!(this->Length(0))) {
         darr = 0;
@@ -182,109 +182,109 @@ __host__ __device__ __forceinline brendancuda::details::FieldBase<_T, _Dimension
 #endif
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline _T* brendancuda::details::FieldBase<_T, _DimensionCount>::IdxToPtr(uint64_t Idx) const {
+__host__ __device__ __forceinline _T* bcuda::details::FieldBase<_T, _DimensionCount>::IdxToPtr(uint64_t Idx) const {
     return darr + Idx;
 }
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline _T& brendancuda::details::FieldBase<_T, _DimensionCount>::IdxToRef(uint64_t Idx) const {
+__device__ __forceinline _T& bcuda::details::FieldBase<_T, _DimensionCount>::IdxToRef(uint64_t Idx) const {
     return darr[Idx];
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __forceinline thrust::device_reference<_T> brendancuda::details::FieldBase<_T, _DimensionCount>::IdxToDRef(uint64_t Idx) const {
+__host__ __forceinline thrust::device_reference<_T> bcuda::details::FieldBase<_T, _DimensionCount>::IdxToDRef(uint64_t Idx) const {
     return *thrust::device_ptr<_T>(darr + Idx);
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline _T* brendancuda::details::FieldBase<_T, _DimensionCount>::CoordsToPtr(const this_t::vector_t& Coords) const {
+__host__ __device__ __forceinline _T* bcuda::details::FieldBase<_T, _DimensionCount>::CoordsToPtr(const this_t::vector_t& Coords) const {
     return IdxToPtr(this->CoordsToIdx(Coords));
 }
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline _T& brendancuda::details::FieldBase<_T, _DimensionCount>::CoordsToRef(const this_t::vector_t& Coords) const {
+__device__ __forceinline _T& bcuda::details::FieldBase<_T, _DimensionCount>::CoordsToRef(const this_t::vector_t& Coords) const {
     return IdxToRef(this->CoordsToIdx(Coords));
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __forceinline thrust::device_reference<_T> brendancuda::details::FieldBase<_T, _DimensionCount>::CoordsToDRef(const this_t::vector_t& Coords) const {
+__host__ __forceinline thrust::device_reference<_T> bcuda::details::FieldBase<_T, _DimensionCount>::CoordsToDRef(const this_t::vector_t& Coords) const {
     return IdxToDRef(this->CoordsToIdx(Coords));
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline uint64_t brendancuda::details::FieldBase<_T, _DimensionCount>::PtrToIdx(const _T* Ptr) const {
+__host__ __device__ __forceinline uint64_t bcuda::details::FieldBase<_T, _DimensionCount>::PtrToIdx(const _T* Ptr) const {
     return Ptr - darr;
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline auto brendancuda::details::FieldBase<_T, _DimensionCount>::PtrToCoords(const _T* Ptr) const -> this_t::vector_t {
+__host__ __device__ __forceinline auto bcuda::details::FieldBase<_T, _DimensionCount>::PtrToCoords(const _T* Ptr) const -> this_t::vector_t {
     return this->IdxToCoords(PtrToIdx(Ptr));
 }
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline _T& brendancuda::details::FieldBase<_T, _DimensionCount>::PtrToRef(const _T* Ptr) const {
+__device__ __forceinline _T& bcuda::details::FieldBase<_T, _DimensionCount>::PtrToRef(const _T* Ptr) const {
     return *Ptr;
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __forceinline thrust::device_reference<_T> brendancuda::details::FieldBase<_T, _DimensionCount>::PtrToDRef(const _T* Ptr) const {
+__host__ __forceinline thrust::device_reference<_T> bcuda::details::FieldBase<_T, _DimensionCount>::PtrToDRef(const _T* Ptr) const {
     return *thrust::device_ptr<_T>(Ptr);
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __forceinline uint64_t brendancuda::details::FieldBase<_T, _DimensionCount>::DRefToIdx(thrust::device_reference<const _T> Ref) const {
+__host__ __forceinline uint64_t bcuda::details::FieldBase<_T, _DimensionCount>::DRefToIdx(thrust::device_reference<const _T> Ref) const {
     return PtrToIdx(RefToPtr(Ref));
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __forceinline uint64_t brendancuda::details::FieldBase<_T, _DimensionCount>::DRefToIdx(thrust::device_reference<_T> Ref) const {
+__host__ __forceinline uint64_t bcuda::details::FieldBase<_T, _DimensionCount>::DRefToIdx(thrust::device_reference<_T> Ref) const {
     return PtrToIdx(RefToPtr(Ref));
 }
 #ifdef __CUDACC__
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline uint64_t brendancuda::details::FieldBase<_T, _DimensionCount>::RefToIdx(const _T& Ref) const {
+__device__ __forceinline uint64_t bcuda::details::FieldBase<_T, _DimensionCount>::RefToIdx(const _T& Ref) const {
     return PtrToIdx(RefToPtr(Ref));
 }
 #endif
 template <typename _T, size_t _DimensionCount>
-__host__ __forceinline auto brendancuda::details::FieldBase<_T, _DimensionCount>::DRefToCoords(thrust::device_reference<_T> Ref) const -> this_t::vector_t {
+__host__ __forceinline auto bcuda::details::FieldBase<_T, _DimensionCount>::DRefToCoords(thrust::device_reference<_T> Ref) const -> this_t::vector_t {
     return PtrToCoords(RefToPtr(Ref));
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __forceinline auto brendancuda::details::FieldBase<_T, _DimensionCount>::DRefToCoords(thrust::device_reference<const _T> Ref) const -> this_t::vector_t {
+__host__ __forceinline auto bcuda::details::FieldBase<_T, _DimensionCount>::DRefToCoords(thrust::device_reference<const _T> Ref) const -> this_t::vector_t {
     return PtrToCoords(RefToPtr(Ref));
 }
 #ifdef __CUDACC__
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline auto brendancuda::details::FieldBase<_T, _DimensionCount>::RefToCoords(const _T& Ref) const -> this_t::vector_t {
+__device__ __forceinline auto bcuda::details::FieldBase<_T, _DimensionCount>::RefToCoords(const _T& Ref) const -> this_t::vector_t {
     return PtrToCoords(RefToPtr(Ref));
 }
 #endif
 template <typename _T, size_t _DimensionCount>
-__host__ __forceinline _T* brendancuda::details::FieldBase<_T, _DimensionCount>::DRefToPtr(thrust::device_reference<_T> Ref) const {
+__host__ __forceinline _T* bcuda::details::FieldBase<_T, _DimensionCount>::DRefToPtr(thrust::device_reference<_T> Ref) const {
     return (&Ref).get();
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __forceinline _T* brendancuda::details::FieldBase<_T, _DimensionCount>::DRefToPtr(thrust::device_reference<const _T> Ref) const {
+__host__ __forceinline _T* bcuda::details::FieldBase<_T, _DimensionCount>::DRefToPtr(thrust::device_reference<const _T> Ref) const {
     return (&Ref).get();
 }
 #ifdef __CUDACC__
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline _T* brendancuda::details::FieldBase<_T, _DimensionCount>::RefToPtr(const _T& Ref) const {
+__device__ __forceinline _T* bcuda::details::FieldBase<_T, _DimensionCount>::RefToPtr(const _T& Ref) const {
     return const_cast<_T*>(&Ref);
 }
 #endif
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline _T& brendancuda::details::FieldBase<_T, _DimensionCount>::operator()(uint64_t Idx) const {
+__device__ __forceinline _T& bcuda::details::FieldBase<_T, _DimensionCount>::operator()(uint64_t Idx) const {
     return IdxToRef(Idx);
 }
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline _T& brendancuda::details::FieldBase<_T, _DimensionCount>::operator()(const this_t::vector_t& Coords) const {
+__device__ __forceinline _T& bcuda::details::FieldBase<_T, _DimensionCount>::operator()(const this_t::vector_t& Coords) const {
     return CoordsToRef(Coords);
 }
 template <typename _T, size_t _DimensionCount>
 template <bool _CopyFromHost>
-__host__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CpyAllIn(const _T* All) const {
+__host__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyAllIn(const _T* All) const {
     cudaMemcpy(darr, All, SizeOnGPU(), _CopyFromHost ? cudaMemcpyHostToDevice : cudaMemcpyDeviceToDevice);
 }
 #ifdef __CUDACC__
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CpyAllIn(const _T* All) const {
+__device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyAllIn(const _T* All) const {
     memcpy(darr, All, SizeOnGPU());
 }
 #endif
 template <typename _T, size_t _DimensionCount>
 template <bool _CopyToHost>
-__host__ __forceinline _T* brendancuda::details::FieldBase<_T, _DimensionCount>::CpyAllOut() const {
+__host__ __forceinline _T* bcuda::details::FieldBase<_T, _DimensionCount>::CpyAllOut() const {
     _T* all;
     if constexpr (_CopyToHost) cudaMalloc(&all, SizeOnGPU());
     else malloc(all);
@@ -295,7 +295,7 @@ __host__ __forceinline _T* brendancuda::details::FieldBase<_T, _DimensionCount>:
 }
 #ifdef __CUDACC__
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline _T* brendancuda::details::FieldBase<_T, _DimensionCount>::CpyAllOut() const {
+__device__ __forceinline _T* bcuda::details::FieldBase<_T, _DimensionCount>::CpyAllOut() const {
     _T* all = malloc(SizeOnGPU());
 
     CpyAllOut(all);
@@ -305,17 +305,17 @@ __device__ __forceinline _T* brendancuda::details::FieldBase<_T, _DimensionCount
 #endif
 template <typename _T, size_t _DimensionCount>
 template <bool _CopyToHost>
-__host__ __device__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CpyAllOut(_T* All) const {
+__host__ __device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyAllOut(_T* All) const {
     cudaMemcpy(All, darr, SizeOnGPU(), _CopyToHost ? cudaMemcpyDeviceToHost : cudaMemcpyDeviceToDevice);
 }
 #ifdef __CUDACC__
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CpyAllOut(_T* All) const {
+__device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyAllOut(_T* All) const {
     memcpy(All, darr, SizeOnGPU());
 }
 #endif
 template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CpyValIn(uint64_t Idx, const _T& Val) const {
+__host__ __device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValIn(uint64_t Idx, const _T& Val) const {
 #ifdef __CUDA_ARCH__
     memcpy(IdxToPtr(Idx), &Val, sizeof(_T));
 #else
@@ -323,7 +323,7 @@ __host__ __device__ __forceinline void brendancuda::details::FieldBase<_T, _Dime
 #endif
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CpyValIn(const this_t::vector_t& Coords, const _T& Val) const {
+__host__ __device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValIn(const this_t::vector_t& Coords, const _T& Val) const {
 #ifdef __CUDA_ARCH__
     memcpy(CoordsToPtr(Coords), &Val, sizeof(_T));
 #else
@@ -332,28 +332,28 @@ __host__ __device__ __forceinline void brendancuda::details::FieldBase<_T, _Dime
 }
 template <typename _T, size_t _DimensionCount>
 template <bool _CopyFromHost>
-__host__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CpyValIn(uint64_t Idx, const _T* Val) const {
+__host__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValIn(uint64_t Idx, const _T* Val) const {
     cudaMemcpy(IdxToPtr(Idx), Val, sizeof(_T), _CopyFromHost ? cudaMemcpyHostToDevice : cudaMemcpyDeviceToDevice);
 }
 #ifdef __CUDACC__
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CpyValIn(uint64_t Idx, const _T* Val) const {
+__device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValIn(uint64_t Idx, const _T* Val) const {
     memcpy(IdxToPtr(Idx), Val, sizeof(_T));
 }
 #endif
 template <typename _T, size_t _DimensionCount>
 template <bool _CopyFromHost>
-__host__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CpyValIn(const this_t::vector_t& Coords, const _T* Val) const {
+__host__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValIn(const this_t::vector_t& Coords, const _T* Val) const {
     cudaMemcpy(CoordsToPtr(Coords), Val, sizeof(_T), _CopyFromHost ? cudaMemcpyHostToDevice : cudaMemcpyDeviceToDevice);
 }
 #ifdef __CUDACC__
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CpyValIn(const this_t::vector_t& Coords, const _T* Val) const {
+__device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValIn(const this_t::vector_t& Coords, const _T* Val) const {
     memcpy(CoordsToPtr(Coords), &Val, sizeof(_T));
 }
 #endif
 template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(uint64_t Idx, _T& Val) const {
+__host__ __device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(uint64_t Idx, _T& Val) const {
 #ifdef __CUDA_ARCH__
     memcpy(&Val, IdxToPtr(Idx), sizeof(_T));
 #else
@@ -361,7 +361,7 @@ __host__ __device__ __forceinline void brendancuda::details::FieldBase<_T, _Dime
 #endif
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(const this_t::vector_t& Coords, _T& Val) const {
+__host__ __device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(const this_t::vector_t& Coords, _T& Val) const {
 #ifdef __CUDA_ARCH__
     memcpy(&Val, CoordsToPtr(Coords), sizeof(_T));
 #else
@@ -370,40 +370,40 @@ __host__ __device__ __forceinline void brendancuda::details::FieldBase<_T, _Dime
 }
 template <typename _T, size_t _DimensionCount>
 template <bool _CopyToHost>
-__host__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(uint64_t Idx, _T* Val) const {
+__host__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(uint64_t Idx, _T* Val) const {
     cudaMemcpy(Val, IdxToPtr(Idx), sizeof(_T), _CopyToHost ? cudaMemcpyDeviceToHost : cudaMemcpyDeviceToDevice);
 }
 #ifdef __CUDACC__
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(uint64_t Idx, _T* Val) const {
+__device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(uint64_t Idx, _T* Val) const {
     memcpy(Val, IdxToPtr(Idx), sizeof(_T));
 }
 #endif
 template <typename _T, size_t _DimensionCount>
 template <bool _CopyToHost>
-__host__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(const this_t::vector_t& Coords, _T* Val) const {
+__host__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(const this_t::vector_t& Coords, _T* Val) const {
     cudaMemcpy(Val, CoordsToPtr(Coords), sizeof(_T), _CopyToHost ? cudaMemcpyDeviceToHost : cudaMemcpyDeviceToDevice);
 }
 #ifdef __CUDACC__
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(const this_t::vector_t& Coords, _T* Val) const {
+__device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(const this_t::vector_t& Coords, _T* Val) const {
     memcpy(Val, CoordsToPtr(Coords), sizeof(_T));
 }
 #endif
 template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline _T brendancuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(uint64_t Idx) const {
+__host__ __device__ __forceinline _T bcuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(uint64_t Idx) const {
     _T val;
     CpyValOut(Idx, val);
     return val;
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline _T brendancuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(const this_t::vector_t& Coords) const {
+__host__ __device__ __forceinline _T bcuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(const this_t::vector_t& Coords) const {
     _T val;
     CpyValOut(Coords, val);
     return val;
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::Dispose() {
+__host__ __device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::Dispose() {
 #ifdef __CUDA_ARCH__
     free(darr);
 #else
@@ -411,37 +411,37 @@ __host__ __device__ __forceinline void brendancuda::details::FieldBase<_T, _Dime
 #endif
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline _T* brendancuda::details::FieldBase<_T, _DimensionCount>::Data() const {
+__host__ __device__ __forceinline _T* bcuda::details::FieldBase<_T, _DimensionCount>::Data() const {
     return darr;
 }
 template <typename _T, size_t _DimensionCount>
 template <bool _InputOnHost>
-__host__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CopyBlockIn(const _T* Input, const this_t::vector_t& InputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const {
+__host__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CopyBlockIn(const _T* Input, const this_t::vector_t& InputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const {
     CopyBlock<_T, _DimensionCount, _InputOnHost, false, true>(Input, darr, InputDimensions, this->Dimensions(), RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
 }
 #ifdef __CUDACC__
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CopyBlockIn(const _T* Input, const this_t::vector_t& InputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const {
+__device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CopyBlockIn(const _T* Input, const this_t::vector_t& InputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const {
     CopyBlock<_T, _DimensionCount, true>(Input, darr, InputDimensions, this->Dimensions(), RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
 }
 #endif
 template <typename _T, size_t _DimensionCount>
 template <bool _OutputOnHost>
-__host__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CopyBlockOut(_T* output, const this_t::vector_t& OutputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const {
+__host__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CopyBlockOut(_T* output, const this_t::vector_t& OutputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const {
     CopyBlock<_T, _DimensionCount, false, _OutputOnHost, true>(darr, output, this->Dimensions(), OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
 }
 #ifdef __CUDACC__
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::CopyBlockOut(_T* output, const this_t::vector_t& OutputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const {
+__device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CopyBlockOut(_T* output, const this_t::vector_t& OutputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const {
     CopyBlock<_T, _DimensionCount, true>(darr, output, this->Dimensions(), OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
 }
 #endif
 template <typename _T, size_t _DimensionCount>
-__host__ __device__ auto brendancuda::details::FieldBase<_T, _DimensionCount>::Clone() const -> this_t {
+__host__ __device__ auto bcuda::details::FieldBase<_T, _DimensionCount>::Clone() const -> this_t {
     return FieldBase<_T, _DimensionCount>(this->Dimensions(), darr);
 }
 template <typename _T, size_t _DimensionCount>
-__forceinline size_t brendancuda::details::FieldBase<_T, _DimensionCount>::SerializedSize() const requires BSerializer::Serializable<_T> {
+__forceinline size_t bcuda::details::FieldBase<_T, _DimensionCount>::SerializedSize() const requires BSerializer::Serializable<_T> {
     size_t t = sizeof(uint32_t) * _DimensionCount;
     size_t l = this->ValueCount();
     for (size_t i = 0; i < l; ++i)
@@ -449,14 +449,14 @@ __forceinline size_t brendancuda::details::FieldBase<_T, _DimensionCount>::Seria
     return t;
 }
 template <typename _T, size_t _DimensionCount>
-__forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::Serialize(void*& Data) const requires BSerializer::Serializable<_T> {
+__forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::Serialize(void*& Data) const requires BSerializer::Serializable<_T> {
     BSerializer::Serialize<this_t::vector_t>(Data, this->Dimensions());
     size_t l = this->ValueCount();
     for (size_t i = 0; i < l; ++i)
         BSerializer::Serialize(Data, CpyValOut(i));
 }
 template <typename _T, size_t _DimensionCount>
-__forceinline auto brendancuda::details::FieldBase<_T, _DimensionCount>::Deserialize(const void*& Data) -> this_t requires BSerializer::Serializable<_T> {
+__forceinline auto bcuda::details::FieldBase<_T, _DimensionCount>::Deserialize(const void*& Data) -> this_t requires BSerializer::Serializable<_T> {
     typename basedb_t::vector_t dimensions = BSerializer::Deserialize<typename basedb_t::vector_t>(Data);
     FieldBase<_T, _DimensionCount> field(dimensions);
     size_t l = field.ValueCount();
@@ -465,6 +465,6 @@ __forceinline auto brendancuda::details::FieldBase<_T, _DimensionCount>::Deseria
     return field;
 }
 template <typename _T, size_t _DimensionCount>
-__forceinline void brendancuda::details::FieldBase<_T, _DimensionCount>::Deserialize(const void*& Data, void* Value) requires BSerializer::Serializable<_T> {
+__forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::Deserialize(const void*& Data, void* Value) requires BSerializer::Serializable<_T> {
     new (Value) FieldBase<_T, _DimensionCount>(Deserialize(Data));
 }

--- a/details_fillwith.cu
+++ b/details_fillwith.cu
@@ -7,6 +7,6 @@ __global__ void fillWithKernel(void* Array, void* Value, size_t ValueSize) {
     memcpy((uint8_t*)Array + blockIdx.x * ValueSize, Value, ValueSize);
 }
 
-__forceinline void brendancuda::details::FillWith(void* Array, size_t ArrayElementCount, void* Value, size_t ValueSize) {
+__forceinline void bcuda::details::FillWith(void* Array, size_t ArrayElementCount, void* Value, size_t ValueSize) {
     fillWithKernel<<<ArrayElementCount, 1>>>(Array, Value, ValueSize);
 }

--- a/details_fillwith.cu
+++ b/details_fillwith.cu
@@ -7,6 +7,6 @@ __global__ void fillWithKernel(void* Array, void* Value, size_t ValueSize) {
     memcpy((uint8_t*)Array + blockIdx.x * ValueSize, Value, ValueSize);
 }
 
-__forceinline void BrendanCUDA::details::FillWith(void* Array, size_t ArrayElementCount, void* Value, size_t ValueSize) {
+__forceinline void brendancuda::details::FillWith(void* Array, size_t ArrayElementCount, void* Value, size_t ValueSize) {
     fillWithKernel<<<ArrayElementCount, 1>>>(Array, Value, ValueSize);
 }

--- a/details_fillwith.h
+++ b/details_fillwith.h
@@ -3,7 +3,7 @@
 #include "errorhelp.h"
 #include <cuda_runtime.h>
 
-namespace brendancuda {
+namespace bcuda {
     namespace details {
         void FillWith(void* Array, size_t ArrayElementCount, void* Value, size_t ValueSize);
     }

--- a/details_fillwith.h
+++ b/details_fillwith.h
@@ -3,7 +3,7 @@
 #include "errorhelp.h"
 #include <cuda_runtime.h>
 
-namespace BrendanCUDA {
+namespace brendancuda {
     namespace details {
         void FillWith(void* Array, size_t ArrayElementCount, void* Value, size_t ValueSize);
     }

--- a/details_getintbin.h
+++ b/details_getintbin.h
@@ -4,7 +4,7 @@
 #include <curand_kernel.h>
 #include <random>
 
-namespace brendancuda {
+namespace bcuda {
     namespace details {
         template <std::integral _T, std::uniform_random_bit_generator _TRNG>
         __host__ static __forceinline _T GetIntBin(_TRNG& RNG) {

--- a/details_getintbin.h
+++ b/details_getintbin.h
@@ -4,7 +4,7 @@
 #include <curand_kernel.h>
 #include <random>
 
-namespace BrendanCUDA {
+namespace brendancuda {
     namespace details {
         template <std::integral _T, std::uniform_random_bit_generator _TRNG>
         __host__ static __forceinline _T GetIntBin(_TRNG& RNG) {

--- a/details_mfieldbase.h
+++ b/details_mfieldbase.h
@@ -45,7 +45,7 @@ namespace brendancuda {
             template <typename _T, uintmax_t _Idx>
             struct MFieldBase_SerializedSize {
                 static void Run(void** Arrs, size_t VCount, const FixedVector<uint32_t, _DimensionCount>& Dimensions, size_t& Total) {
-                    Total += Fields::FieldProxyConst<_T, _DimensionCount>(Dimensions, Arrs[_Idx]).SerializedSize();
+                    Total += fields::FieldProxyConst<_T, _DimensionCount>(Dimensions, Arrs[_Idx]).SerializedSize();
                 }
             };
         };
@@ -55,7 +55,7 @@ namespace brendancuda {
             template <typename _T, uintmax_t _Idx>
             struct MFieldBase_Serialize {
                 static void Run(void** Arrs, size_t VCount, const FixedVector<uint32_t, _DimensionCount>& Dimensions, void*& Data) {
-                    Fields::FieldProxyConst<_T, _DimensionCount>(Dimensions, Arrs[_Idx]).Serialize(Data);
+                    fields::FieldProxyConst<_T, _DimensionCount>(Dimensions, Arrs[_Idx]).Serialize(Data);
                 }
             };
         };
@@ -65,7 +65,7 @@ namespace brendancuda {
             template <typename _T, uintmax_t _Idx>
             struct MFieldBase_Deserialize {
                 static void Run(void** Arrs, size_t VCount, const FixedVector<uint32_t, _DimensionCount>& Dimensions, const void*& Data) {
-                    auto field = Fields::FieldProxy<_T, _DimensionCount>(Dimensions, Arrs[_Idx]);
+                    auto field = fields::FieldProxy<_T, _DimensionCount>(Dimensions, Arrs[_Idx]);
                     for (size_t i = 0; i < VCount; ++i)
                         field.CpyValIn(i, BSerializer::Deserialize<_T>(Data));
                 }
@@ -114,12 +114,12 @@ namespace brendancuda {
 
 #pragma region ProxyAccess
             template <size_t _Idx>
-            __host__ __device__ Fields::FieldProxy<element_t<_Idx>, _DimensionCount> F() const {
-                return Fields::FieldProxy<element_t<_Idx>, _DimensionCount>(this->Dimensions(), (element_t<_Idx>*)darrs[_Idx]);
+            __host__ __device__ fields::FieldProxy<element_t<_Idx>, _DimensionCount> F() const {
+                return fields::FieldProxy<element_t<_Idx>, _DimensionCount>(this->Dimensions(), (element_t<_Idx>*)darrs[_Idx]);
             }
             template <size_t _Idx>
-            __host__ __device__ Fields::FieldProxyConst<element_t<_Idx>, _DimensionCount> FConst() const {
-                return Fields::FieldProxyConst<element_t<_Idx>, _DimensionCount>(this->Dimensions(), (element_t<_Idx>*)darrs[_Idx]);
+            __host__ __device__ fields::FieldProxyConst<element_t<_Idx>, _DimensionCount> FConst() const {
+                return fields::FieldProxyConst<element_t<_Idx>, _DimensionCount>(this->Dimensions(), (element_t<_Idx>*)darrs[_Idx]);
             }
             template <size_t _Idx>
             __host__ __device__ element_t<_Idx>* FData() const {

--- a/details_mfieldbase.h
+++ b/details_mfieldbase.h
@@ -2,7 +2,7 @@
 
 #include "fields_field.h"
 
-namespace BrendanCUDA {
+namespace brendancuda {
     namespace details {
         template <template <typename, uintmax_t> typename _TFunction, uintmax_t _StartIndex, typename... _Ts>
         struct RunFunctionsOverTypeWrapper {

--- a/details_mfieldbase.h
+++ b/details_mfieldbase.h
@@ -2,7 +2,7 @@
 
 #include "fields_field.h"
 
-namespace brendancuda {
+namespace bcuda {
     namespace details {
         template <template <typename, uintmax_t> typename _TFunction, uintmax_t _StartIndex, typename... _Ts>
         struct RunFunctionsOverTypeWrapper {

--- a/dimensionedbase.h
+++ b/dimensionedbase.h
@@ -5,7 +5,7 @@
 #include <cuda_runtime.h>
 #include <thrust/device_reference.h>
 
-namespace BrendanCUDA {
+namespace brendancuda {
     template <size_t _DimensionCount>
     class DimensionedBase {
         static_assert(_DimensionCount, "_DimensionCount may not be zero.");
@@ -43,7 +43,7 @@ namespace BrendanCUDA {
 }
 
 template <size_t _DimensionCount>
-BrendanCUDA::DimensionedBase<_DimensionCount>::DimensionedBase(vector_t Dimensions) {
+brendancuda::DimensionedBase<_DimensionCount>::DimensionedBase(vector_t Dimensions) {
     for (size_t i = 0; i < _DimensionCount; ++i)
         if (!Dimensions[i]) {
             dims = vector_t();
@@ -52,43 +52,43 @@ BrendanCUDA::DimensionedBase<_DimensionCount>::DimensionedBase(vector_t Dimensio
     dims = Dimensions;
 }
 template <size_t _DimensionCount>
-__host__ __device__ __forceinline uint32_t BrendanCUDA::DimensionedBase<_DimensionCount>::LengthX() const requires (_DimensionCount <= 4) {
+__host__ __device__ __forceinline uint32_t brendancuda::DimensionedBase<_DimensionCount>::LengthX() const requires (_DimensionCount <= 4) {
     return dims.x;
 }
 template <size_t _DimensionCount>
-__host__ __device__ __forceinline uint32_t BrendanCUDA::DimensionedBase<_DimensionCount>::LengthY() const requires (_DimensionCount >= 2 && _DimensionCount <= 4) {
+__host__ __device__ __forceinline uint32_t brendancuda::DimensionedBase<_DimensionCount>::LengthY() const requires (_DimensionCount >= 2 && _DimensionCount <= 4) {
     return dims.y;
 }
 template <size_t _DimensionCount>
-__host__ __device__ __forceinline uint32_t BrendanCUDA::DimensionedBase<_DimensionCount>::LengthZ() const requires (_DimensionCount >= 3 && _DimensionCount <= 4) {
+__host__ __device__ __forceinline uint32_t brendancuda::DimensionedBase<_DimensionCount>::LengthZ() const requires (_DimensionCount >= 3 && _DimensionCount <= 4) {
     return dims.z;
 }
 template <size_t _DimensionCount>
-__host__ __device__ __forceinline uint32_t BrendanCUDA::DimensionedBase<_DimensionCount>::LengthW() const requires (_DimensionCount == 4) {
+__host__ __device__ __forceinline uint32_t brendancuda::DimensionedBase<_DimensionCount>::LengthW() const requires (_DimensionCount == 4) {
     return dims.w;
 }
 template <size_t _DimensionCount>
-__host__ __device__ __forceinline auto BrendanCUDA::DimensionedBase<_DimensionCount>::Dimensions() const -> vector_t {
+__host__ __device__ __forceinline auto brendancuda::DimensionedBase<_DimensionCount>::Dimensions() const -> vector_t {
     return dims;
 }
 template <size_t _DimensionCount>
-__host__ __device__ __forceinline dim3 BrendanCUDA::DimensionedBase<_DimensionCount>::DimensionsD() const requires (_DimensionCount <= 3) {
+__host__ __device__ __forceinline dim3 brendancuda::DimensionedBase<_DimensionCount>::DimensionsD() const requires (_DimensionCount <= 3) {
     if constexpr (_DimensionCount == 1) return dim3(dims.x);
     else if constexpr (_DimensionCount == 2) return dim3(dims.x, dims.y);
     else return dim3(dims.x, dims.y, dims.z);
 }
 template <size_t _DimensionCount>
-__host__ __device__ __forceinline size_t BrendanCUDA::DimensionedBase<_DimensionCount>::ValueCount() const {
+__host__ __device__ __forceinline size_t brendancuda::DimensionedBase<_DimensionCount>::ValueCount() const {
     size_t s = 1;
     for (size_t i = 0; i < _DimensionCount; ++i)
         s *= dims[i];
     return s;
 }
 template <size_t _DimensionCount>
-__host__ __device__ __forceinline uint64_t BrendanCUDA::DimensionedBase<_DimensionCount>::CoordsToIdx(vector_t Coords) const {
-    return BrendanCUDA::CoordinatesToIndex<uint64_t, uint32_t, _DimensionCount, true>(Dimensions(), Coords);
+__host__ __device__ __forceinline uint64_t brendancuda::DimensionedBase<_DimensionCount>::CoordsToIdx(vector_t Coords) const {
+    return brendancuda::CoordinatesToIndex<uint64_t, uint32_t, _DimensionCount, true>(Dimensions(), Coords);
 }
 template <size_t _DimensionCount>
-__host__ __device__ __forceinline auto BrendanCUDA::DimensionedBase<_DimensionCount>::IdxToCoords(uint64_t Idx) const -> vector_t {
-    return BrendanCUDA::IndexToCoordinates<uint64_t, uint32_t, _DimensionCount, true>(Dimensions(), Idx);
+__host__ __device__ __forceinline auto brendancuda::DimensionedBase<_DimensionCount>::IdxToCoords(uint64_t Idx) const -> vector_t {
+    return brendancuda::IndexToCoordinates<uint64_t, uint32_t, _DimensionCount, true>(Dimensions(), Idx);
 }

--- a/dimensionedbase.h
+++ b/dimensionedbase.h
@@ -5,7 +5,7 @@
 #include <cuda_runtime.h>
 #include <thrust/device_reference.h>
 
-namespace brendancuda {
+namespace bcuda {
     template <size_t _DimensionCount>
     class DimensionedBase {
         static_assert(_DimensionCount, "_DimensionCount may not be zero.");
@@ -43,7 +43,7 @@ namespace brendancuda {
 }
 
 template <size_t _DimensionCount>
-brendancuda::DimensionedBase<_DimensionCount>::DimensionedBase(vector_t Dimensions) {
+bcuda::DimensionedBase<_DimensionCount>::DimensionedBase(vector_t Dimensions) {
     for (size_t i = 0; i < _DimensionCount; ++i)
         if (!Dimensions[i]) {
             dims = vector_t();
@@ -52,43 +52,43 @@ brendancuda::DimensionedBase<_DimensionCount>::DimensionedBase(vector_t Dimensio
     dims = Dimensions;
 }
 template <size_t _DimensionCount>
-__host__ __device__ __forceinline uint32_t brendancuda::DimensionedBase<_DimensionCount>::LengthX() const requires (_DimensionCount <= 4) {
+__host__ __device__ __forceinline uint32_t bcuda::DimensionedBase<_DimensionCount>::LengthX() const requires (_DimensionCount <= 4) {
     return dims.x;
 }
 template <size_t _DimensionCount>
-__host__ __device__ __forceinline uint32_t brendancuda::DimensionedBase<_DimensionCount>::LengthY() const requires (_DimensionCount >= 2 && _DimensionCount <= 4) {
+__host__ __device__ __forceinline uint32_t bcuda::DimensionedBase<_DimensionCount>::LengthY() const requires (_DimensionCount >= 2 && _DimensionCount <= 4) {
     return dims.y;
 }
 template <size_t _DimensionCount>
-__host__ __device__ __forceinline uint32_t brendancuda::DimensionedBase<_DimensionCount>::LengthZ() const requires (_DimensionCount >= 3 && _DimensionCount <= 4) {
+__host__ __device__ __forceinline uint32_t bcuda::DimensionedBase<_DimensionCount>::LengthZ() const requires (_DimensionCount >= 3 && _DimensionCount <= 4) {
     return dims.z;
 }
 template <size_t _DimensionCount>
-__host__ __device__ __forceinline uint32_t brendancuda::DimensionedBase<_DimensionCount>::LengthW() const requires (_DimensionCount == 4) {
+__host__ __device__ __forceinline uint32_t bcuda::DimensionedBase<_DimensionCount>::LengthW() const requires (_DimensionCount == 4) {
     return dims.w;
 }
 template <size_t _DimensionCount>
-__host__ __device__ __forceinline auto brendancuda::DimensionedBase<_DimensionCount>::Dimensions() const -> vector_t {
+__host__ __device__ __forceinline auto bcuda::DimensionedBase<_DimensionCount>::Dimensions() const -> vector_t {
     return dims;
 }
 template <size_t _DimensionCount>
-__host__ __device__ __forceinline dim3 brendancuda::DimensionedBase<_DimensionCount>::DimensionsD() const requires (_DimensionCount <= 3) {
+__host__ __device__ __forceinline dim3 bcuda::DimensionedBase<_DimensionCount>::DimensionsD() const requires (_DimensionCount <= 3) {
     if constexpr (_DimensionCount == 1) return dim3(dims.x);
     else if constexpr (_DimensionCount == 2) return dim3(dims.x, dims.y);
     else return dim3(dims.x, dims.y, dims.z);
 }
 template <size_t _DimensionCount>
-__host__ __device__ __forceinline size_t brendancuda::DimensionedBase<_DimensionCount>::ValueCount() const {
+__host__ __device__ __forceinline size_t bcuda::DimensionedBase<_DimensionCount>::ValueCount() const {
     size_t s = 1;
     for (size_t i = 0; i < _DimensionCount; ++i)
         s *= dims[i];
     return s;
 }
 template <size_t _DimensionCount>
-__host__ __device__ __forceinline uint64_t brendancuda::DimensionedBase<_DimensionCount>::CoordsToIdx(vector_t Coords) const {
-    return brendancuda::CoordinatesToIndex<uint64_t, uint32_t, _DimensionCount, true>(Dimensions(), Coords);
+__host__ __device__ __forceinline uint64_t bcuda::DimensionedBase<_DimensionCount>::CoordsToIdx(vector_t Coords) const {
+    return bcuda::CoordinatesToIndex<uint64_t, uint32_t, _DimensionCount, true>(Dimensions(), Coords);
 }
 template <size_t _DimensionCount>
-__host__ __device__ __forceinline auto brendancuda::DimensionedBase<_DimensionCount>::IdxToCoords(uint64_t Idx) const -> vector_t {
-    return brendancuda::IndexToCoordinates<uint64_t, uint32_t, _DimensionCount, true>(Dimensions(), Idx);
+__host__ __device__ __forceinline auto bcuda::DimensionedBase<_DimensionCount>::IdxToCoords(uint64_t Idx) const -> vector_t {
+    return bcuda::IndexToCoordinates<uint64_t, uint32_t, _DimensionCount, true>(Dimensions(), Idx);
 }

--- a/errorhelp.h
+++ b/errorhelp.h
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace brendancuda {
+namespace bcuda {
     template <typename _T>
         requires (std::is_enum_v<_T> || std::integral<_T>)
     void ThrowIfBad(_T e) {

--- a/errorhelp.h
+++ b/errorhelp.h
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace BrendanCUDA {
+namespace brendancuda {
     template <typename _T>
         requires (std::is_enum_v<_T> || std::integral<_T>)
     void ThrowIfBad(_T e) {

--- a/exprs.h
+++ b/exprs.h
@@ -6,7 +6,7 @@
 #include <memory>
 #include <unordered_map>
 
-namespace brendancuda {
+namespace bcuda {
     namespace exprs {
         using varmap_t = std::unordered_map<uint64_t, std::any>;
 

--- a/exprs.h
+++ b/exprs.h
@@ -6,7 +6,7 @@
 #include <memory>
 #include <unordered_map>
 
-namespace BrendanCUDA {
+namespace brendancuda {
     namespace Exprs {
         using varmap_t = std::unordered_map<uint64_t, std::any>;
 

--- a/exprs.h
+++ b/exprs.h
@@ -7,7 +7,7 @@
 #include <unordered_map>
 
 namespace brendancuda {
-    namespace Exprs {
+    namespace exprs {
         using varmap_t = std::unordered_map<uint64_t, std::any>;
 
         struct ExprBase {
@@ -821,11 +821,11 @@ namespace brendancuda {
     }
     template <typename _T>
     struct Expression {
-        std::unique_ptr<Exprs::Expr<_T>> ptr;
+        std::unique_ptr<exprs::Expr<_T>> ptr;
 
         Expression(std::nullptr_t = nullptr)
             : ptr(nullptr) { }
-        Expression(std::unique_ptr<Exprs::Expr<_T>>&& Ptr)
+        Expression(std::unique_ptr<exprs::Expr<_T>>&& Ptr)
             : ptr(Ptr) { }
         Expression(const Expression<_T>& OtherExpr)
             : ptr(OtherExpr.ptr->Clone()) { }
@@ -836,7 +836,7 @@ namespace brendancuda {
             return *this;
         }
 
-        _T Calculate(const Exprs::varmap_t& Map) {
+        _T Calculate(const exprs::varmap_t& Map) {
             return ptr->Calc(Map);
         }
     };

--- a/fields_dfield.h
+++ b/fields_dfield.h
@@ -192,12 +192,12 @@ namespace brendancuda {
             }
 #endif
             template <bool _OutputOnHost>
-            __host__ __forceinline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
-                basefb_t::template CopyBlockOut<_OutputOnHost>(Output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
+            __host__ __forceinline void CopyBlockOut(_T* output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
+                basefb_t::template CopyBlockOut<_OutputOnHost>(output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
-                basefb_t::CopyBlockOut(Output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
+            __device__ __forceinline void CopyBlockOut(_T* output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
+                basefb_t::CopyBlockOut(output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #endif
             __forceinline size_t SerializedSize() const requires BSerializer::Serializable<_T> {
@@ -411,12 +411,12 @@ namespace brendancuda {
             }
 #endif
             template <bool _OutputOnHost>
-            __host__ __forceinline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
-                basefb_t::template CopyBlockOut<_OutputOnHost>(Output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
+            __host__ __forceinline void CopyBlockOut(_T* output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
+                basefb_t::template CopyBlockOut<_OutputOnHost>(output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
-                basefb_t::CopyBlockOut(Output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
+            __device__ __forceinline void CopyBlockOut(_T* output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
+                basefb_t::CopyBlockOut(output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #endif
             __forceinline size_t SerializedSize() const requires BSerializer::Serializable<_T> {
@@ -545,12 +545,12 @@ namespace brendancuda {
                 return basefb_t::CpyValOut(Coords);
             }
             template <bool _OutputOnHost>
-            __host__ __forceinline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
-                basefb_t::template CopyBlockOut<_OutputOnHost>(Output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
+            __host__ __forceinline void CopyBlockOut(_T* output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
+                basefb_t::template CopyBlockOut<_OutputOnHost>(output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
-                basefb_t::CopyBlockOut(Output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
+            __device__ __forceinline void CopyBlockOut(_T* output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
+                basefb_t::CopyBlockOut(output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #endif
             __forceinline size_t SerializedSize() const requires BSerializer::Serializable<_T> {

--- a/fields_dfield.h
+++ b/fields_dfield.h
@@ -6,7 +6,7 @@
 #include <stdexcept>
 #include <string>
 
-namespace BrendanCUDA {
+namespace brendancuda {
     namespace details {
         template <typename _T, size_t _DimensionCount>
         using dfieldIK_t = void(*)(FixedVector<uint32_t, _DimensionCount> Pos, Fields::FieldProxyConst<_T, _DimensionCount> Previous, _T& NextVal);

--- a/fields_dfield.h
+++ b/fields_dfield.h
@@ -9,9 +9,9 @@
 namespace brendancuda {
     namespace details {
         template <typename _T, size_t _DimensionCount>
-        using dfieldIK_t = void(*)(FixedVector<uint32_t, _DimensionCount> Pos, Fields::FieldProxyConst<_T, _DimensionCount> Previous, _T& NextVal);
+        using dfieldIK_t = void(*)(FixedVector<uint32_t, _DimensionCount> Pos, fields::FieldProxyConst<_T, _DimensionCount> Previous, _T& NextVal);
     }
-    namespace Fields {
+    namespace fields {
         template <typename _T, size_t _DimensionCount>
         class DField;
         template <typename _T, size_t _DimensionCount>
@@ -74,16 +74,16 @@ namespace brendancuda {
             __host__ __device__ __forceinline size_t SizeOnGPU() const {
                 return basefb_t::SizeOnGPU();
             }
-            __host__ __device__ Fields::FieldProxy<_T, _DimensionCount> F() {
+            __host__ __device__ fields::FieldProxy<_T, _DimensionCount> F() {
                 return basefb_t::F();
             }
-            __host__ __device__ Fields::FieldProxy<_T, _DimensionCount> B() {
+            __host__ __device__ fields::FieldProxy<_T, _DimensionCount> B() {
                 return basefb_t::B();
             }
-            __host__ __device__ Fields::FieldProxyConst<_T, _DimensionCount> FConst() const {
+            __host__ __device__ fields::FieldProxyConst<_T, _DimensionCount> FConst() const {
                 return basefb_t::FConst();
             }
-            __host__ __device__ Fields::FieldProxyConst<_T, _DimensionCount> BConst() const {
+            __host__ __device__ fields::FieldProxyConst<_T, _DimensionCount> BConst() const {
                 return basefb_t::BConst();
             }
             __host__ __device__ _T* FData() {
@@ -302,16 +302,16 @@ namespace brendancuda {
             __host__ __device__ __forceinline size_t SizeOnGPU() const {
                 return basefb_t::SizeOnGPU();
             }
-            __host__ __device__ Fields::FieldProxy<_T, _DimensionCount> F() const {
+            __host__ __device__ fields::FieldProxy<_T, _DimensionCount> F() const {
                 return basefb_t::F();
             }
-            __host__ __device__ Fields::FieldProxy<_T, _DimensionCount> B() const {
+            __host__ __device__ fields::FieldProxy<_T, _DimensionCount> B() const {
                 return basefb_t::B();
             }
-            __host__ __device__ Fields::FieldProxyConst<_T, _DimensionCount> FConst() const {
+            __host__ __device__ fields::FieldProxyConst<_T, _DimensionCount> FConst() const {
                 return basefb_t::FConst();
             }
-            __host__ __device__ Fields::FieldProxyConst<_T, _DimensionCount> BConst() const {
+            __host__ __device__ fields::FieldProxyConst<_T, _DimensionCount> BConst() const {
                 return basefb_t::BConst();
             }
             __host__ __device__ _T* FData() const {
@@ -484,10 +484,10 @@ namespace brendancuda {
             __host__ __device__ __forceinline size_t SizeOnGPU() const {
                 return basefb_t::SizeOnGPU();
             }
-            __host__ __device__ Fields::FieldProxyConst<_T, _DimensionCount> FConst() const {
+            __host__ __device__ fields::FieldProxyConst<_T, _DimensionCount> FConst() const {
                 return basefb_t::FConst();
             }
-            __host__ __device__ Fields::FieldProxyConst<_T, _DimensionCount> BConst() const {
+            __host__ __device__ fields::FieldProxyConst<_T, _DimensionCount> BConst() const {
                 return basefb_t::BConst();
             }
             __host__ __device__ const _T* FData() const {

--- a/fields_dfield.h
+++ b/fields_dfield.h
@@ -6,7 +6,7 @@
 #include <stdexcept>
 #include <string>
 
-namespace brendancuda {
+namespace bcuda {
     namespace details {
         template <typename _T, size_t _DimensionCount>
         using dfieldIK_t = void(*)(FixedVector<uint32_t, _DimensionCount> Pos, fields::FieldProxyConst<_T, _DimensionCount> Previous, _T& NextVal);

--- a/fields_field.h
+++ b/fields_field.h
@@ -317,12 +317,12 @@ namespace brendancuda {
             }
 #endif
             template <bool _OutputOnHost>
-            __host__ __forceinline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
-                basefb_t::template CopyBlockOut<_OutputOnHost>(Output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
+            __host__ __forceinline void CopyBlockOut(_T* output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
+                basefb_t::template CopyBlockOut<_OutputOnHost>(output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
-                basefb_t::CopyBlockOut(Output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
+            __device__ __forceinline void CopyBlockOut(_T* output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
+                basefb_t::CopyBlockOut(output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #endif
             __forceinline size_t SerializedSize() const requires BSerializer::Serializable<_T> {
@@ -614,12 +614,12 @@ namespace brendancuda {
             }
 #endif
             template <bool _OutputOnHost>
-            __host__ __forceinline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
-                basefb_t::template CopyBlockOut<_OutputOnHost>(Output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
+            __host__ __forceinline void CopyBlockOut(_T* output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
+                basefb_t::template CopyBlockOut<_OutputOnHost>(output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
-                basefb_t::CopyBlockOut(Output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
+            __device__ __forceinline void CopyBlockOut(_T* output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
+                basefb_t::CopyBlockOut(output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #endif
             __forceinline size_t SerializedSize() const requires BSerializer::Serializable<_T> {
@@ -837,12 +837,12 @@ namespace brendancuda {
                 return basefb_t::Data();
             }
             template <bool _OutputOnHost>
-            __host__ __forceinline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
-                basefb_t::template CopyBlockOut<_OutputOnHost>(Output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
+            __host__ __forceinline void CopyBlockOut(_T* output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
+                basefb_t::template CopyBlockOut<_OutputOnHost>(output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
-                basefb_t::CopyBlockOut(Output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
+            __device__ __forceinline void CopyBlockOut(_T* output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
+                basefb_t::CopyBlockOut(output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #endif
             __forceinline size_t SerializedSize() const requires BSerializer::Serializable<_T> {

--- a/fields_field.h
+++ b/fields_field.h
@@ -7,7 +7,7 @@
 #include <thrust/device_ptr.h>
 
 namespace brendancuda {
-    namespace Fields {
+    namespace fields {
         template <typename _T, size_t _DimensionCount>
         class Field;
         template <typename _T, size_t _DimensionCount>

--- a/fields_field.h
+++ b/fields_field.h
@@ -6,7 +6,7 @@
 #include <memory>
 #include <thrust/device_ptr.h>
 
-namespace brendancuda {
+namespace bcuda {
     namespace fields {
         template <typename _T, size_t _DimensionCount>
         class Field;

--- a/fields_field.h
+++ b/fields_field.h
@@ -6,7 +6,7 @@
 #include <memory>
 #include <thrust/device_ptr.h>
 
-namespace BrendanCUDA {
+namespace brendancuda {
     namespace Fields {
         template <typename _T, size_t _DimensionCount>
         class Field;

--- a/fields_instance.h
+++ b/fields_instance.h
@@ -14,7 +14,7 @@ namespace brendancuda {
             ArrayV<size_t> outputs;
             void* obj;
             void* objectRunner_sharedData;
-            Random::AnyRNG<uint32_t> rng;
+            random::AnyRNG<uint32_t> rng;
         };
     }
     namespace fields {
@@ -23,7 +23,7 @@ namespace brendancuda {
         template <typename _T, size_t _DimensionCount>
         using fieldInstance_createField_t = DField<_T, _DimensionCount>*(*)(void* SharedData);
         struct FieldInstance_Construct_Settings final {
-            Random::AnyRNG<uint32_t> rng;
+            random::AnyRNG<uint32_t> rng;
             void* objectRunner_sharedData;
             void* createField_sharedData;
             size_t inputCount;
@@ -54,7 +54,7 @@ namespace brendancuda {
 template <typename _T, size_t _DimensionCount, brendancuda::fields::fieldInstance_createField_t<_T, _DimensionCount> _CreateField>
 void* brendancuda::fields::FieldInstance_Construct(void* Object, void* Settings) {
     FieldInstance_Construct_Settings settings = *(FieldInstance_Construct_Settings*)Settings;
-    Random::AnyRNG<uint32_t>& rng = settings.rng;
+    random::AnyRNG<uint32_t>& rng = settings.rng;
 
     details::FieldInstance_CurrentInstance<_T, _DimensionCount>* p_rv = new details::FieldInstance_CurrentInstance<_T, _DimensionCount>{ _CreateField(settings.createField_sharedData), ArrayV<uint32_3>(settings.inputCount), ArrayV<uint32_3>(settings.outputCount), Object, settings.objectRunner_sharedData, rng };
     details::FieldInstance_CurrentInstance<_T, _DimensionCount>& rv = *p_rv;

--- a/fields_instance.h
+++ b/fields_instance.h
@@ -42,12 +42,12 @@ namespace brendancuda {
         template <typename _T, size_t _DimensionCount>
         void FieldInstance_Destruct(void* CurrentInstance);
         template <typename _T, size_t _DimensionCount, fieldInstance_createField_t<_T, _DimensionCount> _CreateField, fieldInstance_objectRunner_t<_T, _DimensionCount> _ObjectRunner>
-        ai::evolution::evaluation::output::InstanceFunctions<_T*, _T*> FieldInstance();
+        ai::evol::evaluation::output::InstanceFunctions<_T*, _T*> FieldInstance();
 
         template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
         _TOutput* FieldInstance_Iterate(void* CurrentInstance, _TInput* Inputs);
         template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, fieldInstance_createField_t<_TFieldValue, _DimensionCount> _CreateField, fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
-        ai::evolution::evaluation::output::InstanceFunctions<_TInput*, _TOutput*> FieldInstance();
+        ai::evol::evaluation::output::InstanceFunctions<_TInput*, _TOutput*> FieldInstance();
     }
 }
 
@@ -112,8 +112,8 @@ void brendancuda::fields::FieldInstance_Destruct(void* CurrentInstance) {
 };
 
 template <typename _T, size_t _DimensionCount, brendancuda::fields::fieldInstance_createField_t<_T, _DimensionCount> _CreateField, brendancuda::fields::fieldInstance_objectRunner_t<_T, _DimensionCount> _ObjectRunner>
-brendancuda::ai::evolution::evaluation::output::InstanceFunctions<_T*, _T*> brendancuda::fields::FieldInstance() {
-    ai::evolution::evaluation::output::InstanceFunctions<_T*, _T*> ifs;
+brendancuda::ai::evol::evaluation::output::InstanceFunctions<_T*, _T*> brendancuda::fields::FieldInstance() {
+    ai::evol::evaluation::output::InstanceFunctions<_T*, _T*> ifs;
     ifs.constructInstance = FieldInstance_Construct<_T, _DimensionCount, _CreateField>;
     ifs.iterateInstance = FieldInstance_Iterate<_T, _DimensionCount, _ObjectRunner>;
     ifs.destructInstance = FieldInstance_Destruct<_T, _DimensionCount>;
@@ -150,8 +150,8 @@ _TOutput* brendancuda::fields::FieldInstance_Iterate(void* CurrentInstance, _TIn
 }
 
 template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, brendancuda::fields::fieldInstance_createField_t<_TFieldValue, _DimensionCount> _CreateField, brendancuda::fields::fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, brendancuda::fields::fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, brendancuda::fields::fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
-brendancuda::ai::evolution::evaluation::output::InstanceFunctions<_TInput*, _TOutput*> brendancuda::fields::FieldInstance() {
-    ai::evolution::evaluation::output::InstanceFunctions<_TInput*, _TOutput*> ifs;
+brendancuda::ai::evol::evaluation::output::InstanceFunctions<_TInput*, _TOutput*> brendancuda::fields::FieldInstance() {
+    ai::evol::evaluation::output::InstanceFunctions<_TInput*, _TOutput*> ifs;
     ifs.constructInstance = FieldInstance_Construct<_TFieldValue, _DimensionCount, _CreateField>;
     ifs.iterateInstance = FieldInstance_Iterate<_TFieldValue, _DimensionCount, _TInput, _TOutput, _AssignInput, _GetOutput, _ObjectRunner>;
     ifs.destructInstance = FieldInstance_Destruct<_TFieldValue, _DimensionCount>;

--- a/fields_instance.h
+++ b/fields_instance.h
@@ -42,12 +42,12 @@ namespace brendancuda {
         template <typename _T, size_t _DimensionCount>
         void FieldInstance_Destruct(void* CurrentInstance);
         template <typename _T, size_t _DimensionCount, fieldInstance_createField_t<_T, _DimensionCount> _CreateField, fieldInstance_objectRunner_t<_T, _DimensionCount> _ObjectRunner>
-        ai::evol::evaluation::output::InstanceFunctions<_T*, _T*> FieldInstance();
+        ai::evol::eval::output::InstanceFunctions<_T*, _T*> FieldInstance();
 
         template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
         _TOutput* FieldInstance_Iterate(void* CurrentInstance, _TInput* Inputs);
         template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, fieldInstance_createField_t<_TFieldValue, _DimensionCount> _CreateField, fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
-        ai::evol::evaluation::output::InstanceFunctions<_TInput*, _TOutput*> FieldInstance();
+        ai::evol::eval::output::InstanceFunctions<_TInput*, _TOutput*> FieldInstance();
     }
 }
 
@@ -112,8 +112,8 @@ void brendancuda::fields::FieldInstance_Destruct(void* CurrentInstance) {
 };
 
 template <typename _T, size_t _DimensionCount, brendancuda::fields::fieldInstance_createField_t<_T, _DimensionCount> _CreateField, brendancuda::fields::fieldInstance_objectRunner_t<_T, _DimensionCount> _ObjectRunner>
-brendancuda::ai::evol::evaluation::output::InstanceFunctions<_T*, _T*> brendancuda::fields::FieldInstance() {
-    ai::evol::evaluation::output::InstanceFunctions<_T*, _T*> ifs;
+brendancuda::ai::evol::eval::output::InstanceFunctions<_T*, _T*> brendancuda::fields::FieldInstance() {
+    ai::evol::eval::output::InstanceFunctions<_T*, _T*> ifs;
     ifs.constructInstance = FieldInstance_Construct<_T, _DimensionCount, _CreateField>;
     ifs.iterateInstance = FieldInstance_Iterate<_T, _DimensionCount, _ObjectRunner>;
     ifs.destructInstance = FieldInstance_Destruct<_T, _DimensionCount>;
@@ -150,8 +150,8 @@ _TOutput* brendancuda::fields::FieldInstance_Iterate(void* CurrentInstance, _TIn
 }
 
 template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, brendancuda::fields::fieldInstance_createField_t<_TFieldValue, _DimensionCount> _CreateField, brendancuda::fields::fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, brendancuda::fields::fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, brendancuda::fields::fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
-brendancuda::ai::evol::evaluation::output::InstanceFunctions<_TInput*, _TOutput*> brendancuda::fields::FieldInstance() {
-    ai::evol::evaluation::output::InstanceFunctions<_TInput*, _TOutput*> ifs;
+brendancuda::ai::evol::eval::output::InstanceFunctions<_TInput*, _TOutput*> brendancuda::fields::FieldInstance() {
+    ai::evol::eval::output::InstanceFunctions<_TInput*, _TOutput*> ifs;
     ifs.constructInstance = FieldInstance_Construct<_TFieldValue, _DimensionCount, _CreateField>;
     ifs.iterateInstance = FieldInstance_Iterate<_TFieldValue, _DimensionCount, _TInput, _TOutput, _AssignInput, _GetOutput, _ObjectRunner>;
     ifs.destructInstance = FieldInstance_Destruct<_TFieldValue, _DimensionCount>;

--- a/fields_instance.h
+++ b/fields_instance.h
@@ -5,7 +5,7 @@
 #include "rand_anyrng.h"
 #include <tuple>
 
-namespace brendancuda {
+namespace bcuda {
     namespace details {
         template <typename _T, size_t _DimensionCount>
         struct FieldInstance_CurrentInstance final {
@@ -51,8 +51,8 @@ namespace brendancuda {
     }
 }
 
-template <typename _T, size_t _DimensionCount, brendancuda::fields::fieldInstance_createField_t<_T, _DimensionCount> _CreateField>
-void* brendancuda::fields::FieldInstance_Construct(void* Object, void* Settings) {
+template <typename _T, size_t _DimensionCount, bcuda::fields::fieldInstance_createField_t<_T, _DimensionCount> _CreateField>
+void* bcuda::fields::FieldInstance_Construct(void* Object, void* Settings) {
     FieldInstance_Construct_Settings settings = *(FieldInstance_Construct_Settings*)Settings;
     random::AnyRNG<uint32_t>& rng = settings.rng;
 
@@ -82,8 +82,8 @@ void* brendancuda::fields::FieldInstance_Construct(void* Object, void* Settings)
 
     return p_rv;
 };
-template <typename _T, size_t _DimensionCount, brendancuda::fields::fieldInstance_objectRunner_t<_T, _DimensionCount> _ObjectRunner>
-_T* brendancuda::fields::FieldInstance_Iterate(void* CurrentInstance, _T* Inputs) {
+template <typename _T, size_t _DimensionCount, bcuda::fields::fieldInstance_objectRunner_t<_T, _DimensionCount> _ObjectRunner>
+_T* bcuda::fields::FieldInstance_Iterate(void* CurrentInstance, _T* Inputs) {
     details::FieldInstance_CurrentInstance<_T, _DimensionCount>& c = *(details::FieldInstance_CurrentInstance<_T, _DimensionCount>*)CurrentInstance;
     DField<_T, _DimensionCount>& df = c.dfield;
     ArrayV<size_t>& il = c.inputs;
@@ -107,12 +107,12 @@ _T* brendancuda::fields::FieldInstance_Iterate(void* CurrentInstance, _T* Inputs
     return opts;
 };
 template <typename _T, size_t _DimensionCount>
-void brendancuda::fields::FieldInstance_Destruct(void* CurrentInstance) {
+void bcuda::fields::FieldInstance_Destruct(void* CurrentInstance) {
     delete (details::FieldInstance_CurrentInstance<_T, _DimensionCount>*)CurrentInstance;
 };
 
-template <typename _T, size_t _DimensionCount, brendancuda::fields::fieldInstance_createField_t<_T, _DimensionCount> _CreateField, brendancuda::fields::fieldInstance_objectRunner_t<_T, _DimensionCount> _ObjectRunner>
-brendancuda::ai::evol::eval::output::InstanceFunctions<_T*, _T*> brendancuda::fields::FieldInstance() {
+template <typename _T, size_t _DimensionCount, bcuda::fields::fieldInstance_createField_t<_T, _DimensionCount> _CreateField, bcuda::fields::fieldInstance_objectRunner_t<_T, _DimensionCount> _ObjectRunner>
+bcuda::ai::evol::eval::output::InstanceFunctions<_T*, _T*> bcuda::fields::FieldInstance() {
     ai::evol::eval::output::InstanceFunctions<_T*, _T*> ifs;
     ifs.constructInstance = FieldInstance_Construct<_T, _DimensionCount, _CreateField>;
     ifs.iterateInstance = FieldInstance_Iterate<_T, _DimensionCount, _ObjectRunner>;
@@ -120,8 +120,8 @@ brendancuda::ai::evol::eval::output::InstanceFunctions<_T*, _T*> brendancuda::fi
     return ifs;
 }
 
-template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, brendancuda::fields::fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, brendancuda::fields::fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, brendancuda::fields::fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
-_TOutput* brendancuda::fields::FieldInstance_Iterate(void* CurrentInstance, _TInput* Inputs) {
+template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, bcuda::fields::fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, bcuda::fields::fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, bcuda::fields::fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
+_TOutput* bcuda::fields::FieldInstance_Iterate(void* CurrentInstance, _TInput* Inputs) {
     details::FieldInstance_CurrentInstance<_TFieldValue, _DimensionCount> c = *(details::FieldInstance_CurrentInstance<_TFieldValue, _DimensionCount>*)CurrentInstance;
     DField<_TFieldValue, _DimensionCount>& df = c.dfield;
     ArrayV<size_t>& il = c.inputs;
@@ -149,8 +149,8 @@ _TOutput* brendancuda::fields::FieldInstance_Iterate(void* CurrentInstance, _TIn
     return opts;
 }
 
-template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, brendancuda::fields::fieldInstance_createField_t<_TFieldValue, _DimensionCount> _CreateField, brendancuda::fields::fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, brendancuda::fields::fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, brendancuda::fields::fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
-brendancuda::ai::evol::eval::output::InstanceFunctions<_TInput*, _TOutput*> brendancuda::fields::FieldInstance() {
+template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, bcuda::fields::fieldInstance_createField_t<_TFieldValue, _DimensionCount> _CreateField, bcuda::fields::fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, bcuda::fields::fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, bcuda::fields::fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
+bcuda::ai::evol::eval::output::InstanceFunctions<_TInput*, _TOutput*> bcuda::fields::FieldInstance() {
     ai::evol::eval::output::InstanceFunctions<_TInput*, _TOutput*> ifs;
     ifs.constructInstance = FieldInstance_Construct<_TFieldValue, _DimensionCount, _CreateField>;
     ifs.iterateInstance = FieldInstance_Iterate<_TFieldValue, _DimensionCount, _TInput, _TOutput, _AssignInput, _GetOutput, _ObjectRunner>;

--- a/fields_instance.h
+++ b/fields_instance.h
@@ -42,12 +42,12 @@ namespace brendancuda {
         template <typename _T, size_t _DimensionCount>
         void FieldInstance_Destruct(void* CurrentInstance);
         template <typename _T, size_t _DimensionCount, fieldInstance_createField_t<_T, _DimensionCount> _CreateField, fieldInstance_objectRunner_t<_T, _DimensionCount> _ObjectRunner>
-        ai::evolution::Evaluation::Output::InstanceFunctions<_T*, _T*> FieldInstance();
+        ai::evolution::evaluation::Output::InstanceFunctions<_T*, _T*> FieldInstance();
 
         template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
         _TOutput* FieldInstance_Iterate(void* CurrentInstance, _TInput* Inputs);
         template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, fieldInstance_createField_t<_TFieldValue, _DimensionCount> _CreateField, fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
-        ai::evolution::Evaluation::Output::InstanceFunctions<_TInput*, _TOutput*> FieldInstance();
+        ai::evolution::evaluation::Output::InstanceFunctions<_TInput*, _TOutput*> FieldInstance();
     }
 }
 
@@ -112,8 +112,8 @@ void brendancuda::fields::FieldInstance_Destruct(void* CurrentInstance) {
 };
 
 template <typename _T, size_t _DimensionCount, brendancuda::fields::fieldInstance_createField_t<_T, _DimensionCount> _CreateField, brendancuda::fields::fieldInstance_objectRunner_t<_T, _DimensionCount> _ObjectRunner>
-brendancuda::ai::evolution::Evaluation::Output::InstanceFunctions<_T*, _T*> brendancuda::fields::FieldInstance() {
-    ai::evolution::Evaluation::Output::InstanceFunctions<_T*, _T*> ifs;
+brendancuda::ai::evolution::evaluation::Output::InstanceFunctions<_T*, _T*> brendancuda::fields::FieldInstance() {
+    ai::evolution::evaluation::Output::InstanceFunctions<_T*, _T*> ifs;
     ifs.constructInstance = FieldInstance_Construct<_T, _DimensionCount, _CreateField>;
     ifs.iterateInstance = FieldInstance_Iterate<_T, _DimensionCount, _ObjectRunner>;
     ifs.destructInstance = FieldInstance_Destruct<_T, _DimensionCount>;
@@ -150,8 +150,8 @@ _TOutput* brendancuda::fields::FieldInstance_Iterate(void* CurrentInstance, _TIn
 }
 
 template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, brendancuda::fields::fieldInstance_createField_t<_TFieldValue, _DimensionCount> _CreateField, brendancuda::fields::fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, brendancuda::fields::fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, brendancuda::fields::fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
-brendancuda::ai::evolution::Evaluation::Output::InstanceFunctions<_TInput*, _TOutput*> brendancuda::fields::FieldInstance() {
-    ai::evolution::Evaluation::Output::InstanceFunctions<_TInput*, _TOutput*> ifs;
+brendancuda::ai::evolution::evaluation::Output::InstanceFunctions<_TInput*, _TOutput*> brendancuda::fields::FieldInstance() {
+    ai::evolution::evaluation::Output::InstanceFunctions<_TInput*, _TOutput*> ifs;
     ifs.constructInstance = FieldInstance_Construct<_TFieldValue, _DimensionCount, _CreateField>;
     ifs.iterateInstance = FieldInstance_Iterate<_TFieldValue, _DimensionCount, _TInput, _TOutput, _AssignInput, _GetOutput, _ObjectRunner>;
     ifs.destructInstance = FieldInstance_Destruct<_TFieldValue, _DimensionCount>;

--- a/fields_instance.h
+++ b/fields_instance.h
@@ -42,12 +42,12 @@ namespace brendancuda {
         template <typename _T, size_t _DimensionCount>
         void FieldInstance_Destruct(void* CurrentInstance);
         template <typename _T, size_t _DimensionCount, fieldInstance_createField_t<_T, _DimensionCount> _CreateField, fieldInstance_objectRunner_t<_T, _DimensionCount> _ObjectRunner>
-        AI::Evolution::Evaluation::Output::InstanceFunctions<_T*, _T*> FieldInstance();
+        ai::Evolution::Evaluation::Output::InstanceFunctions<_T*, _T*> FieldInstance();
 
         template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
         _TOutput* FieldInstance_Iterate(void* CurrentInstance, _TInput* Inputs);
         template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, fieldInstance_createField_t<_TFieldValue, _DimensionCount> _CreateField, fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
-        AI::Evolution::Evaluation::Output::InstanceFunctions<_TInput*, _TOutput*> FieldInstance();
+        ai::Evolution::Evaluation::Output::InstanceFunctions<_TInput*, _TOutput*> FieldInstance();
     }
 }
 
@@ -112,8 +112,8 @@ void brendancuda::fields::FieldInstance_Destruct(void* CurrentInstance) {
 };
 
 template <typename _T, size_t _DimensionCount, brendancuda::fields::fieldInstance_createField_t<_T, _DimensionCount> _CreateField, brendancuda::fields::fieldInstance_objectRunner_t<_T, _DimensionCount> _ObjectRunner>
-brendancuda::AI::Evolution::Evaluation::Output::InstanceFunctions<_T*, _T*> brendancuda::fields::FieldInstance() {
-    AI::Evolution::Evaluation::Output::InstanceFunctions<_T*, _T*> ifs;
+brendancuda::ai::Evolution::Evaluation::Output::InstanceFunctions<_T*, _T*> brendancuda::fields::FieldInstance() {
+    ai::Evolution::Evaluation::Output::InstanceFunctions<_T*, _T*> ifs;
     ifs.constructInstance = FieldInstance_Construct<_T, _DimensionCount, _CreateField>;
     ifs.iterateInstance = FieldInstance_Iterate<_T, _DimensionCount, _ObjectRunner>;
     ifs.destructInstance = FieldInstance_Destruct<_T, _DimensionCount>;
@@ -150,8 +150,8 @@ _TOutput* brendancuda::fields::FieldInstance_Iterate(void* CurrentInstance, _TIn
 }
 
 template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, brendancuda::fields::fieldInstance_createField_t<_TFieldValue, _DimensionCount> _CreateField, brendancuda::fields::fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, brendancuda::fields::fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, brendancuda::fields::fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
-brendancuda::AI::Evolution::Evaluation::Output::InstanceFunctions<_TInput*, _TOutput*> brendancuda::fields::FieldInstance() {
-    AI::Evolution::Evaluation::Output::InstanceFunctions<_TInput*, _TOutput*> ifs;
+brendancuda::ai::Evolution::Evaluation::Output::InstanceFunctions<_TInput*, _TOutput*> brendancuda::fields::FieldInstance() {
+    ai::Evolution::Evaluation::Output::InstanceFunctions<_TInput*, _TOutput*> ifs;
     ifs.constructInstance = FieldInstance_Construct<_TFieldValue, _DimensionCount, _CreateField>;
     ifs.iterateInstance = FieldInstance_Iterate<_TFieldValue, _DimensionCount, _TInput, _TOutput, _AssignInput, _GetOutput, _ObjectRunner>;
     ifs.destructInstance = FieldInstance_Destruct<_TFieldValue, _DimensionCount>;

--- a/fields_instance.h
+++ b/fields_instance.h
@@ -9,7 +9,7 @@ namespace brendancuda {
     namespace details {
         template <typename _T, size_t _DimensionCount>
         struct FieldInstance_CurrentInstance final {
-            Fields::DField<_T, _DimensionCount> dfield;
+            fields::DField<_T, _DimensionCount> dfield;
             ArrayV<size_t> inputs;
             ArrayV<size_t> outputs;
             void* obj;
@@ -17,9 +17,9 @@ namespace brendancuda {
             Random::AnyRNG<uint32_t> rng;
         };
     }
-    namespace Fields {
+    namespace fields {
         template <typename _T, size_t _DimensionCount>
-        using fieldInstance_objectRunner_t = void(*)(void* Object, Fields::DFieldProxy<_T, _DimensionCount> Field, void* SharedData);
+        using fieldInstance_objectRunner_t = void(*)(void* Object, fields::DFieldProxy<_T, _DimensionCount> Field, void* SharedData);
         template <typename _T, size_t _DimensionCount>
         using fieldInstance_createField_t = DField<_T, _DimensionCount>*(*)(void* SharedData);
         struct FieldInstance_Construct_Settings final {
@@ -51,8 +51,8 @@ namespace brendancuda {
     }
 }
 
-template <typename _T, size_t _DimensionCount, brendancuda::Fields::fieldInstance_createField_t<_T, _DimensionCount> _CreateField>
-void* brendancuda::Fields::FieldInstance_Construct(void* Object, void* Settings) {
+template <typename _T, size_t _DimensionCount, brendancuda::fields::fieldInstance_createField_t<_T, _DimensionCount> _CreateField>
+void* brendancuda::fields::FieldInstance_Construct(void* Object, void* Settings) {
     FieldInstance_Construct_Settings settings = *(FieldInstance_Construct_Settings*)Settings;
     Random::AnyRNG<uint32_t>& rng = settings.rng;
 
@@ -82,8 +82,8 @@ void* brendancuda::Fields::FieldInstance_Construct(void* Object, void* Settings)
 
     return p_rv;
 };
-template <typename _T, size_t _DimensionCount, brendancuda::Fields::fieldInstance_objectRunner_t<_T, _DimensionCount> _ObjectRunner>
-_T* brendancuda::Fields::FieldInstance_Iterate(void* CurrentInstance, _T* Inputs) {
+template <typename _T, size_t _DimensionCount, brendancuda::fields::fieldInstance_objectRunner_t<_T, _DimensionCount> _ObjectRunner>
+_T* brendancuda::fields::FieldInstance_Iterate(void* CurrentInstance, _T* Inputs) {
     details::FieldInstance_CurrentInstance<_T, _DimensionCount>& c = *(details::FieldInstance_CurrentInstance<_T, _DimensionCount>*)CurrentInstance;
     DField<_T, _DimensionCount>& df = c.dfield;
     ArrayV<size_t>& il = c.inputs;
@@ -107,12 +107,12 @@ _T* brendancuda::Fields::FieldInstance_Iterate(void* CurrentInstance, _T* Inputs
     return opts;
 };
 template <typename _T, size_t _DimensionCount>
-void brendancuda::Fields::FieldInstance_Destruct(void* CurrentInstance) {
+void brendancuda::fields::FieldInstance_Destruct(void* CurrentInstance) {
     delete (details::FieldInstance_CurrentInstance<_T, _DimensionCount>*)CurrentInstance;
 };
 
-template <typename _T, size_t _DimensionCount, brendancuda::Fields::fieldInstance_createField_t<_T, _DimensionCount> _CreateField, brendancuda::Fields::fieldInstance_objectRunner_t<_T, _DimensionCount> _ObjectRunner>
-brendancuda::AI::Evolution::Evaluation::Output::InstanceFunctions<_T*, _T*> brendancuda::Fields::FieldInstance() {
+template <typename _T, size_t _DimensionCount, brendancuda::fields::fieldInstance_createField_t<_T, _DimensionCount> _CreateField, brendancuda::fields::fieldInstance_objectRunner_t<_T, _DimensionCount> _ObjectRunner>
+brendancuda::AI::Evolution::Evaluation::Output::InstanceFunctions<_T*, _T*> brendancuda::fields::FieldInstance() {
     AI::Evolution::Evaluation::Output::InstanceFunctions<_T*, _T*> ifs;
     ifs.constructInstance = FieldInstance_Construct<_T, _DimensionCount, _CreateField>;
     ifs.iterateInstance = FieldInstance_Iterate<_T, _DimensionCount, _ObjectRunner>;
@@ -120,8 +120,8 @@ brendancuda::AI::Evolution::Evaluation::Output::InstanceFunctions<_T*, _T*> bren
     return ifs;
 }
 
-template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, brendancuda::Fields::fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, brendancuda::Fields::fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, brendancuda::Fields::fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
-_TOutput* brendancuda::Fields::FieldInstance_Iterate(void* CurrentInstance, _TInput* Inputs) {
+template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, brendancuda::fields::fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, brendancuda::fields::fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, brendancuda::fields::fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
+_TOutput* brendancuda::fields::FieldInstance_Iterate(void* CurrentInstance, _TInput* Inputs) {
     details::FieldInstance_CurrentInstance<_TFieldValue, _DimensionCount> c = *(details::FieldInstance_CurrentInstance<_TFieldValue, _DimensionCount>*)CurrentInstance;
     DField<_TFieldValue, _DimensionCount>& df = c.dfield;
     ArrayV<size_t>& il = c.inputs;
@@ -149,8 +149,8 @@ _TOutput* brendancuda::Fields::FieldInstance_Iterate(void* CurrentInstance, _TIn
     return opts;
 }
 
-template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, brendancuda::Fields::fieldInstance_createField_t<_TFieldValue, _DimensionCount> _CreateField, brendancuda::Fields::fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, brendancuda::Fields::fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, brendancuda::Fields::fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
-brendancuda::AI::Evolution::Evaluation::Output::InstanceFunctions<_TInput*, _TOutput*> brendancuda::Fields::FieldInstance() {
+template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, brendancuda::fields::fieldInstance_createField_t<_TFieldValue, _DimensionCount> _CreateField, brendancuda::fields::fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, brendancuda::fields::fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, brendancuda::fields::fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
+brendancuda::AI::Evolution::Evaluation::Output::InstanceFunctions<_TInput*, _TOutput*> brendancuda::fields::FieldInstance() {
     AI::Evolution::Evaluation::Output::InstanceFunctions<_TInput*, _TOutput*> ifs;
     ifs.constructInstance = FieldInstance_Construct<_TFieldValue, _DimensionCount, _CreateField>;
     ifs.iterateInstance = FieldInstance_Iterate<_TFieldValue, _DimensionCount, _TInput, _TOutput, _AssignInput, _GetOutput, _ObjectRunner>;

--- a/fields_instance.h
+++ b/fields_instance.h
@@ -42,12 +42,12 @@ namespace brendancuda {
         template <typename _T, size_t _DimensionCount>
         void FieldInstance_Destruct(void* CurrentInstance);
         template <typename _T, size_t _DimensionCount, fieldInstance_createField_t<_T, _DimensionCount> _CreateField, fieldInstance_objectRunner_t<_T, _DimensionCount> _ObjectRunner>
-        ai::Evolution::Evaluation::Output::InstanceFunctions<_T*, _T*> FieldInstance();
+        ai::evolution::Evaluation::Output::InstanceFunctions<_T*, _T*> FieldInstance();
 
         template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
         _TOutput* FieldInstance_Iterate(void* CurrentInstance, _TInput* Inputs);
         template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, fieldInstance_createField_t<_TFieldValue, _DimensionCount> _CreateField, fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
-        ai::Evolution::Evaluation::Output::InstanceFunctions<_TInput*, _TOutput*> FieldInstance();
+        ai::evolution::Evaluation::Output::InstanceFunctions<_TInput*, _TOutput*> FieldInstance();
     }
 }
 
@@ -112,8 +112,8 @@ void brendancuda::fields::FieldInstance_Destruct(void* CurrentInstance) {
 };
 
 template <typename _T, size_t _DimensionCount, brendancuda::fields::fieldInstance_createField_t<_T, _DimensionCount> _CreateField, brendancuda::fields::fieldInstance_objectRunner_t<_T, _DimensionCount> _ObjectRunner>
-brendancuda::ai::Evolution::Evaluation::Output::InstanceFunctions<_T*, _T*> brendancuda::fields::FieldInstance() {
-    ai::Evolution::Evaluation::Output::InstanceFunctions<_T*, _T*> ifs;
+brendancuda::ai::evolution::Evaluation::Output::InstanceFunctions<_T*, _T*> brendancuda::fields::FieldInstance() {
+    ai::evolution::Evaluation::Output::InstanceFunctions<_T*, _T*> ifs;
     ifs.constructInstance = FieldInstance_Construct<_T, _DimensionCount, _CreateField>;
     ifs.iterateInstance = FieldInstance_Iterate<_T, _DimensionCount, _ObjectRunner>;
     ifs.destructInstance = FieldInstance_Destruct<_T, _DimensionCount>;
@@ -150,8 +150,8 @@ _TOutput* brendancuda::fields::FieldInstance_Iterate(void* CurrentInstance, _TIn
 }
 
 template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, brendancuda::fields::fieldInstance_createField_t<_TFieldValue, _DimensionCount> _CreateField, brendancuda::fields::fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, brendancuda::fields::fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, brendancuda::fields::fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
-brendancuda::ai::Evolution::Evaluation::Output::InstanceFunctions<_TInput*, _TOutput*> brendancuda::fields::FieldInstance() {
-    ai::Evolution::Evaluation::Output::InstanceFunctions<_TInput*, _TOutput*> ifs;
+brendancuda::ai::evolution::Evaluation::Output::InstanceFunctions<_TInput*, _TOutput*> brendancuda::fields::FieldInstance() {
+    ai::evolution::Evaluation::Output::InstanceFunctions<_TInput*, _TOutput*> ifs;
     ifs.constructInstance = FieldInstance_Construct<_TFieldValue, _DimensionCount, _CreateField>;
     ifs.iterateInstance = FieldInstance_Iterate<_TFieldValue, _DimensionCount, _TInput, _TOutput, _AssignInput, _GetOutput, _ObjectRunner>;
     ifs.destructInstance = FieldInstance_Destruct<_TFieldValue, _DimensionCount>;

--- a/fields_instance.h
+++ b/fields_instance.h
@@ -5,7 +5,7 @@
 #include "rand_anyrng.h"
 #include <tuple>
 
-namespace BrendanCUDA {
+namespace brendancuda {
     namespace details {
         template <typename _T, size_t _DimensionCount>
         struct FieldInstance_CurrentInstance final {
@@ -51,8 +51,8 @@ namespace BrendanCUDA {
     }
 }
 
-template <typename _T, size_t _DimensionCount, BrendanCUDA::Fields::fieldInstance_createField_t<_T, _DimensionCount> _CreateField>
-void* BrendanCUDA::Fields::FieldInstance_Construct(void* Object, void* Settings) {
+template <typename _T, size_t _DimensionCount, brendancuda::Fields::fieldInstance_createField_t<_T, _DimensionCount> _CreateField>
+void* brendancuda::Fields::FieldInstance_Construct(void* Object, void* Settings) {
     FieldInstance_Construct_Settings settings = *(FieldInstance_Construct_Settings*)Settings;
     Random::AnyRNG<uint32_t>& rng = settings.rng;
 
@@ -82,8 +82,8 @@ void* BrendanCUDA::Fields::FieldInstance_Construct(void* Object, void* Settings)
 
     return p_rv;
 };
-template <typename _T, size_t _DimensionCount, BrendanCUDA::Fields::fieldInstance_objectRunner_t<_T, _DimensionCount> _ObjectRunner>
-_T* BrendanCUDA::Fields::FieldInstance_Iterate(void* CurrentInstance, _T* Inputs) {
+template <typename _T, size_t _DimensionCount, brendancuda::Fields::fieldInstance_objectRunner_t<_T, _DimensionCount> _ObjectRunner>
+_T* brendancuda::Fields::FieldInstance_Iterate(void* CurrentInstance, _T* Inputs) {
     details::FieldInstance_CurrentInstance<_T, _DimensionCount>& c = *(details::FieldInstance_CurrentInstance<_T, _DimensionCount>*)CurrentInstance;
     DField<_T, _DimensionCount>& df = c.dfield;
     ArrayV<size_t>& il = c.inputs;
@@ -107,12 +107,12 @@ _T* BrendanCUDA::Fields::FieldInstance_Iterate(void* CurrentInstance, _T* Inputs
     return opts;
 };
 template <typename _T, size_t _DimensionCount>
-void BrendanCUDA::Fields::FieldInstance_Destruct(void* CurrentInstance) {
+void brendancuda::Fields::FieldInstance_Destruct(void* CurrentInstance) {
     delete (details::FieldInstance_CurrentInstance<_T, _DimensionCount>*)CurrentInstance;
 };
 
-template <typename _T, size_t _DimensionCount, BrendanCUDA::Fields::fieldInstance_createField_t<_T, _DimensionCount> _CreateField, BrendanCUDA::Fields::fieldInstance_objectRunner_t<_T, _DimensionCount> _ObjectRunner>
-BrendanCUDA::AI::Evolution::Evaluation::Output::InstanceFunctions<_T*, _T*> BrendanCUDA::Fields::FieldInstance() {
+template <typename _T, size_t _DimensionCount, brendancuda::Fields::fieldInstance_createField_t<_T, _DimensionCount> _CreateField, brendancuda::Fields::fieldInstance_objectRunner_t<_T, _DimensionCount> _ObjectRunner>
+brendancuda::AI::Evolution::Evaluation::Output::InstanceFunctions<_T*, _T*> brendancuda::Fields::FieldInstance() {
     AI::Evolution::Evaluation::Output::InstanceFunctions<_T*, _T*> ifs;
     ifs.constructInstance = FieldInstance_Construct<_T, _DimensionCount, _CreateField>;
     ifs.iterateInstance = FieldInstance_Iterate<_T, _DimensionCount, _ObjectRunner>;
@@ -120,8 +120,8 @@ BrendanCUDA::AI::Evolution::Evaluation::Output::InstanceFunctions<_T*, _T*> Bren
     return ifs;
 }
 
-template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, BrendanCUDA::Fields::fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, BrendanCUDA::Fields::fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, BrendanCUDA::Fields::fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
-_TOutput* BrendanCUDA::Fields::FieldInstance_Iterate(void* CurrentInstance, _TInput* Inputs) {
+template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, brendancuda::Fields::fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, brendancuda::Fields::fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, brendancuda::Fields::fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
+_TOutput* brendancuda::Fields::FieldInstance_Iterate(void* CurrentInstance, _TInput* Inputs) {
     details::FieldInstance_CurrentInstance<_TFieldValue, _DimensionCount> c = *(details::FieldInstance_CurrentInstance<_TFieldValue, _DimensionCount>*)CurrentInstance;
     DField<_TFieldValue, _DimensionCount>& df = c.dfield;
     ArrayV<size_t>& il = c.inputs;
@@ -149,8 +149,8 @@ _TOutput* BrendanCUDA::Fields::FieldInstance_Iterate(void* CurrentInstance, _TIn
     return opts;
 }
 
-template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, BrendanCUDA::Fields::fieldInstance_createField_t<_TFieldValue, _DimensionCount> _CreateField, BrendanCUDA::Fields::fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, BrendanCUDA::Fields::fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, BrendanCUDA::Fields::fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
-BrendanCUDA::AI::Evolution::Evaluation::Output::InstanceFunctions<_TInput*, _TOutput*> BrendanCUDA::Fields::FieldInstance() {
+template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, brendancuda::Fields::fieldInstance_createField_t<_TFieldValue, _DimensionCount> _CreateField, brendancuda::Fields::fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, brendancuda::Fields::fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, brendancuda::Fields::fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
+brendancuda::AI::Evolution::Evaluation::Output::InstanceFunctions<_TInput*, _TOutput*> brendancuda::Fields::FieldInstance() {
     AI::Evolution::Evaluation::Output::InstanceFunctions<_TInput*, _TOutput*> ifs;
     ifs.constructInstance = FieldInstance_Construct<_TFieldValue, _DimensionCount, _CreateField>;
     ifs.iterateInstance = FieldInstance_Iterate<_TFieldValue, _DimensionCount, _TInput, _TOutput, _AssignInput, _GetOutput, _ObjectRunner>;

--- a/fields_instance.h
+++ b/fields_instance.h
@@ -42,12 +42,12 @@ namespace brendancuda {
         template <typename _T, size_t _DimensionCount>
         void FieldInstance_Destruct(void* CurrentInstance);
         template <typename _T, size_t _DimensionCount, fieldInstance_createField_t<_T, _DimensionCount> _CreateField, fieldInstance_objectRunner_t<_T, _DimensionCount> _ObjectRunner>
-        ai::evolution::evaluation::Output::InstanceFunctions<_T*, _T*> FieldInstance();
+        ai::evolution::evaluation::output::InstanceFunctions<_T*, _T*> FieldInstance();
 
         template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
         _TOutput* FieldInstance_Iterate(void* CurrentInstance, _TInput* Inputs);
         template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, fieldInstance_createField_t<_TFieldValue, _DimensionCount> _CreateField, fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
-        ai::evolution::evaluation::Output::InstanceFunctions<_TInput*, _TOutput*> FieldInstance();
+        ai::evolution::evaluation::output::InstanceFunctions<_TInput*, _TOutput*> FieldInstance();
     }
 }
 
@@ -112,8 +112,8 @@ void brendancuda::fields::FieldInstance_Destruct(void* CurrentInstance) {
 };
 
 template <typename _T, size_t _DimensionCount, brendancuda::fields::fieldInstance_createField_t<_T, _DimensionCount> _CreateField, brendancuda::fields::fieldInstance_objectRunner_t<_T, _DimensionCount> _ObjectRunner>
-brendancuda::ai::evolution::evaluation::Output::InstanceFunctions<_T*, _T*> brendancuda::fields::FieldInstance() {
-    ai::evolution::evaluation::Output::InstanceFunctions<_T*, _T*> ifs;
+brendancuda::ai::evolution::evaluation::output::InstanceFunctions<_T*, _T*> brendancuda::fields::FieldInstance() {
+    ai::evolution::evaluation::output::InstanceFunctions<_T*, _T*> ifs;
     ifs.constructInstance = FieldInstance_Construct<_T, _DimensionCount, _CreateField>;
     ifs.iterateInstance = FieldInstance_Iterate<_T, _DimensionCount, _ObjectRunner>;
     ifs.destructInstance = FieldInstance_Destruct<_T, _DimensionCount>;
@@ -150,8 +150,8 @@ _TOutput* brendancuda::fields::FieldInstance_Iterate(void* CurrentInstance, _TIn
 }
 
 template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, brendancuda::fields::fieldInstance_createField_t<_TFieldValue, _DimensionCount> _CreateField, brendancuda::fields::fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, brendancuda::fields::fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, brendancuda::fields::fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
-brendancuda::ai::evolution::evaluation::Output::InstanceFunctions<_TInput*, _TOutput*> brendancuda::fields::FieldInstance() {
-    ai::evolution::evaluation::Output::InstanceFunctions<_TInput*, _TOutput*> ifs;
+brendancuda::ai::evolution::evaluation::output::InstanceFunctions<_TInput*, _TOutput*> brendancuda::fields::FieldInstance() {
+    ai::evolution::evaluation::output::InstanceFunctions<_TInput*, _TOutput*> ifs;
     ifs.constructInstance = FieldInstance_Construct<_TFieldValue, _DimensionCount, _CreateField>;
     ifs.iterateInstance = FieldInstance_Iterate<_TFieldValue, _DimensionCount, _TInput, _TOutput, _AssignInput, _GetOutput, _ObjectRunner>;
     ifs.destructInstance = FieldInstance_Destruct<_TFieldValue, _DimensionCount>;

--- a/fields_mdfield.h
+++ b/fields_mdfield.h
@@ -4,7 +4,7 @@
 #include "fields_mfield.h"
 #include <array>
 
-namespace brendancuda {
+namespace bcuda {
     namespace details {
         template <size_t _DimensionCount, bool _Public, typename _T>
         using publicPrivateSelector_t = std::conditional_t<_Public, fields::FieldProxyConst<_T, _DimensionCount>, _T>;

--- a/fields_mdfield.h
+++ b/fields_mdfield.h
@@ -4,7 +4,7 @@
 #include "fields_mfield.h"
 #include <array>
 
-namespace BrendanCUDA {
+namespace brendancuda {
     namespace details {
         template <size_t _DimensionCount, bool _Public, typename _T>
         using publicPrivateSelector_t = std::conditional_t<_Public, Fields::FieldProxyConst<_T, _DimensionCount>, _T>;

--- a/fields_mdfield.h
+++ b/fields_mdfield.h
@@ -7,7 +7,7 @@
 namespace brendancuda {
     namespace details {
         template <size_t _DimensionCount, bool _Public, typename _T>
-        using publicPrivateSelector_t = std::conditional_t<_Public, Fields::FieldProxyConst<_T, _DimensionCount>, _T>;
+        using publicPrivateSelector_t = std::conditional_t<_Public, fields::FieldProxyConst<_T, _DimensionCount>, _T>;
 
         template <size_t _DimensionCount, typename _TTypes, typename _TPublics>
         struct MDFPPIK;
@@ -39,10 +39,10 @@ namespace brendancuda {
         using mdfppik_t = typename MDFPPIK<_DimensionCount, _TTypes, _TPublics>::type_t;
 
         template <size_t _DimensionCount, typename... _Ts>
-        using mdfkf_t = void(*)(const FixedVector<uint32_t, _DimensionCount>& Pos, const Fields::FieldProxyConst<_Ts, _DimensionCount>&... Prevs, _Ts&... Next);
+        using mdfkf_t = void(*)(const FixedVector<uint32_t, _DimensionCount>& Pos, const fields::FieldProxyConst<_Ts, _DimensionCount>&... Prevs, _Ts&... Next);
     }
 
-    namespace Fields {
+    namespace fields {
         template <size_t _DimensionCount, typename... _Ts>
         class MDField;
         template <size_t _DimensionCount, typename... _Ts>

--- a/fields_mfield.h
+++ b/fields_mfield.h
@@ -7,7 +7,7 @@
 #include <stdexcept>
 #include <string>
 
-namespace BrendanCUDA {
+namespace brendancuda {
     namespace Fields {
         template <size_t _DimensionCount, typename... _Ts>
         class MField;

--- a/fields_mfield.h
+++ b/fields_mfield.h
@@ -7,7 +7,7 @@
 #include <stdexcept>
 #include <string>
 
-namespace brendancuda {
+namespace bcuda {
     namespace fields {
         template <size_t _DimensionCount, typename... _Ts>
         class MField;

--- a/fields_mfield.h
+++ b/fields_mfield.h
@@ -8,7 +8,7 @@
 #include <string>
 
 namespace brendancuda {
-    namespace Fields {
+    namespace fields {
         template <size_t _DimensionCount, typename... _Ts>
         class MField;
         template <size_t _DimensionCount, typename... _Ts>
@@ -82,11 +82,11 @@ namespace brendancuda {
                 return basefb_t::TotalSizeOnGPU();
             }
             template <size_t _Idx>
-            __host__ __device__ Fields::FieldProxy<this_t::template element_t<_Idx>, _DimensionCount> F() {
+            __host__ __device__ fields::FieldProxy<this_t::template element_t<_Idx>, _DimensionCount> F() {
                 return basefb_t::template F<_Idx>();
             }
             template <size_t _Idx>
-            __host__ __device__ Fields::FieldProxyConst<this_t::template element_t<_Idx>, _DimensionCount> FConst() const {
+            __host__ __device__ fields::FieldProxyConst<this_t::template element_t<_Idx>, _DimensionCount> FConst() const {
                 return basefb_t::template FConst<_Idx>();
             }
             template <size_t _Idx>
@@ -200,11 +200,11 @@ namespace brendancuda {
                 return basefb_t::TotalSizeOnGPU();
             }
             template <size_t _Idx>
-            __host__ __device__ Fields::FieldProxy<element_t<_Idx>, _DimensionCount> F() const {
+            __host__ __device__ fields::FieldProxy<element_t<_Idx>, _DimensionCount> F() const {
                 return basefb_t::template F<_Idx>();
             }
             template <size_t _Idx>
-            __host__ __device__ Fields::FieldProxyConst<element_t<_Idx>, _DimensionCount> FConst() const {
+            __host__ __device__ fields::FieldProxyConst<element_t<_Idx>, _DimensionCount> FConst() const {
                 return basefb_t::template FConst<_Idx>();
             }
             template <size_t _Idx>
@@ -286,7 +286,7 @@ namespace brendancuda {
                 return basefb_t::TotalSizeOnGPU();
             }
             template <size_t _Idx>
-            __host__ __device__ Fields::FieldProxyConst<element_t<_Idx>, _DimensionCount> FConst() const {
+            __host__ __device__ fields::FieldProxyConst<element_t<_Idx>, _DimensionCount> FConst() const {
                 return basefb_t::template FConst<_Idx>();
             }
             template <size_t _Idx>

--- a/fixedvectors.h
+++ b/fixedvectors.h
@@ -8,7 +8,7 @@
 #include <cstdint>
 #include <cuda_runtime.h>
 
-namespace BrendanCUDA {
+namespace brendancuda {
     namespace details {
         template <typename _T, size_t _Size>
             requires std::is_arithmetic_v<_T>
@@ -137,31 +137,31 @@ namespace BrendanCUDA {
 
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr BrendanCUDA::FixedVector<_T, _Size>::FixedVector() {
+__host__ __device__ __forceinline constexpr brendancuda::FixedVector<_T, _Size>::FixedVector() {
     for (size_t i = 0; i < _Size; ++i) {
         this->v[i] = 0;
     }
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr BrendanCUDA::FixedVector<_T, _Size>::FixedVector(const _T V[_Size]) {
+__host__ __device__ __forceinline constexpr brendancuda::FixedVector<_T, _Size>::FixedVector(const _T V[_Size]) {
     for (size_t i = 0; i < _Size; ++i) {
         this->v[i] = V[i];
     }
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr _T& BrendanCUDA::FixedVector<_T, _Size>::operator[](size_t Index) {
+__host__ __device__ __forceinline constexpr _T& brendancuda::FixedVector<_T, _Size>::operator[](size_t Index) {
     return this->v[Index];
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr const _T& BrendanCUDA::FixedVector<_T, _Size>::operator[](size_t Index) const {
+__host__ __device__ __forceinline constexpr const _T& brendancuda::FixedVector<_T, _Size>::operator[](size_t Index) const {
     return this->v[Index];
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr auto BrendanCUDA::FixedVector<_T, _Size>::operator+(FixedVector<_T, _Size> Other) const -> FixedVector<_T, _Size> {
+__host__ __device__ __forceinline constexpr auto brendancuda::FixedVector<_T, _Size>::operator+(FixedVector<_T, _Size> Other) const -> FixedVector<_T, _Size> {
     FixedVector<_T, _Size> r;
     for (size_t i = 0; i < _Size; ++i) {
         r[i] = this->v[i] + Other[i];
@@ -170,14 +170,14 @@ __host__ __device__ __forceinline constexpr auto BrendanCUDA::FixedVector<_T, _S
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline void BrendanCUDA::FixedVector<_T, _Size>::operator+=(FixedVector<_T, _Size> Other) {
+__host__ __device__ __forceinline void brendancuda::FixedVector<_T, _Size>::operator+=(FixedVector<_T, _Size> Other) {
     for (size_t i = 0; i < _Size; ++i) {
         this->v[i] += Other[i];
     }
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr auto BrendanCUDA::FixedVector<_T, _Size>::operator-(FixedVector<_T, _Size> Other) const -> FixedVector<_T, _Size> {
+__host__ __device__ __forceinline constexpr auto brendancuda::FixedVector<_T, _Size>::operator-(FixedVector<_T, _Size> Other) const -> FixedVector<_T, _Size> {
     FixedVector<_T, _Size> r;
     for (size_t i = 0; i < _Size; ++i) {
         r[i] = this->v[i] - Other[i];
@@ -186,14 +186,14 @@ __host__ __device__ __forceinline constexpr auto BrendanCUDA::FixedVector<_T, _S
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline void BrendanCUDA::FixedVector<_T, _Size>::operator-=(FixedVector<_T, _Size> Other) {
+__host__ __device__ __forceinline void brendancuda::FixedVector<_T, _Size>::operator-=(FixedVector<_T, _Size> Other) {
     for (size_t i = 0; i < _Size; ++i) {
         this->v[i] -= Other[i];
     }
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr auto BrendanCUDA::FixedVector<_T, _Size>::operator*(_T Other) const -> FixedVector<_T, _Size> {
+__host__ __device__ __forceinline constexpr auto brendancuda::FixedVector<_T, _Size>::operator*(_T Other) const -> FixedVector<_T, _Size> {
     FixedVector<_T, _Size> r;
     for (size_t i = 0; i < _Size; ++i) {
         r[i] = this->v[i] * Other;
@@ -202,14 +202,14 @@ __host__ __device__ __forceinline constexpr auto BrendanCUDA::FixedVector<_T, _S
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline void BrendanCUDA::FixedVector<_T, _Size>::operator*=(_T Other) {
+__host__ __device__ __forceinline void brendancuda::FixedVector<_T, _Size>::operator*=(_T Other) {
     for (size_t i = 0; i < _Size; ++i) {
         this->v[i] *= Other;
     }
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr auto BrendanCUDA::FixedVector<_T, _Size>::operator/(_T Other) const -> FixedVector<_T, _Size> {
+__host__ __device__ __forceinline constexpr auto brendancuda::FixedVector<_T, _Size>::operator/(_T Other) const -> FixedVector<_T, _Size> {
     FixedVector<_T, _Size> r;
     for (size_t i = 0; i < _Size; ++i) {
         r[i] = this->v[i] / Other;
@@ -218,14 +218,14 @@ __host__ __device__ __forceinline constexpr auto BrendanCUDA::FixedVector<_T, _S
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline void BrendanCUDA::FixedVector<_T, _Size>::operator/=(_T Other) {
+__host__ __device__ __forceinline void brendancuda::FixedVector<_T, _Size>::operator/=(_T Other) {
     for (size_t i = 0; i < _Size; ++i) {
         this->v[i] /= Other;
     }
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr _T BrendanCUDA::FixedVector<_T, _Size>::Dot(FixedVector<_T, _Size> Left, FixedVector<_T, _Size> Right) {
+__host__ __device__ __forceinline constexpr _T brendancuda::FixedVector<_T, _Size>::Dot(FixedVector<_T, _Size> Left, FixedVector<_T, _Size> Right) {
     _T t = 0;
     for (size_t i = 0; i < _Size; ++i) {
         t += Left[i] * Right[i];
@@ -234,7 +234,7 @@ __host__ __device__ __forceinline constexpr _T BrendanCUDA::FixedVector<_T, _Siz
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr _T BrendanCUDA::FixedVector<_T, _Size>::MagnatudeSquared() const {
+__host__ __device__ __forceinline constexpr _T brendancuda::FixedVector<_T, _Size>::MagnatudeSquared() const {
     _T t = 0;
     for (size_t i = 0; i < _Size; ++i) {
         _T thisV = this->v[i];
@@ -244,17 +244,17 @@ __host__ __device__ __forceinline constexpr _T BrendanCUDA::FixedVector<_T, _Siz
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline _T BrendanCUDA::FixedVector<_T, _Size>::MagnatudeI() const requires std::integral<_T> {
+__host__ __device__ __forceinline _T brendancuda::FixedVector<_T, _Size>::MagnatudeI() const requires std::integral<_T> {
     return Math::sqrt(MagnatudeSquared());
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline float BrendanCUDA::FixedVector<_T, _Size>::MagnatudeF() const requires std::integral<_T> {
+__host__ __device__ __forceinline float brendancuda::FixedVector<_T, _Size>::MagnatudeF() const requires std::integral<_T> {
     return sqrt((float)MagnatudeSquared());
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline std::conditional_t<std::floating_point<_T>, _T, double> BrendanCUDA::FixedVector<_T, _Size>::Magnatude() const {
+__host__ __device__ __forceinline std::conditional_t<std::floating_point<_T>, _T, double> brendancuda::FixedVector<_T, _Size>::Magnatude() const {
     if constexpr (std::floating_point<_T>) {
         return sqrt(MagnatudeSquared());
     }
@@ -264,26 +264,26 @@ __host__ __device__ __forceinline std::conditional_t<std::floating_point<_T>, _T
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__forceinline size_t BrendanCUDA::FixedVector<_T, _Size>::SerializedSize() const {
+__forceinline size_t brendancuda::FixedVector<_T, _Size>::SerializedSize() const {
     return sizeof(_T) * _Size;
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__forceinline void BrendanCUDA::FixedVector<_T, _Size>::Serialize(void*& Data) const {
+__forceinline void brendancuda::FixedVector<_T, _Size>::Serialize(void*& Data) const {
     for (size_t i = 0; i < _Size; ++i)
         BSerializer::Serialize(Data, this->v[i]);
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__forceinline BrendanCUDA::FixedVector<_T, _Size> BrendanCUDA::FixedVector<_T, _Size>::Deserialize(const void*& Data) {
-    BrendanCUDA::FixedVector<_T, _Size> vec;
+__forceinline brendancuda::FixedVector<_T, _Size> brendancuda::FixedVector<_T, _Size>::Deserialize(const void*& Data) {
+    brendancuda::FixedVector<_T, _Size> vec;
     for (size_t i = 0; i < _Size; ++i)
         vec[i] = BSerializer::Deserialize<_T>(Data);
     return vec;
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__forceinline void BrendanCUDA::FixedVector<_T, _Size>::Deserialize(const void*& Data, void* Value) {
+__forceinline void brendancuda::FixedVector<_T, _Size>::Deserialize(const void*& Data, void* Value) {
     FixedVector<_T, _Size>* p_vec = new (Value) FixedVector<_T, _Size>;
     FixedVector<_T, _Size>& vec = *p_vec;
     for (size_t i = 0; i < _Size; ++i)
@@ -292,18 +292,18 @@ __forceinline void BrendanCUDA::FixedVector<_T, _Size>::Deserialize(const void*&
 
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr BrendanCUDA::FixedVector<_T, 2> BrendanCUDA::FixedVector<_T, _Size>::Cross(FixedVector<_T, 2> Value) requires (_Size == 2) {
+__host__ __device__ __forceinline constexpr brendancuda::FixedVector<_T, 2> brendancuda::FixedVector<_T, _Size>::Cross(FixedVector<_T, 2> Value) requires (_Size == 2) {
     return Value.Cross();
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr _T BrendanCUDA::FixedVector<_T, _Size>::Cross(FixedVector<_T, 2> Left, FixedVector<_T, 2> Right) requires (_Size == 2) {
+__host__ __device__ __forceinline constexpr _T brendancuda::FixedVector<_T, _Size>::Cross(FixedVector<_T, 2> Left, FixedVector<_T, 2> Right) requires (_Size == 2) {
     return Left.x * Right.y - Left.y * Right.x;
 }
 
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr BrendanCUDA::FixedVector<_T, 3> BrendanCUDA::FixedVector<_T, _Size>::Cross(FixedVector<_T, 3> Left, FixedVector<_T, 3> Right) requires (_Size == 3) {
+__host__ __device__ __forceinline constexpr brendancuda::FixedVector<_T, 3> brendancuda::FixedVector<_T, _Size>::Cross(FixedVector<_T, 3> Left, FixedVector<_T, 3> Right) requires (_Size == 3) {
     return FixedVector<_T, 3>(
         Left.y * Right.z - Left.z * Right.y,
         Left.z * Right.x - Left.x * Right.z,

--- a/fixedvectors.h
+++ b/fixedvectors.h
@@ -8,7 +8,7 @@
 #include <cstdint>
 #include <cuda_runtime.h>
 
-namespace brendancuda {
+namespace bcuda {
     namespace details {
         template <typename _T, size_t _Size>
             requires std::is_arithmetic_v<_T>
@@ -137,31 +137,31 @@ namespace brendancuda {
 
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr brendancuda::FixedVector<_T, _Size>::FixedVector() {
+__host__ __device__ __forceinline constexpr bcuda::FixedVector<_T, _Size>::FixedVector() {
     for (size_t i = 0; i < _Size; ++i) {
         this->v[i] = 0;
     }
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr brendancuda::FixedVector<_T, _Size>::FixedVector(const _T V[_Size]) {
+__host__ __device__ __forceinline constexpr bcuda::FixedVector<_T, _Size>::FixedVector(const _T V[_Size]) {
     for (size_t i = 0; i < _Size; ++i) {
         this->v[i] = V[i];
     }
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr _T& brendancuda::FixedVector<_T, _Size>::operator[](size_t Index) {
+__host__ __device__ __forceinline constexpr _T& bcuda::FixedVector<_T, _Size>::operator[](size_t Index) {
     return this->v[Index];
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr const _T& brendancuda::FixedVector<_T, _Size>::operator[](size_t Index) const {
+__host__ __device__ __forceinline constexpr const _T& bcuda::FixedVector<_T, _Size>::operator[](size_t Index) const {
     return this->v[Index];
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr auto brendancuda::FixedVector<_T, _Size>::operator+(FixedVector<_T, _Size> Other) const -> FixedVector<_T, _Size> {
+__host__ __device__ __forceinline constexpr auto bcuda::FixedVector<_T, _Size>::operator+(FixedVector<_T, _Size> Other) const -> FixedVector<_T, _Size> {
     FixedVector<_T, _Size> r;
     for (size_t i = 0; i < _Size; ++i) {
         r[i] = this->v[i] + Other[i];
@@ -170,14 +170,14 @@ __host__ __device__ __forceinline constexpr auto brendancuda::FixedVector<_T, _S
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline void brendancuda::FixedVector<_T, _Size>::operator+=(FixedVector<_T, _Size> Other) {
+__host__ __device__ __forceinline void bcuda::FixedVector<_T, _Size>::operator+=(FixedVector<_T, _Size> Other) {
     for (size_t i = 0; i < _Size; ++i) {
         this->v[i] += Other[i];
     }
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr auto brendancuda::FixedVector<_T, _Size>::operator-(FixedVector<_T, _Size> Other) const -> FixedVector<_T, _Size> {
+__host__ __device__ __forceinline constexpr auto bcuda::FixedVector<_T, _Size>::operator-(FixedVector<_T, _Size> Other) const -> FixedVector<_T, _Size> {
     FixedVector<_T, _Size> r;
     for (size_t i = 0; i < _Size; ++i) {
         r[i] = this->v[i] - Other[i];
@@ -186,14 +186,14 @@ __host__ __device__ __forceinline constexpr auto brendancuda::FixedVector<_T, _S
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline void brendancuda::FixedVector<_T, _Size>::operator-=(FixedVector<_T, _Size> Other) {
+__host__ __device__ __forceinline void bcuda::FixedVector<_T, _Size>::operator-=(FixedVector<_T, _Size> Other) {
     for (size_t i = 0; i < _Size; ++i) {
         this->v[i] -= Other[i];
     }
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr auto brendancuda::FixedVector<_T, _Size>::operator*(_T Other) const -> FixedVector<_T, _Size> {
+__host__ __device__ __forceinline constexpr auto bcuda::FixedVector<_T, _Size>::operator*(_T Other) const -> FixedVector<_T, _Size> {
     FixedVector<_T, _Size> r;
     for (size_t i = 0; i < _Size; ++i) {
         r[i] = this->v[i] * Other;
@@ -202,14 +202,14 @@ __host__ __device__ __forceinline constexpr auto brendancuda::FixedVector<_T, _S
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline void brendancuda::FixedVector<_T, _Size>::operator*=(_T Other) {
+__host__ __device__ __forceinline void bcuda::FixedVector<_T, _Size>::operator*=(_T Other) {
     for (size_t i = 0; i < _Size; ++i) {
         this->v[i] *= Other;
     }
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr auto brendancuda::FixedVector<_T, _Size>::operator/(_T Other) const -> FixedVector<_T, _Size> {
+__host__ __device__ __forceinline constexpr auto bcuda::FixedVector<_T, _Size>::operator/(_T Other) const -> FixedVector<_T, _Size> {
     FixedVector<_T, _Size> r;
     for (size_t i = 0; i < _Size; ++i) {
         r[i] = this->v[i] / Other;
@@ -218,14 +218,14 @@ __host__ __device__ __forceinline constexpr auto brendancuda::FixedVector<_T, _S
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline void brendancuda::FixedVector<_T, _Size>::operator/=(_T Other) {
+__host__ __device__ __forceinline void bcuda::FixedVector<_T, _Size>::operator/=(_T Other) {
     for (size_t i = 0; i < _Size; ++i) {
         this->v[i] /= Other;
     }
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr _T brendancuda::FixedVector<_T, _Size>::Dot(FixedVector<_T, _Size> Left, FixedVector<_T, _Size> Right) {
+__host__ __device__ __forceinline constexpr _T bcuda::FixedVector<_T, _Size>::Dot(FixedVector<_T, _Size> Left, FixedVector<_T, _Size> Right) {
     _T t = 0;
     for (size_t i = 0; i < _Size; ++i) {
         t += Left[i] * Right[i];
@@ -234,7 +234,7 @@ __host__ __device__ __forceinline constexpr _T brendancuda::FixedVector<_T, _Siz
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr _T brendancuda::FixedVector<_T, _Size>::MagnatudeSquared() const {
+__host__ __device__ __forceinline constexpr _T bcuda::FixedVector<_T, _Size>::MagnatudeSquared() const {
     _T t = 0;
     for (size_t i = 0; i < _Size; ++i) {
         _T thisV = this->v[i];
@@ -244,17 +244,17 @@ __host__ __device__ __forceinline constexpr _T brendancuda::FixedVector<_T, _Siz
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline _T brendancuda::FixedVector<_T, _Size>::MagnatudeI() const requires std::integral<_T> {
+__host__ __device__ __forceinline _T bcuda::FixedVector<_T, _Size>::MagnatudeI() const requires std::integral<_T> {
     return math::sqrt(MagnatudeSquared());
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline float brendancuda::FixedVector<_T, _Size>::MagnatudeF() const requires std::integral<_T> {
+__host__ __device__ __forceinline float bcuda::FixedVector<_T, _Size>::MagnatudeF() const requires std::integral<_T> {
     return sqrt((float)MagnatudeSquared());
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline std::conditional_t<std::floating_point<_T>, _T, double> brendancuda::FixedVector<_T, _Size>::Magnatude() const {
+__host__ __device__ __forceinline std::conditional_t<std::floating_point<_T>, _T, double> bcuda::FixedVector<_T, _Size>::Magnatude() const {
     if constexpr (std::floating_point<_T>) {
         return sqrt(MagnatudeSquared());
     }
@@ -264,26 +264,26 @@ __host__ __device__ __forceinline std::conditional_t<std::floating_point<_T>, _T
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__forceinline size_t brendancuda::FixedVector<_T, _Size>::SerializedSize() const {
+__forceinline size_t bcuda::FixedVector<_T, _Size>::SerializedSize() const {
     return sizeof(_T) * _Size;
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__forceinline void brendancuda::FixedVector<_T, _Size>::Serialize(void*& Data) const {
+__forceinline void bcuda::FixedVector<_T, _Size>::Serialize(void*& Data) const {
     for (size_t i = 0; i < _Size; ++i)
         BSerializer::Serialize(Data, this->v[i]);
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__forceinline brendancuda::FixedVector<_T, _Size> brendancuda::FixedVector<_T, _Size>::Deserialize(const void*& Data) {
-    brendancuda::FixedVector<_T, _Size> vec;
+__forceinline bcuda::FixedVector<_T, _Size> bcuda::FixedVector<_T, _Size>::Deserialize(const void*& Data) {
+    bcuda::FixedVector<_T, _Size> vec;
     for (size_t i = 0; i < _Size; ++i)
         vec[i] = BSerializer::Deserialize<_T>(Data);
     return vec;
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__forceinline void brendancuda::FixedVector<_T, _Size>::Deserialize(const void*& Data, void* Value) {
+__forceinline void bcuda::FixedVector<_T, _Size>::Deserialize(const void*& Data, void* Value) {
     FixedVector<_T, _Size>* p_vec = new (Value) FixedVector<_T, _Size>;
     FixedVector<_T, _Size>& vec = *p_vec;
     for (size_t i = 0; i < _Size; ++i)
@@ -292,18 +292,18 @@ __forceinline void brendancuda::FixedVector<_T, _Size>::Deserialize(const void*&
 
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr brendancuda::FixedVector<_T, 2> brendancuda::FixedVector<_T, _Size>::Cross(FixedVector<_T, 2> Value) requires (_Size == 2) {
+__host__ __device__ __forceinline constexpr bcuda::FixedVector<_T, 2> bcuda::FixedVector<_T, _Size>::Cross(FixedVector<_T, 2> Value) requires (_Size == 2) {
     return Value.Cross();
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr _T brendancuda::FixedVector<_T, _Size>::Cross(FixedVector<_T, 2> Left, FixedVector<_T, 2> Right) requires (_Size == 2) {
+__host__ __device__ __forceinline constexpr _T bcuda::FixedVector<_T, _Size>::Cross(FixedVector<_T, 2> Left, FixedVector<_T, 2> Right) requires (_Size == 2) {
     return Left.x * Right.y - Left.y * Right.x;
 }
 
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr brendancuda::FixedVector<_T, 3> brendancuda::FixedVector<_T, _Size>::Cross(FixedVector<_T, 3> Left, FixedVector<_T, 3> Right) requires (_Size == 3) {
+__host__ __device__ __forceinline constexpr bcuda::FixedVector<_T, 3> bcuda::FixedVector<_T, _Size>::Cross(FixedVector<_T, 3> Left, FixedVector<_T, 3> Right) requires (_Size == 3) {
     return FixedVector<_T, 3>(
         Left.y * Right.z - Left.z * Right.y,
         Left.z * Right.x - Left.x * Right.z,

--- a/fixedvectors.h
+++ b/fixedvectors.h
@@ -245,7 +245,7 @@ __host__ __device__ __forceinline constexpr _T brendancuda::FixedVector<_T, _Siz
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>
 __host__ __device__ __forceinline _T brendancuda::FixedVector<_T, _Size>::MagnatudeI() const requires std::integral<_T> {
-    return Math::sqrt(MagnatudeSquared());
+    return math::sqrt(MagnatudeSquared());
 }
 template <typename _T, size_t _Size>
     requires std::is_arithmetic_v<_T>

--- a/kernellaunch.cuh
+++ b/kernellaunch.cuh
@@ -4,7 +4,7 @@
 #include <cuda_runtime.h>
 #include <device_launch_parameters.h>
 
-namespace BrendanCUDA {
+namespace brendancuda {
 #ifdef __CUDACC__
     __device__ uint32_t GetCoordinates1() {
         return blockIdx.x * blockDim.x + threadIdx.x;

--- a/kernellaunch.cuh
+++ b/kernellaunch.cuh
@@ -4,7 +4,7 @@
 #include <cuda_runtime.h>
 #include <device_launch_parameters.h>
 
-namespace brendancuda {
+namespace bcuda {
 #ifdef __CUDACC__
     __device__ uint32_t GetCoordinates1() {
         return blockIdx.x * blockDim.x + threadIdx.x;

--- a/mathfuncs.h
+++ b/mathfuncs.h
@@ -6,7 +6,7 @@
 #include <cuda_runtime.h>
 
 namespace brendancuda {
-    namespace Math {
+    namespace math {
         template <typename _T>
         __host__ __device__ static __forceinline _T sqrt(_T value);
 
@@ -16,7 +16,7 @@ namespace brendancuda {
 }
 
 template <>
-__host__ __device__ static __forceinline int32_t brendancuda::Math::sqrt<int32_t>(int32_t value) {
+__host__ __device__ static __forceinline int32_t brendancuda::math::sqrt<int32_t>(int32_t value) {
     if (value < 0) {
         return -1;
     }
@@ -40,7 +40,7 @@ __host__ __device__ static __forceinline int32_t brendancuda::Math::sqrt<int32_t
     return lower;
 }
 template <>
-__host__ __device__ static __forceinline uint32_t brendancuda::Math::sqrt<uint32_t>(uint32_t value) {
+__host__ __device__ static __forceinline uint32_t brendancuda::math::sqrt<uint32_t>(uint32_t value) {
     if (value < 2) {
         return value;
     }
@@ -61,7 +61,7 @@ __host__ __device__ static __forceinline uint32_t brendancuda::Math::sqrt<uint32
     return lower;
 }
 template <>
-__host__ __device__ static __forceinline int64_t brendancuda::Math::sqrt<int64_t>(int64_t value) {
+__host__ __device__ static __forceinline int64_t brendancuda::math::sqrt<int64_t>(int64_t value) {
     if (value < 0) {
         return -1;
     }
@@ -85,7 +85,7 @@ __host__ __device__ static __forceinline int64_t brendancuda::Math::sqrt<int64_t
     return lower;
 }
 template <>
-__host__ __device__ static __forceinline uint64_t brendancuda::Math::sqrt<uint64_t>(uint64_t value) {
+__host__ __device__ static __forceinline uint64_t brendancuda::math::sqrt<uint64_t>(uint64_t value) {
     if (value < 2) {
         return value;
     }
@@ -106,7 +106,7 @@ __host__ __device__ static __forceinline uint64_t brendancuda::Math::sqrt<uint64
     return lower;
 }
 template <typename _T>
-__host__ __device__ static __forceinline _T brendancuda::Math::sqrt(_T value) {
+__host__ __device__ static __forceinline _T brendancuda::math::sqrt(_T value) {
     if constexpr (std::signed_integral<_T>)
         return (_T)sqrt((int32_t)value);
     else if constexpr (std::unsigned_integral<_T>)
@@ -116,7 +116,7 @@ __host__ __device__ static __forceinline _T brendancuda::Math::sqrt(_T value) {
 }
 
 template <typename _T>
-__host__ __device__ static __forceinline _T brendancuda::Math::clamp(_T value, _T lower, _T upper) {
+__host__ __device__ static __forceinline _T brendancuda::math::clamp(_T value, _T lower, _T upper) {
     if (value < lower) {
         return lower;
     }

--- a/mathfuncs.h
+++ b/mathfuncs.h
@@ -5,7 +5,7 @@
 #include <cstdint>
 #include <cuda_runtime.h>
 
-namespace brendancuda {
+namespace bcuda {
     namespace math {
         template <typename _T>
         __host__ __device__ static __forceinline _T sqrt(_T value);
@@ -16,7 +16,7 @@ namespace brendancuda {
 }
 
 template <>
-__host__ __device__ static __forceinline int32_t brendancuda::math::sqrt<int32_t>(int32_t value) {
+__host__ __device__ static __forceinline int32_t bcuda::math::sqrt<int32_t>(int32_t value) {
     if (value < 0) {
         return -1;
     }
@@ -40,7 +40,7 @@ __host__ __device__ static __forceinline int32_t brendancuda::math::sqrt<int32_t
     return lower;
 }
 template <>
-__host__ __device__ static __forceinline uint32_t brendancuda::math::sqrt<uint32_t>(uint32_t value) {
+__host__ __device__ static __forceinline uint32_t bcuda::math::sqrt<uint32_t>(uint32_t value) {
     if (value < 2) {
         return value;
     }
@@ -61,7 +61,7 @@ __host__ __device__ static __forceinline uint32_t brendancuda::math::sqrt<uint32
     return lower;
 }
 template <>
-__host__ __device__ static __forceinline int64_t brendancuda::math::sqrt<int64_t>(int64_t value) {
+__host__ __device__ static __forceinline int64_t bcuda::math::sqrt<int64_t>(int64_t value) {
     if (value < 0) {
         return -1;
     }
@@ -85,7 +85,7 @@ __host__ __device__ static __forceinline int64_t brendancuda::math::sqrt<int64_t
     return lower;
 }
 template <>
-__host__ __device__ static __forceinline uint64_t brendancuda::math::sqrt<uint64_t>(uint64_t value) {
+__host__ __device__ static __forceinline uint64_t bcuda::math::sqrt<uint64_t>(uint64_t value) {
     if (value < 2) {
         return value;
     }
@@ -106,7 +106,7 @@ __host__ __device__ static __forceinline uint64_t brendancuda::math::sqrt<uint64
     return lower;
 }
 template <typename _T>
-__host__ __device__ static __forceinline _T brendancuda::math::sqrt(_T value) {
+__host__ __device__ static __forceinline _T bcuda::math::sqrt(_T value) {
     if constexpr (std::signed_integral<_T>)
         return (_T)sqrt((int32_t)value);
     else if constexpr (std::unsigned_integral<_T>)
@@ -116,7 +116,7 @@ __host__ __device__ static __forceinline _T brendancuda::math::sqrt(_T value) {
 }
 
 template <typename _T>
-__host__ __device__ static __forceinline _T brendancuda::math::clamp(_T value, _T lower, _T upper) {
+__host__ __device__ static __forceinline _T bcuda::math::clamp(_T value, _T lower, _T upper) {
     if (value < lower) {
         return lower;
     }

--- a/mathfuncs.h
+++ b/mathfuncs.h
@@ -5,7 +5,7 @@
 #include <cstdint>
 #include <cuda_runtime.h>
 
-namespace BrendanCUDA {
+namespace brendancuda {
     namespace Math {
         template <typename _T>
         __host__ __device__ static __forceinline _T sqrt(_T value);
@@ -16,7 +16,7 @@ namespace BrendanCUDA {
 }
 
 template <>
-__host__ __device__ static __forceinline int32_t BrendanCUDA::Math::sqrt<int32_t>(int32_t value) {
+__host__ __device__ static __forceinline int32_t brendancuda::Math::sqrt<int32_t>(int32_t value) {
     if (value < 0) {
         return -1;
     }
@@ -40,7 +40,7 @@ __host__ __device__ static __forceinline int32_t BrendanCUDA::Math::sqrt<int32_t
     return lower;
 }
 template <>
-__host__ __device__ static __forceinline uint32_t BrendanCUDA::Math::sqrt<uint32_t>(uint32_t value) {
+__host__ __device__ static __forceinline uint32_t brendancuda::Math::sqrt<uint32_t>(uint32_t value) {
     if (value < 2) {
         return value;
     }
@@ -61,7 +61,7 @@ __host__ __device__ static __forceinline uint32_t BrendanCUDA::Math::sqrt<uint32
     return lower;
 }
 template <>
-__host__ __device__ static __forceinline int64_t BrendanCUDA::Math::sqrt<int64_t>(int64_t value) {
+__host__ __device__ static __forceinline int64_t brendancuda::Math::sqrt<int64_t>(int64_t value) {
     if (value < 0) {
         return -1;
     }
@@ -85,7 +85,7 @@ __host__ __device__ static __forceinline int64_t BrendanCUDA::Math::sqrt<int64_t
     return lower;
 }
 template <>
-__host__ __device__ static __forceinline uint64_t BrendanCUDA::Math::sqrt<uint64_t>(uint64_t value) {
+__host__ __device__ static __forceinline uint64_t brendancuda::Math::sqrt<uint64_t>(uint64_t value) {
     if (value < 2) {
         return value;
     }
@@ -106,7 +106,7 @@ __host__ __device__ static __forceinline uint64_t BrendanCUDA::Math::sqrt<uint64
     return lower;
 }
 template <typename _T>
-__host__ __device__ static __forceinline _T BrendanCUDA::Math::sqrt(_T value) {
+__host__ __device__ static __forceinline _T brendancuda::Math::sqrt(_T value) {
     if constexpr (std::signed_integral<_T>)
         return (_T)sqrt((int32_t)value);
     else if constexpr (std::unsigned_integral<_T>)
@@ -116,7 +116,7 @@ __host__ __device__ static __forceinline _T BrendanCUDA::Math::sqrt(_T value) {
 }
 
 template <typename _T>
-__host__ __device__ static __forceinline _T BrendanCUDA::Math::clamp(_T value, _T lower, _T upper) {
+__host__ __device__ static __forceinline _T brendancuda::Math::clamp(_T value, _T lower, _T upper) {
     if (value < lower) {
         return lower;
     }

--- a/nets_makenet.cu
+++ b/nets_makenet.cu
@@ -6,12 +6,12 @@
 #include <curand_kernel.h>
 #include <device_launch_parameters.h>
 
-using brendancuda::float_3;
-using brendancuda::CoordinatesToIndex;
-using brendancuda::uint32_3;
-using brendancuda::ThrowIfBad;
-using brendancuda::nets::NetNode;
-using brendancuda::nets::Net;
+using bcuda::float_3;
+using bcuda::CoordinatesToIndex;
+using bcuda::uint32_3;
+using bcuda::ThrowIfBad;
+using bcuda::nets::NetNode;
+using bcuda::nets::Net;
 using std::make_tuple;
 using thrust::device_vector;
 
@@ -116,7 +116,7 @@ __device__ void addToBucketTS(BucketTS& bucket, size_t value) {
     atomicExch(&bucket.lock, 0);
 }
 
-__global__ void fillBuckets1(BucketTS* bucketData, size_t bucketCountPerD, brendancuda::float_3* data, size_t dataCount) {
+__global__ void fillBuckets1(BucketTS* bucketData, size_t bucketCountPerD, bcuda::float_3* data, size_t dataCount) {
     float_3 p = data[blockIdx.x];
     
     uint32_3 bCs = whichBucket(p, bucketCountPerD);
@@ -126,7 +126,7 @@ __global__ void fillBuckets1(BucketTS* bucketData, size_t bucketCountPerD, brend
     addToBucketTS(bucketData[bI], blockIdx.x);
 }
 
-__global__ void fillBuckets2(Bucket* nodeData, BucketTS* bucketData, uint32_t bucketCountPerD, brendancuda::float_3* data, float ConnectionRange) {
+__global__ void fillBuckets2(Bucket* nodeData, BucketTS* bucketData, uint32_t bucketCountPerD, bcuda::float_3* data, float ConnectionRange) {
     float_3 p = data[blockIdx.x];
     Bucket& mnd = nodeData[blockIdx.x];
 
@@ -189,7 +189,7 @@ __global__ void disposeOfBuckets(BucketTS* buckets) {
     delete[] buckets[blockIdx.x].data;
 }
 
-brendancuda::nets::Net brendancuda::nets::MakeNet_3D(size_t NodeCount, float ConnectionRange, random::AnyRNG<uint64_t> RNG, thrust::device_vector<float_3>** NodePoints) {
+bcuda::nets::Net bcuda::nets::MakeNet_3D(size_t NodeCount, float ConnectionRange, random::AnyRNG<uint64_t> RNG, thrust::device_vector<float_3>** NodePoints) {
     thrust::device_vector<float_3>* dv = new thrust::device_vector<float_3>(NodeCount);
 
     random::InitRandomArray<false, float, random::AnyRNG<uint64_t>>(Span<float>((float*)(dv->data().get()), NodeCount * 3), RNG);

--- a/nets_makenet.cu
+++ b/nets_makenet.cu
@@ -6,12 +6,12 @@
 #include <curand_kernel.h>
 #include <device_launch_parameters.h>
 
-using BrendanCUDA::float_3;
-using BrendanCUDA::CoordinatesToIndex;
-using BrendanCUDA::uint32_3;
-using BrendanCUDA::ThrowIfBad;
-using BrendanCUDA::Nets::NetNode;
-using BrendanCUDA::Nets::Net;
+using brendancuda::float_3;
+using brendancuda::CoordinatesToIndex;
+using brendancuda::uint32_3;
+using brendancuda::ThrowIfBad;
+using brendancuda::Nets::NetNode;
+using brendancuda::Nets::Net;
 using std::make_tuple;
 using thrust::device_vector;
 
@@ -116,7 +116,7 @@ __device__ void addToBucketTS(BucketTS& bucket, size_t value) {
     atomicExch(&bucket.lock, 0);
 }
 
-__global__ void fillBuckets1(BucketTS* bucketData, size_t bucketCountPerD, BrendanCUDA::float_3* data, size_t dataCount) {
+__global__ void fillBuckets1(BucketTS* bucketData, size_t bucketCountPerD, brendancuda::float_3* data, size_t dataCount) {
     float_3 p = data[blockIdx.x];
     
     uint32_3 bCs = whichBucket(p, bucketCountPerD);
@@ -126,7 +126,7 @@ __global__ void fillBuckets1(BucketTS* bucketData, size_t bucketCountPerD, Brend
     addToBucketTS(bucketData[bI], blockIdx.x);
 }
 
-__global__ void fillBuckets2(Bucket* nodeData, BucketTS* bucketData, uint32_t bucketCountPerD, BrendanCUDA::float_3* data, float ConnectionRange) {
+__global__ void fillBuckets2(Bucket* nodeData, BucketTS* bucketData, uint32_t bucketCountPerD, brendancuda::float_3* data, float ConnectionRange) {
     float_3 p = data[blockIdx.x];
     Bucket& mnd = nodeData[blockIdx.x];
 
@@ -189,7 +189,7 @@ __global__ void disposeOfBuckets(BucketTS* buckets) {
     delete[] buckets[blockIdx.x].data;
 }
 
-BrendanCUDA::Nets::Net BrendanCUDA::Nets::MakeNet_3D(size_t NodeCount, float ConnectionRange, Random::AnyRNG<uint64_t> RNG, thrust::device_vector<float_3>** NodePoints) {
+brendancuda::Nets::Net brendancuda::Nets::MakeNet_3D(size_t NodeCount, float ConnectionRange, Random::AnyRNG<uint64_t> RNG, thrust::device_vector<float_3>** NodePoints) {
     thrust::device_vector<float_3>* dv = new thrust::device_vector<float_3>(NodeCount);
 
     Random::InitRandomArray<false, float, Random::AnyRNG<uint64_t>>(Span<float>((float*)(dv->data().get()), NodeCount * 3), RNG);

--- a/nets_makenet.cu
+++ b/nets_makenet.cu
@@ -10,8 +10,8 @@ using brendancuda::float_3;
 using brendancuda::CoordinatesToIndex;
 using brendancuda::uint32_3;
 using brendancuda::ThrowIfBad;
-using brendancuda::Nets::NetNode;
-using brendancuda::Nets::Net;
+using brendancuda::nets::NetNode;
+using brendancuda::nets::Net;
 using std::make_tuple;
 using thrust::device_vector;
 
@@ -189,7 +189,7 @@ __global__ void disposeOfBuckets(BucketTS* buckets) {
     delete[] buckets[blockIdx.x].data;
 }
 
-brendancuda::Nets::Net brendancuda::Nets::MakeNet_3D(size_t NodeCount, float ConnectionRange, random::AnyRNG<uint64_t> RNG, thrust::device_vector<float_3>** NodePoints) {
+brendancuda::nets::Net brendancuda::nets::MakeNet_3D(size_t NodeCount, float ConnectionRange, random::AnyRNG<uint64_t> RNG, thrust::device_vector<float_3>** NodePoints) {
     thrust::device_vector<float_3>* dv = new thrust::device_vector<float_3>(NodeCount);
 
     random::InitRandomArray<false, float, random::AnyRNG<uint64_t>>(Span<float>((float*)(dv->data().get()), NodeCount * 3), RNG);

--- a/nets_makenet.cu
+++ b/nets_makenet.cu
@@ -189,10 +189,10 @@ __global__ void disposeOfBuckets(BucketTS* buckets) {
     delete[] buckets[blockIdx.x].data;
 }
 
-brendancuda::Nets::Net brendancuda::Nets::MakeNet_3D(size_t NodeCount, float ConnectionRange, Random::AnyRNG<uint64_t> RNG, thrust::device_vector<float_3>** NodePoints) {
+brendancuda::Nets::Net brendancuda::Nets::MakeNet_3D(size_t NodeCount, float ConnectionRange, random::AnyRNG<uint64_t> RNG, thrust::device_vector<float_3>** NodePoints) {
     thrust::device_vector<float_3>* dv = new thrust::device_vector<float_3>(NodeCount);
 
-    Random::InitRandomArray<false, float, Random::AnyRNG<uint64_t>>(Span<float>((float*)(dv->data().get()), NodeCount * 3), RNG);
+    random::InitRandomArray<false, float, random::AnyRNG<uint64_t>>(Span<float>((float*)(dv->data().get()), NodeCount * 3), RNG);
 
     constexpr size_t bucketCountPerD = 10;
 

--- a/nets_makenet.h
+++ b/nets_makenet.h
@@ -4,9 +4,9 @@
 #include "points.h"
 #include "rand_anyrng.h"
 
-namespace BrendanCUDA {
+namespace brendancuda {
     namespace Nets {
-        //Creates a BrendanCUDA::Nets::Net by creating NodeCount points in a rectangular prism such that all coordinates are in the range of [0, 1], and then connecting up the nodes cooresponding to any points within a distance of ConnectionRange from each other. If NodePoints is non-null, the value it points to will be assigned the vector of points -- otherwise, the vector of points will be disposed of.
-        Net MakeNet_3D(size_t NodeCount, float ConnectionRange, BrendanCUDA::Random::AnyRNG<uint64_t> RNG, thrust::device_vector<float_3>** NodePoints);
+        //Creates a brendancuda::Nets::Net by creating NodeCount points in a rectangular prism such that all coordinates are in the range of [0, 1], and then connecting up the nodes cooresponding to any points within a distance of ConnectionRange from each other. If NodePoints is non-null, the value it points to will be assigned the vector of points -- otherwise, the vector of points will be disposed of.
+        Net MakeNet_3D(size_t NodeCount, float ConnectionRange, brendancuda::Random::AnyRNG<uint64_t> RNG, thrust::device_vector<float_3>** NodePoints);
     }
 }

--- a/nets_makenet.h
+++ b/nets_makenet.h
@@ -4,9 +4,9 @@
 #include "points.h"
 #include "rand_anyrng.h"
 
-namespace brendancuda {
+namespace bcuda {
     namespace nets {
-        //Creates a brendancuda::nets::Net by creating NodeCount points in a rectangular prism such that all coordinates are in the range of [0, 1], and then connecting up the nodes cooresponding to any points within a distance of ConnectionRange from each other. If NodePoints is non-null, the value it points to will be assigned the vector of points -- otherwise, the vector of points will be disposed of.
-        Net MakeNet_3D(size_t NodeCount, float ConnectionRange, brendancuda::random::AnyRNG<uint64_t> RNG, thrust::device_vector<float_3>** NodePoints);
+        //Creates a bcuda::nets::Net by creating NodeCount points in a rectangular prism such that all coordinates are in the range of [0, 1], and then connecting up the nodes cooresponding to any points within a distance of ConnectionRange from each other. If NodePoints is non-null, the value it points to will be assigned the vector of points -- otherwise, the vector of points will be disposed of.
+        Net MakeNet_3D(size_t NodeCount, float ConnectionRange, bcuda::random::AnyRNG<uint64_t> RNG, thrust::device_vector<float_3>** NodePoints);
     }
 }

--- a/nets_makenet.h
+++ b/nets_makenet.h
@@ -5,8 +5,8 @@
 #include "rand_anyrng.h"
 
 namespace brendancuda {
-    namespace Nets {
-        //Creates a brendancuda::Nets::Net by creating NodeCount points in a rectangular prism such that all coordinates are in the range of [0, 1], and then connecting up the nodes cooresponding to any points within a distance of ConnectionRange from each other. If NodePoints is non-null, the value it points to will be assigned the vector of points -- otherwise, the vector of points will be disposed of.
+    namespace nets {
+        //Creates a brendancuda::nets::Net by creating NodeCount points in a rectangular prism such that all coordinates are in the range of [0, 1], and then connecting up the nodes cooresponding to any points within a distance of ConnectionRange from each other. If NodePoints is non-null, the value it points to will be assigned the vector of points -- otherwise, the vector of points will be disposed of.
         Net MakeNet_3D(size_t NodeCount, float ConnectionRange, brendancuda::random::AnyRNG<uint64_t> RNG, thrust::device_vector<float_3>** NodePoints);
     }
 }

--- a/nets_makenet.h
+++ b/nets_makenet.h
@@ -7,6 +7,6 @@
 namespace brendancuda {
     namespace Nets {
         //Creates a brendancuda::Nets::Net by creating NodeCount points in a rectangular prism such that all coordinates are in the range of [0, 1], and then connecting up the nodes cooresponding to any points within a distance of ConnectionRange from each other. If NodePoints is non-null, the value it points to will be assigned the vector of points -- otherwise, the vector of points will be disposed of.
-        Net MakeNet_3D(size_t NodeCount, float ConnectionRange, brendancuda::Random::AnyRNG<uint64_t> RNG, thrust::device_vector<float_3>** NodePoints);
+        Net MakeNet_3D(size_t NodeCount, float ConnectionRange, brendancuda::random::AnyRNG<uint64_t> RNG, thrust::device_vector<float_3>** NodePoints);
     }
 }

--- a/nets_net.cu
+++ b/nets_net.cu
@@ -6,20 +6,20 @@
 #include <device_launch_parameters.h>
 #include <string>
 
-__global__ void net_addConnection_checkForPreexistence(BrendanCUDA::Nets::NetNode** arr, BrendanCUDA::Nets::NetNode* v, bool* opt) {
+__global__ void net_addConnection_checkForPreexistence(brendancuda::Nets::NetNode** arr, brendancuda::Nets::NetNode* v, bool* opt) {
     if (arr[blockIdx.x] == v) {
         *opt = true;
     }
 }
 
-__global__ void replaceBase(BrendanCUDA::Nets::NetNode* oldBase, BrendanCUDA::Nets::NetNode** oldNodes, BrendanCUDA::Nets::NetNode* newBase, BrendanCUDA::Nets::NetNode** newNodes) {
-    BrendanCUDA::Nets::NetNode* oldNode = oldNodes[blockIdx.x];
-    BrendanCUDA::Nets::NetNode*& newNode = newNodes[blockIdx.x];
+__global__ void replaceBase(brendancuda::Nets::NetNode* oldBase, brendancuda::Nets::NetNode** oldNodes, brendancuda::Nets::NetNode* newBase, brendancuda::Nets::NetNode** newNodes) {
+    brendancuda::Nets::NetNode* oldNode = oldNodes[blockIdx.x];
+    brendancuda::Nets::NetNode*& newNode = newNodes[blockIdx.x];
 
     newNode = oldNode - oldBase + newBase;
 }
 
-BrendanCUDA::Nets::Net BrendanCUDA::Nets::Net::Clone(dataCloner_t DataCloner) const {
+brendancuda::Nets::Net brendancuda::Nets::Net::Clone(dataCloner_t DataCloner) const {
     thrust::device_vector<NetNode>* p_newNodes = new thrust::device_vector<NetNode>(nodes.size());
     thrust::device_vector<NetNode>& newNodes = *p_newNodes;
     NetNode* oldBaseNN = nodes.data().get();
@@ -39,7 +39,7 @@ BrendanCUDA::Nets::Net BrendanCUDA::Nets::Net::Clone(dataCloner_t DataCloner) co
     return Net(newNodes);
 }
 
-bool BrendanCUDA::Nets::Net::AddConnection_OnlyInput(NetNode* InputNode, NetNode* OutputNode, bool CheckForPreexistence, bool CheckForAvailableExcess) {
+bool brendancuda::Nets::Net::AddConnection_OnlyInput(NetNode* InputNode, NetNode* OutputNode, bool CheckForPreexistence, bool CheckForAvailableExcess) {
     NetNode in = GetVR(InputNode);
 
     if (in.outputs) {
@@ -95,7 +95,7 @@ bool BrendanCUDA::Nets::Net::AddConnection_OnlyInput(NetNode* InputNode, NetNode
     SetVR(InputNode, in);
     return true;
 }
-bool BrendanCUDA::Nets::Net::AddConnection_OnlyOutput(NetNode* InputNode, NetNode* OutputNode, bool CheckForPreexistence, bool CheckForAvailableExcess) {
+bool brendancuda::Nets::Net::AddConnection_OnlyOutput(NetNode* InputNode, NetNode* OutputNode, bool CheckForPreexistence, bool CheckForAvailableExcess) {
     NetNode on = GetVR(InputNode);
 
     if (on.inputs) {
@@ -151,7 +151,7 @@ bool BrendanCUDA::Nets::Net::AddConnection_OnlyOutput(NetNode* InputNode, NetNod
     SetVR(OutputNode, on);
     return true;
 }
-bool BrendanCUDA::Nets::Net::AddConnection(NetNode* InputNode, NetNode* OutputNode, bool CheckForPreexistence, bool CheckForAvailableExcess) {
+bool brendancuda::Nets::Net::AddConnection(NetNode* InputNode, NetNode* OutputNode, bool CheckForPreexistence, bool CheckForAvailableExcess) {
     if (InputNode != OutputNode) {
         NetNode in = GetVR(InputNode);
         NetNode on = GetVR(OutputNode);
@@ -330,7 +330,7 @@ bool BrendanCUDA::Nets::Net::AddConnection(NetNode* InputNode, NetNode* OutputNo
     }
 }
 
-bool BrendanCUDA::Nets::Net::RemoveConnection_OnlyInput(NetNode* InputNode, NetNode* OutputNode, bool RemoveExcess) {
+bool brendancuda::Nets::Net::RemoveConnection_OnlyInput(NetNode* InputNode, NetNode* OutputNode, bool RemoveExcess) {
     NetNode in = GetVR(InputNode);
 
     if (in.outputs) {
@@ -387,7 +387,7 @@ ExitB:
         return false;
     }
 }
-bool BrendanCUDA::Nets::Net::RemoveConnection_OnlyOutput(NetNode* InputNode, NetNode* OutputNode, bool RemoveExcess) {
+bool brendancuda::Nets::Net::RemoveConnection_OnlyOutput(NetNode* InputNode, NetNode* OutputNode, bool RemoveExcess) {
     NetNode on = GetVR(OutputNode);
 
     if (on.inputs) {
@@ -444,7 +444,7 @@ ExitB:
         return false;
     }
 }
-bool BrendanCUDA::Nets::Net::RemoveConnection(NetNode* InputNode, NetNode* OutputNode, bool RemoveExcess) {
+bool brendancuda::Nets::Net::RemoveConnection(NetNode* InputNode, NetNode* OutputNode, bool RemoveExcess) {
     if (InputNode != OutputNode) {
         NetNode in = GetVR(InputNode);
         NetNode on = GetVR(OutputNode);
@@ -631,7 +631,7 @@ Exit1D:
     }
 }
 
-void BrendanCUDA::Nets::Net::RemoveAllConnections(NetNode* Node, bool RemoveExcess) {
+void brendancuda::Nets::Net::RemoveAllConnections(NetNode* Node, bool RemoveExcess) {
     NetNode nn = GetVR(Node);
     NetNode** inputs = new NetNode*[nn.inputCount];
     NetNode** outputs = new NetNode*[nn.outputCount];
@@ -661,7 +661,7 @@ void BrendanCUDA::Nets::Net::RemoveAllConnections(NetNode* Node, bool RemoveExce
     nn.outputCount = 0;
     SetVR(Node, nn);
 }
-void BrendanCUDA::Nets::Net::PrintTo(std::ostream& Output, size_t IndentPre, size_t IndentSize) const {
+void brendancuda::Nets::Net::PrintTo(std::ostream& Output, size_t IndentPre, size_t IndentSize) const {
     std::string pi(IndentPre, ' ');
     std::string si(IndentSize, ' ');
     const thrust::device_vector<NetNode>& vec = DataVec();

--- a/nets_net.cu
+++ b/nets_net.cu
@@ -6,20 +6,20 @@
 #include <device_launch_parameters.h>
 #include <string>
 
-__global__ void net_addConnection_checkForPreexistence(brendancuda::Nets::NetNode** arr, brendancuda::Nets::NetNode* v, bool* opt) {
+__global__ void net_addConnection_checkForPreexistence(brendancuda::nets::NetNode** arr, brendancuda::nets::NetNode* v, bool* opt) {
     if (arr[blockIdx.x] == v) {
         *opt = true;
     }
 }
 
-__global__ void replaceBase(brendancuda::Nets::NetNode* oldBase, brendancuda::Nets::NetNode** oldNodes, brendancuda::Nets::NetNode* newBase, brendancuda::Nets::NetNode** newNodes) {
-    brendancuda::Nets::NetNode* oldNode = oldNodes[blockIdx.x];
-    brendancuda::Nets::NetNode*& newNode = newNodes[blockIdx.x];
+__global__ void replaceBase(brendancuda::nets::NetNode* oldBase, brendancuda::nets::NetNode** oldNodes, brendancuda::nets::NetNode* newBase, brendancuda::nets::NetNode** newNodes) {
+    brendancuda::nets::NetNode* oldNode = oldNodes[blockIdx.x];
+    brendancuda::nets::NetNode*& newNode = newNodes[blockIdx.x];
 
     newNode = oldNode - oldBase + newBase;
 }
 
-brendancuda::Nets::Net brendancuda::Nets::Net::Clone(dataCloner_t DataCloner) const {
+brendancuda::nets::Net brendancuda::nets::Net::Clone(dataCloner_t DataCloner) const {
     thrust::device_vector<NetNode>* p_newNodes = new thrust::device_vector<NetNode>(nodes.size());
     thrust::device_vector<NetNode>& newNodes = *p_newNodes;
     NetNode* oldBaseNN = nodes.data().get();
@@ -39,7 +39,7 @@ brendancuda::Nets::Net brendancuda::Nets::Net::Clone(dataCloner_t DataCloner) co
     return Net(newNodes);
 }
 
-bool brendancuda::Nets::Net::AddConnection_OnlyInput(NetNode* InputNode, NetNode* OutputNode, bool CheckForPreexistence, bool CheckForAvailableExcess) {
+bool brendancuda::nets::Net::AddConnection_OnlyInput(NetNode* InputNode, NetNode* OutputNode, bool CheckForPreexistence, bool CheckForAvailableExcess) {
     NetNode in = GetVR(InputNode);
 
     if (in.outputs) {
@@ -95,7 +95,7 @@ bool brendancuda::Nets::Net::AddConnection_OnlyInput(NetNode* InputNode, NetNode
     SetVR(InputNode, in);
     return true;
 }
-bool brendancuda::Nets::Net::AddConnection_OnlyOutput(NetNode* InputNode, NetNode* OutputNode, bool CheckForPreexistence, bool CheckForAvailableExcess) {
+bool brendancuda::nets::Net::AddConnection_OnlyOutput(NetNode* InputNode, NetNode* OutputNode, bool CheckForPreexistence, bool CheckForAvailableExcess) {
     NetNode on = GetVR(InputNode);
 
     if (on.inputs) {
@@ -151,7 +151,7 @@ bool brendancuda::Nets::Net::AddConnection_OnlyOutput(NetNode* InputNode, NetNod
     SetVR(OutputNode, on);
     return true;
 }
-bool brendancuda::Nets::Net::AddConnection(NetNode* InputNode, NetNode* OutputNode, bool CheckForPreexistence, bool CheckForAvailableExcess) {
+bool brendancuda::nets::Net::AddConnection(NetNode* InputNode, NetNode* OutputNode, bool CheckForPreexistence, bool CheckForAvailableExcess) {
     if (InputNode != OutputNode) {
         NetNode in = GetVR(InputNode);
         NetNode on = GetVR(OutputNode);
@@ -330,7 +330,7 @@ bool brendancuda::Nets::Net::AddConnection(NetNode* InputNode, NetNode* OutputNo
     }
 }
 
-bool brendancuda::Nets::Net::RemoveConnection_OnlyInput(NetNode* InputNode, NetNode* OutputNode, bool RemoveExcess) {
+bool brendancuda::nets::Net::RemoveConnection_OnlyInput(NetNode* InputNode, NetNode* OutputNode, bool RemoveExcess) {
     NetNode in = GetVR(InputNode);
 
     if (in.outputs) {
@@ -387,7 +387,7 @@ ExitB:
         return false;
     }
 }
-bool brendancuda::Nets::Net::RemoveConnection_OnlyOutput(NetNode* InputNode, NetNode* OutputNode, bool RemoveExcess) {
+bool brendancuda::nets::Net::RemoveConnection_OnlyOutput(NetNode* InputNode, NetNode* OutputNode, bool RemoveExcess) {
     NetNode on = GetVR(OutputNode);
 
     if (on.inputs) {
@@ -444,7 +444,7 @@ ExitB:
         return false;
     }
 }
-bool brendancuda::Nets::Net::RemoveConnection(NetNode* InputNode, NetNode* OutputNode, bool RemoveExcess) {
+bool brendancuda::nets::Net::RemoveConnection(NetNode* InputNode, NetNode* OutputNode, bool RemoveExcess) {
     if (InputNode != OutputNode) {
         NetNode in = GetVR(InputNode);
         NetNode on = GetVR(OutputNode);
@@ -631,7 +631,7 @@ Exit1D:
     }
 }
 
-void brendancuda::Nets::Net::RemoveAllConnections(NetNode* Node, bool RemoveExcess) {
+void brendancuda::nets::Net::RemoveAllConnections(NetNode* Node, bool RemoveExcess) {
     NetNode nn = GetVR(Node);
     NetNode** inputs = new NetNode*[nn.inputCount];
     NetNode** outputs = new NetNode*[nn.outputCount];
@@ -661,7 +661,7 @@ void brendancuda::Nets::Net::RemoveAllConnections(NetNode* Node, bool RemoveExce
     nn.outputCount = 0;
     SetVR(Node, nn);
 }
-void brendancuda::Nets::Net::PrintTo(std::ostream& Output, size_t IndentPre, size_t IndentSize) const {
+void brendancuda::nets::Net::PrintTo(std::ostream& Output, size_t IndentPre, size_t IndentSize) const {
     std::string pi(IndentPre, ' ');
     std::string si(IndentSize, ' ');
     const thrust::device_vector<NetNode>& vec = DataVec();

--- a/nets_net.cu
+++ b/nets_net.cu
@@ -6,20 +6,20 @@
 #include <device_launch_parameters.h>
 #include <string>
 
-__global__ void net_addConnection_checkForPreexistence(brendancuda::nets::NetNode** arr, brendancuda::nets::NetNode* v, bool* opt) {
+__global__ void net_addConnection_checkForPreexistence(bcuda::nets::NetNode** arr, bcuda::nets::NetNode* v, bool* opt) {
     if (arr[blockIdx.x] == v) {
         *opt = true;
     }
 }
 
-__global__ void replaceBase(brendancuda::nets::NetNode* oldBase, brendancuda::nets::NetNode** oldNodes, brendancuda::nets::NetNode* newBase, brendancuda::nets::NetNode** newNodes) {
-    brendancuda::nets::NetNode* oldNode = oldNodes[blockIdx.x];
-    brendancuda::nets::NetNode*& newNode = newNodes[blockIdx.x];
+__global__ void replaceBase(bcuda::nets::NetNode* oldBase, bcuda::nets::NetNode** oldNodes, bcuda::nets::NetNode* newBase, bcuda::nets::NetNode** newNodes) {
+    bcuda::nets::NetNode* oldNode = oldNodes[blockIdx.x];
+    bcuda::nets::NetNode*& newNode = newNodes[blockIdx.x];
 
     newNode = oldNode - oldBase + newBase;
 }
 
-brendancuda::nets::Net brendancuda::nets::Net::Clone(dataCloner_t DataCloner) const {
+bcuda::nets::Net bcuda::nets::Net::Clone(dataCloner_t DataCloner) const {
     thrust::device_vector<NetNode>* p_newNodes = new thrust::device_vector<NetNode>(nodes.size());
     thrust::device_vector<NetNode>& newNodes = *p_newNodes;
     NetNode* oldBaseNN = nodes.data().get();
@@ -39,7 +39,7 @@ brendancuda::nets::Net brendancuda::nets::Net::Clone(dataCloner_t DataCloner) co
     return Net(newNodes);
 }
 
-bool brendancuda::nets::Net::AddConnection_OnlyInput(NetNode* InputNode, NetNode* OutputNode, bool CheckForPreexistence, bool CheckForAvailableExcess) {
+bool bcuda::nets::Net::AddConnection_OnlyInput(NetNode* InputNode, NetNode* OutputNode, bool CheckForPreexistence, bool CheckForAvailableExcess) {
     NetNode in = GetVR(InputNode);
 
     if (in.outputs) {
@@ -95,7 +95,7 @@ bool brendancuda::nets::Net::AddConnection_OnlyInput(NetNode* InputNode, NetNode
     SetVR(InputNode, in);
     return true;
 }
-bool brendancuda::nets::Net::AddConnection_OnlyOutput(NetNode* InputNode, NetNode* OutputNode, bool CheckForPreexistence, bool CheckForAvailableExcess) {
+bool bcuda::nets::Net::AddConnection_OnlyOutput(NetNode* InputNode, NetNode* OutputNode, bool CheckForPreexistence, bool CheckForAvailableExcess) {
     NetNode on = GetVR(InputNode);
 
     if (on.inputs) {
@@ -151,7 +151,7 @@ bool brendancuda::nets::Net::AddConnection_OnlyOutput(NetNode* InputNode, NetNod
     SetVR(OutputNode, on);
     return true;
 }
-bool brendancuda::nets::Net::AddConnection(NetNode* InputNode, NetNode* OutputNode, bool CheckForPreexistence, bool CheckForAvailableExcess) {
+bool bcuda::nets::Net::AddConnection(NetNode* InputNode, NetNode* OutputNode, bool CheckForPreexistence, bool CheckForAvailableExcess) {
     if (InputNode != OutputNode) {
         NetNode in = GetVR(InputNode);
         NetNode on = GetVR(OutputNode);
@@ -330,7 +330,7 @@ bool brendancuda::nets::Net::AddConnection(NetNode* InputNode, NetNode* OutputNo
     }
 }
 
-bool brendancuda::nets::Net::RemoveConnection_OnlyInput(NetNode* InputNode, NetNode* OutputNode, bool RemoveExcess) {
+bool bcuda::nets::Net::RemoveConnection_OnlyInput(NetNode* InputNode, NetNode* OutputNode, bool RemoveExcess) {
     NetNode in = GetVR(InputNode);
 
     if (in.outputs) {
@@ -387,7 +387,7 @@ ExitB:
         return false;
     }
 }
-bool brendancuda::nets::Net::RemoveConnection_OnlyOutput(NetNode* InputNode, NetNode* OutputNode, bool RemoveExcess) {
+bool bcuda::nets::Net::RemoveConnection_OnlyOutput(NetNode* InputNode, NetNode* OutputNode, bool RemoveExcess) {
     NetNode on = GetVR(OutputNode);
 
     if (on.inputs) {
@@ -444,7 +444,7 @@ ExitB:
         return false;
     }
 }
-bool brendancuda::nets::Net::RemoveConnection(NetNode* InputNode, NetNode* OutputNode, bool RemoveExcess) {
+bool bcuda::nets::Net::RemoveConnection(NetNode* InputNode, NetNode* OutputNode, bool RemoveExcess) {
     if (InputNode != OutputNode) {
         NetNode in = GetVR(InputNode);
         NetNode on = GetVR(OutputNode);
@@ -631,7 +631,7 @@ Exit1D:
     }
 }
 
-void brendancuda::nets::Net::RemoveAllConnections(NetNode* Node, bool RemoveExcess) {
+void bcuda::nets::Net::RemoveAllConnections(NetNode* Node, bool RemoveExcess) {
     NetNode nn = GetVR(Node);
     NetNode** inputs = new NetNode*[nn.inputCount];
     NetNode** outputs = new NetNode*[nn.outputCount];
@@ -661,7 +661,7 @@ void brendancuda::nets::Net::RemoveAllConnections(NetNode* Node, bool RemoveExce
     nn.outputCount = 0;
     SetVR(Node, nn);
 }
-void brendancuda::nets::Net::PrintTo(std::ostream& Output, size_t IndentPre, size_t IndentSize) const {
+void bcuda::nets::Net::PrintTo(std::ostream& Output, size_t IndentPre, size_t IndentSize) const {
     std::string pi(IndentPre, ' ');
     std::string si(IndentSize, ' ');
     const thrust::device_vector<NetNode>& vec = DataVec();

--- a/nets_net.h
+++ b/nets_net.h
@@ -6,13 +6,13 @@
 #include <thrust/device_vector.h>
 
 namespace brendancuda {
-    namespace Nets {
+    namespace nets {
         struct NetNode;
         //Destroys the NetNode::data field, provided context.
         using dataDestructor_t = void(*)(NetNode);
         //Clones the NetNode::data field, provided context.
         using dataCloner_t = void*(*)(NetNode);
-        //A node of a brendancuda::Nets::Net.
+        //A node of a brendancuda::nets::Net.
         struct NetNode {
             //A pointer to the data attached to the node.
             void* data;
@@ -25,20 +25,20 @@ namespace brendancuda {
             //The count of the output connections.
             size_t outputCount;
 
-            //Constructs a brendancuda::Nets::NetNode object.
+            //Constructs a brendancuda::nets::NetNode object.
             __host__ __device__ __forceinline NetNode();
 
-            //Disposes of a brendancuda::Nets::NetNode object.
+            //Disposes of a brendancuda::nets::NetNode object.
             __forceinline void Dispose(dataDestructor_t DataDestructor) const;
         };
         //A directed graph.
         class Net {
         public:
-            //Creates a brendancuda::Nets::Net object.
+            //Creates a brendancuda::nets::Net object.
             __forceinline Net();
-            //Creates a brendancuda::Nets::Net object, using Data as its vector of nodes without copying it.
+            //Creates a brendancuda::nets::Net object, using Data as its vector of nodes without copying it.
             __forceinline Net(thrust::device_vector<NetNode>& Data);
-            //Disposes of a brendancuda::Nets::Net object.
+            //Disposes of a brendancuda::nets::Net object.
             __forceinline void Dispose(dataDestructor_t DataDestructor);
             //Returns the vector of nodes, for external manipulation at the user's risk.
             __forceinline thrust::device_vector<NetNode>& DataVec();
@@ -52,7 +52,7 @@ namespace brendancuda {
             __forceinline thrust::device_reference<const NetNode> operator[](size_t i) const;
             //Prints a list of nodes, their identifiers, and their inputs and outputs to the Output stream. IndentPre is the amount of spaces (not indents) before the left of the printout, and IndentSize is the amount of spaces in each indent afterward.
             void PrintTo(std::ostream& Output, size_t IndentPre = 0, size_t IndentSize = 4) const;
-            //Makes a deep-copy of the brendancuda::Nets::Net object.
+            //Makes a deep-copy of the brendancuda::nets::Net object.
             Net Clone(dataCloner_t DataCloner) const;
 
             //Adds a connection between InputNode and OutputNode that goes from InputNode to OutputNode, but only changes InputNode. Use at your own risk.
@@ -75,7 +75,7 @@ namespace brendancuda {
     }
 }
 
-__host__ __device__ __forceinline brendancuda::Nets::NetNode::NetNode() {
+__host__ __device__ __forceinline brendancuda::nets::NetNode::NetNode() {
     data = 0;
     inputs = 0;
     inputCount = 0;
@@ -83,7 +83,7 @@ __host__ __device__ __forceinline brendancuda::Nets::NetNode::NetNode() {
     outputCount = 0;
 }
 
-__forceinline void brendancuda::Nets::NetNode::Dispose(dataDestructor_t DataDestructor) const {
+__forceinline void brendancuda::nets::NetNode::Dispose(dataDestructor_t DataDestructor) const {
     if (DataDestructor) {
         DataDestructor(*this);
     }
@@ -96,39 +96,39 @@ __forceinline void brendancuda::Nets::NetNode::Dispose(dataDestructor_t DataDest
 #endif
 }
 
-__forceinline brendancuda::Nets::Net::Net()
+__forceinline brendancuda::nets::Net::Net()
     : nodes(*(new thrust::device_vector<NetNode>())) {}
 
-__forceinline brendancuda::Nets::Net::Net(thrust::device_vector<NetNode>& Data)
+__forceinline brendancuda::nets::Net::Net(thrust::device_vector<NetNode>& Data)
     : nodes(Data) {}
 
-__forceinline void brendancuda::Nets::Net::Dispose(dataDestructor_t DataDestructor) {
+__forceinline void brendancuda::nets::Net::Dispose(dataDestructor_t DataDestructor) {
     for (size_t i = 0; i < nodes.size(); ++i) {
         ((NetNode)nodes[i]).Dispose(DataDestructor);
     }
     delete (&nodes);
 }
 
-__forceinline thrust::device_vector<brendancuda::Nets::NetNode>& brendancuda::Nets::Net::DataVec() {
+__forceinline thrust::device_vector<brendancuda::nets::NetNode>& brendancuda::nets::Net::DataVec() {
     return nodes;
 }
 
-__forceinline const thrust::device_vector<brendancuda::Nets::NetNode>& brendancuda::Nets::Net::DataVec() const {
+__forceinline const thrust::device_vector<brendancuda::nets::NetNode>& brendancuda::nets::Net::DataVec() const {
     return nodes;
 }
 
-__forceinline thrust::device_ptr<brendancuda::Nets::NetNode> brendancuda::Nets::Net::DataPtr() {
+__forceinline thrust::device_ptr<brendancuda::nets::NetNode> brendancuda::nets::Net::DataPtr() {
     return nodes.data();
 }
 
-__forceinline thrust::device_ptr<const brendancuda::Nets::NetNode> brendancuda::Nets::Net::DataPtr() const {
+__forceinline thrust::device_ptr<const brendancuda::nets::NetNode> brendancuda::nets::Net::DataPtr() const {
     return nodes.data();
 }
 
-__forceinline thrust::device_reference<brendancuda::Nets::NetNode> brendancuda::Nets::Net::operator[](size_t i) {
+__forceinline thrust::device_reference<brendancuda::nets::NetNode> brendancuda::nets::Net::operator[](size_t i) {
     return nodes[i];
 }
 
-__forceinline thrust::device_reference<const brendancuda::Nets::NetNode> brendancuda::Nets::Net::operator[](size_t i) const {
+__forceinline thrust::device_reference<const brendancuda::nets::NetNode> brendancuda::nets::Net::operator[](size_t i) const {
     return nodes[i];
 }

--- a/nets_net.h
+++ b/nets_net.h
@@ -5,14 +5,14 @@
 #include <ostream>
 #include <thrust/device_vector.h>
 
-namespace BrendanCUDA {
+namespace brendancuda {
     namespace Nets {
         struct NetNode;
         //Destroys the NetNode::data field, provided context.
         using dataDestructor_t = void(*)(NetNode);
         //Clones the NetNode::data field, provided context.
         using dataCloner_t = void*(*)(NetNode);
-        //A node of a BrendanCUDA::Nets::Net.
+        //A node of a brendancuda::Nets::Net.
         struct NetNode {
             //A pointer to the data attached to the node.
             void* data;
@@ -25,20 +25,20 @@ namespace BrendanCUDA {
             //The count of the output connections.
             size_t outputCount;
 
-            //Constructs a BrendanCUDA::Nets::NetNode object.
+            //Constructs a brendancuda::Nets::NetNode object.
             __host__ __device__ __forceinline NetNode();
 
-            //Disposes of a BrendanCUDA::Nets::NetNode object.
+            //Disposes of a brendancuda::Nets::NetNode object.
             __forceinline void Dispose(dataDestructor_t DataDestructor) const;
         };
         //A directed graph.
         class Net {
         public:
-            //Creates a BrendanCUDA::Nets::Net object.
+            //Creates a brendancuda::Nets::Net object.
             __forceinline Net();
-            //Creates a BrendanCUDA::Nets::Net object, using Data as its vector of nodes without copying it.
+            //Creates a brendancuda::Nets::Net object, using Data as its vector of nodes without copying it.
             __forceinline Net(thrust::device_vector<NetNode>& Data);
-            //Disposes of a BrendanCUDA::Nets::Net object.
+            //Disposes of a brendancuda::Nets::Net object.
             __forceinline void Dispose(dataDestructor_t DataDestructor);
             //Returns the vector of nodes, for external manipulation at the user's risk.
             __forceinline thrust::device_vector<NetNode>& DataVec();
@@ -52,7 +52,7 @@ namespace BrendanCUDA {
             __forceinline thrust::device_reference<const NetNode> operator[](size_t i) const;
             //Prints a list of nodes, their identifiers, and their inputs and outputs to the Output stream. IndentPre is the amount of spaces (not indents) before the left of the printout, and IndentSize is the amount of spaces in each indent afterward.
             void PrintTo(std::ostream& Output, size_t IndentPre = 0, size_t IndentSize = 4) const;
-            //Makes a deep-copy of the BrendanCUDA::Nets::Net object.
+            //Makes a deep-copy of the brendancuda::Nets::Net object.
             Net Clone(dataCloner_t DataCloner) const;
 
             //Adds a connection between InputNode and OutputNode that goes from InputNode to OutputNode, but only changes InputNode. Use at your own risk.
@@ -75,7 +75,7 @@ namespace BrendanCUDA {
     }
 }
 
-__host__ __device__ __forceinline BrendanCUDA::Nets::NetNode::NetNode() {
+__host__ __device__ __forceinline brendancuda::Nets::NetNode::NetNode() {
     data = 0;
     inputs = 0;
     inputCount = 0;
@@ -83,7 +83,7 @@ __host__ __device__ __forceinline BrendanCUDA::Nets::NetNode::NetNode() {
     outputCount = 0;
 }
 
-__forceinline void BrendanCUDA::Nets::NetNode::Dispose(dataDestructor_t DataDestructor) const {
+__forceinline void brendancuda::Nets::NetNode::Dispose(dataDestructor_t DataDestructor) const {
     if (DataDestructor) {
         DataDestructor(*this);
     }
@@ -96,39 +96,39 @@ __forceinline void BrendanCUDA::Nets::NetNode::Dispose(dataDestructor_t DataDest
 #endif
 }
 
-__forceinline BrendanCUDA::Nets::Net::Net()
+__forceinline brendancuda::Nets::Net::Net()
     : nodes(*(new thrust::device_vector<NetNode>())) {}
 
-__forceinline BrendanCUDA::Nets::Net::Net(thrust::device_vector<NetNode>& Data)
+__forceinline brendancuda::Nets::Net::Net(thrust::device_vector<NetNode>& Data)
     : nodes(Data) {}
 
-__forceinline void BrendanCUDA::Nets::Net::Dispose(dataDestructor_t DataDestructor) {
+__forceinline void brendancuda::Nets::Net::Dispose(dataDestructor_t DataDestructor) {
     for (size_t i = 0; i < nodes.size(); ++i) {
         ((NetNode)nodes[i]).Dispose(DataDestructor);
     }
     delete (&nodes);
 }
 
-__forceinline thrust::device_vector<BrendanCUDA::Nets::NetNode>& BrendanCUDA::Nets::Net::DataVec() {
+__forceinline thrust::device_vector<brendancuda::Nets::NetNode>& brendancuda::Nets::Net::DataVec() {
     return nodes;
 }
 
-__forceinline const thrust::device_vector<BrendanCUDA::Nets::NetNode>& BrendanCUDA::Nets::Net::DataVec() const {
+__forceinline const thrust::device_vector<brendancuda::Nets::NetNode>& brendancuda::Nets::Net::DataVec() const {
     return nodes;
 }
 
-__forceinline thrust::device_ptr<BrendanCUDA::Nets::NetNode> BrendanCUDA::Nets::Net::DataPtr() {
+__forceinline thrust::device_ptr<brendancuda::Nets::NetNode> brendancuda::Nets::Net::DataPtr() {
     return nodes.data();
 }
 
-__forceinline thrust::device_ptr<const BrendanCUDA::Nets::NetNode> BrendanCUDA::Nets::Net::DataPtr() const {
+__forceinline thrust::device_ptr<const brendancuda::Nets::NetNode> brendancuda::Nets::Net::DataPtr() const {
     return nodes.data();
 }
 
-__forceinline thrust::device_reference<BrendanCUDA::Nets::NetNode> BrendanCUDA::Nets::Net::operator[](size_t i) {
+__forceinline thrust::device_reference<brendancuda::Nets::NetNode> brendancuda::Nets::Net::operator[](size_t i) {
     return nodes[i];
 }
 
-__forceinline thrust::device_reference<const BrendanCUDA::Nets::NetNode> BrendanCUDA::Nets::Net::operator[](size_t i) const {
+__forceinline thrust::device_reference<const brendancuda::Nets::NetNode> brendancuda::Nets::Net::operator[](size_t i) const {
     return nodes[i];
 }

--- a/nets_net.h
+++ b/nets_net.h
@@ -5,14 +5,14 @@
 #include <ostream>
 #include <thrust/device_vector.h>
 
-namespace brendancuda {
+namespace bcuda {
     namespace nets {
         struct NetNode;
         //Destroys the NetNode::data field, provided context.
         using dataDestructor_t = void(*)(NetNode);
         //Clones the NetNode::data field, provided context.
         using dataCloner_t = void*(*)(NetNode);
-        //A node of a brendancuda::nets::Net.
+        //A node of a bcuda::nets::Net.
         struct NetNode {
             //A pointer to the data attached to the node.
             void* data;
@@ -25,20 +25,20 @@ namespace brendancuda {
             //The count of the output connections.
             size_t outputCount;
 
-            //Constructs a brendancuda::nets::NetNode object.
+            //Constructs a bcuda::nets::NetNode object.
             __host__ __device__ __forceinline NetNode();
 
-            //Disposes of a brendancuda::nets::NetNode object.
+            //Disposes of a bcuda::nets::NetNode object.
             __forceinline void Dispose(dataDestructor_t DataDestructor) const;
         };
         //A directed graph.
         class Net {
         public:
-            //Creates a brendancuda::nets::Net object.
+            //Creates a bcuda::nets::Net object.
             __forceinline Net();
-            //Creates a brendancuda::nets::Net object, using Data as its vector of nodes without copying it.
+            //Creates a bcuda::nets::Net object, using Data as its vector of nodes without copying it.
             __forceinline Net(thrust::device_vector<NetNode>& Data);
-            //Disposes of a brendancuda::nets::Net object.
+            //Disposes of a bcuda::nets::Net object.
             __forceinline void Dispose(dataDestructor_t DataDestructor);
             //Returns the vector of nodes, for external manipulation at the user's risk.
             __forceinline thrust::device_vector<NetNode>& DataVec();
@@ -52,7 +52,7 @@ namespace brendancuda {
             __forceinline thrust::device_reference<const NetNode> operator[](size_t i) const;
             //Prints a list of nodes, their identifiers, and their inputs and outputs to the Output stream. IndentPre is the amount of spaces (not indents) before the left of the printout, and IndentSize is the amount of spaces in each indent afterward.
             void PrintTo(std::ostream& Output, size_t IndentPre = 0, size_t IndentSize = 4) const;
-            //Makes a deep-copy of the brendancuda::nets::Net object.
+            //Makes a deep-copy of the bcuda::nets::Net object.
             Net Clone(dataCloner_t DataCloner) const;
 
             //Adds a connection between InputNode and OutputNode that goes from InputNode to OutputNode, but only changes InputNode. Use at your own risk.
@@ -75,7 +75,7 @@ namespace brendancuda {
     }
 }
 
-__host__ __device__ __forceinline brendancuda::nets::NetNode::NetNode() {
+__host__ __device__ __forceinline bcuda::nets::NetNode::NetNode() {
     data = 0;
     inputs = 0;
     inputCount = 0;
@@ -83,7 +83,7 @@ __host__ __device__ __forceinline brendancuda::nets::NetNode::NetNode() {
     outputCount = 0;
 }
 
-__forceinline void brendancuda::nets::NetNode::Dispose(dataDestructor_t DataDestructor) const {
+__forceinline void bcuda::nets::NetNode::Dispose(dataDestructor_t DataDestructor) const {
     if (DataDestructor) {
         DataDestructor(*this);
     }
@@ -96,39 +96,39 @@ __forceinline void brendancuda::nets::NetNode::Dispose(dataDestructor_t DataDest
 #endif
 }
 
-__forceinline brendancuda::nets::Net::Net()
+__forceinline bcuda::nets::Net::Net()
     : nodes(*(new thrust::device_vector<NetNode>())) {}
 
-__forceinline brendancuda::nets::Net::Net(thrust::device_vector<NetNode>& Data)
+__forceinline bcuda::nets::Net::Net(thrust::device_vector<NetNode>& Data)
     : nodes(Data) {}
 
-__forceinline void brendancuda::nets::Net::Dispose(dataDestructor_t DataDestructor) {
+__forceinline void bcuda::nets::Net::Dispose(dataDestructor_t DataDestructor) {
     for (size_t i = 0; i < nodes.size(); ++i) {
         ((NetNode)nodes[i]).Dispose(DataDestructor);
     }
     delete (&nodes);
 }
 
-__forceinline thrust::device_vector<brendancuda::nets::NetNode>& brendancuda::nets::Net::DataVec() {
+__forceinline thrust::device_vector<bcuda::nets::NetNode>& bcuda::nets::Net::DataVec() {
     return nodes;
 }
 
-__forceinline const thrust::device_vector<brendancuda::nets::NetNode>& brendancuda::nets::Net::DataVec() const {
+__forceinline const thrust::device_vector<bcuda::nets::NetNode>& bcuda::nets::Net::DataVec() const {
     return nodes;
 }
 
-__forceinline thrust::device_ptr<brendancuda::nets::NetNode> brendancuda::nets::Net::DataPtr() {
+__forceinline thrust::device_ptr<bcuda::nets::NetNode> bcuda::nets::Net::DataPtr() {
     return nodes.data();
 }
 
-__forceinline thrust::device_ptr<const brendancuda::nets::NetNode> brendancuda::nets::Net::DataPtr() const {
+__forceinline thrust::device_ptr<const bcuda::nets::NetNode> bcuda::nets::Net::DataPtr() const {
     return nodes.data();
 }
 
-__forceinline thrust::device_reference<brendancuda::nets::NetNode> brendancuda::nets::Net::operator[](size_t i) {
+__forceinline thrust::device_reference<bcuda::nets::NetNode> bcuda::nets::Net::operator[](size_t i) {
     return nodes[i];
 }
 
-__forceinline thrust::device_reference<const brendancuda::nets::NetNode> brendancuda::nets::Net::operator[](size_t i) const {
+__forceinline thrust::device_reference<const bcuda::nets::NetNode> bcuda::nets::Net::operator[](size_t i) const {
     return nodes[i];
 }

--- a/packs.h
+++ b/packs.h
@@ -3,7 +3,7 @@
 #include <type_traits>
 
 namespace brendancuda {
-    namespace Packs {
+    namespace packs {
         namespace details {
             template <uintmax_t _Idx, typename... _Ts>
             struct typeAt;

--- a/packs.h
+++ b/packs.h
@@ -2,7 +2,7 @@
 
 #include <type_traits>
 
-namespace BrendanCUDA {
+namespace brendancuda {
     namespace Packs {
         namespace details {
             template <uintmax_t _Idx, typename... _Ts>

--- a/packs.h
+++ b/packs.h
@@ -2,7 +2,7 @@
 
 #include <type_traits>
 
-namespace brendancuda {
+namespace bcuda {
     namespace packs {
         namespace details {
             template <uintmax_t _Idx, typename... _Ts>

--- a/points.h
+++ b/points.h
@@ -4,7 +4,7 @@
 #include <cstdint>
 #include <cuda_runtime.h>
 
-namespace BrendanCUDA {
+namespace brendancuda {
     template <std::unsigned_integral _TIndex, std::unsigned_integral _TVectorElement, size_t _VectorLength, bool _RowMajor>
     __host__ __device__ constexpr __forceinline _TIndex CoordinatesToIndex(FixedVector<_TVectorElement, _VectorLength> Dimensions, FixedVector<_TVectorElement, _VectorLength> Coordinates);
     template <std::unsigned_integral _TIndex, std::unsigned_integral _TVectorElement, size_t _VectorLength, bool _RowMajor>
@@ -12,7 +12,7 @@ namespace BrendanCUDA {
 }
 
 template <std::unsigned_integral _TIndex, std::unsigned_integral _TVectorElement, size_t _VectorLength, bool _RowMajor>
-__host__ __device__ constexpr __forceinline _TIndex BrendanCUDA::CoordinatesToIndex(FixedVector<_TVectorElement, _VectorLength> Dimensions, FixedVector<_TVectorElement, _VectorLength> Coordinates) {
+__host__ __device__ constexpr __forceinline _TIndex brendancuda::CoordinatesToIndex(FixedVector<_TVectorElement, _VectorLength> Dimensions, FixedVector<_TVectorElement, _VectorLength> Coordinates) {
     _TIndex idx = 0;
     if constexpr (_RowMajor) {
         for (size_t i = _VectorLength - 1; i != (size_t)-1; --i) {
@@ -29,7 +29,7 @@ __host__ __device__ constexpr __forceinline _TIndex BrendanCUDA::CoordinatesToIn
     return idx;
 }
 template <std::unsigned_integral _TIndex, std::unsigned_integral _TVectorElement, size_t _VectorLength, bool _RowMajor>
-__host__ __device__ constexpr __forceinline BrendanCUDA::FixedVector<_TVectorElement, _VectorLength> BrendanCUDA::IndexToCoordinates(FixedVector<_TVectorElement, _VectorLength> Dimensions, _TIndex Index) {
+__host__ __device__ constexpr __forceinline brendancuda::FixedVector<_TVectorElement, _VectorLength> brendancuda::IndexToCoordinates(FixedVector<_TVectorElement, _VectorLength> Dimensions, _TIndex Index) {
     FixedVector<_TVectorElement, _VectorLength> r;
     if constexpr (_RowMajor) {
         for (size_t i = _VectorLength - 1; i != (size_t)-1; ++i) {

--- a/points.h
+++ b/points.h
@@ -4,7 +4,7 @@
 #include <cstdint>
 #include <cuda_runtime.h>
 
-namespace brendancuda {
+namespace bcuda {
     template <std::unsigned_integral _TIndex, std::unsigned_integral _TVectorElement, size_t _VectorLength, bool _RowMajor>
     __host__ __device__ constexpr __forceinline _TIndex CoordinatesToIndex(FixedVector<_TVectorElement, _VectorLength> Dimensions, FixedVector<_TVectorElement, _VectorLength> Coordinates);
     template <std::unsigned_integral _TIndex, std::unsigned_integral _TVectorElement, size_t _VectorLength, bool _RowMajor>
@@ -12,7 +12,7 @@ namespace brendancuda {
 }
 
 template <std::unsigned_integral _TIndex, std::unsigned_integral _TVectorElement, size_t _VectorLength, bool _RowMajor>
-__host__ __device__ constexpr __forceinline _TIndex brendancuda::CoordinatesToIndex(FixedVector<_TVectorElement, _VectorLength> Dimensions, FixedVector<_TVectorElement, _VectorLength> Coordinates) {
+__host__ __device__ constexpr __forceinline _TIndex bcuda::CoordinatesToIndex(FixedVector<_TVectorElement, _VectorLength> Dimensions, FixedVector<_TVectorElement, _VectorLength> Coordinates) {
     _TIndex idx = 0;
     if constexpr (_RowMajor) {
         for (size_t i = _VectorLength - 1; i != (size_t)-1; --i) {
@@ -29,7 +29,7 @@ __host__ __device__ constexpr __forceinline _TIndex brendancuda::CoordinatesToIn
     return idx;
 }
 template <std::unsigned_integral _TIndex, std::unsigned_integral _TVectorElement, size_t _VectorLength, bool _RowMajor>
-__host__ __device__ constexpr __forceinline brendancuda::FixedVector<_TVectorElement, _VectorLength> brendancuda::IndexToCoordinates(FixedVector<_TVectorElement, _VectorLength> Dimensions, _TIndex Index) {
+__host__ __device__ constexpr __forceinline bcuda::FixedVector<_TVectorElement, _VectorLength> bcuda::IndexToCoordinates(FixedVector<_TVectorElement, _VectorLength> Dimensions, _TIndex Index) {
     FixedVector<_TVectorElement, _VectorLength> r;
     if constexpr (_RowMajor) {
         for (size_t i = _VectorLength - 1; i != (size_t)-1; ++i) {

--- a/rand_anyrng.h
+++ b/rand_anyrng.h
@@ -5,7 +5,7 @@
 #include <limits>
 #include <random>
 
-namespace brendancuda {
+namespace bcuda {
     namespace details {
         template <typename _TOutputType, typename _TRNG>
         _TOutputType RunRNGFunc(void* RNG) {

--- a/rand_anyrng.h
+++ b/rand_anyrng.h
@@ -15,7 +15,7 @@ namespace brendancuda {
         template <typename _TOutputType>
         using runRNGFunc_t = _TOutputType(*)(void*);
     }
-    namespace Random {
+    namespace random {
         template <std::unsigned_integral _TOutputType>
         class AnyRNG {
         public:

--- a/rand_anyrng.h
+++ b/rand_anyrng.h
@@ -5,7 +5,7 @@
 #include <limits>
 #include <random>
 
-namespace BrendanCUDA {
+namespace brendancuda {
     namespace details {
         template <typename _TOutputType, typename _TRNG>
         _TOutputType RunRNGFunc(void* RNG) {

--- a/rand_bits.h
+++ b/rand_bits.h
@@ -24,7 +24,7 @@ namespace brendancuda {
 
 template <std::uniform_random_bit_generator _TRNG>
 __host__ __forceinline uint32_t brendancuda::Random::Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
-    uint32_t ct = brendancuda::Binary::CountBitsB(ProbabilityOf1);
+    uint32_t ct = brendancuda::binary::CountBitsB(ProbabilityOf1);
     if (!ct) {
         return 0;
     }
@@ -43,7 +43,7 @@ __host__ __forceinline uint32_t brendancuda::Random::Get32Bits(uint32_t Probabil
 }
 template <std::uniform_random_bit_generator _TRNG>
 __host__ __forceinline uint64_t brendancuda::Random::Get64Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
-    uint32_t ct = brendancuda::Binary::CountBitsB(ProbabilityOf1);
+    uint32_t ct = brendancuda::binary::CountBitsB(ProbabilityOf1);
     if (!ct) {
         return 0;
     }
@@ -63,7 +63,7 @@ __host__ __forceinline uint64_t brendancuda::Random::Get64Bits(uint32_t Probabil
 #ifdef __CUDACC__
 template <brendancuda::KernelCurandState _TRNG>
 __device__ __forceinline uint32_t brendancuda::Random::Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
-    uint32_t ct = brendancuda::Binary::CountBitsB(ProbabilityOf1);
+    uint32_t ct = brendancuda::binary::CountBitsB(ProbabilityOf1);
     if (!ct) {
         return 0;
     }
@@ -81,7 +81,7 @@ __device__ __forceinline uint32_t brendancuda::Random::Get32Bits(uint32_t Probab
 }
 template <brendancuda::KernelCurandState _TRNG>
 __device__ __forceinline uint64_t brendancuda::Random::Get64Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
-    uint32_t ct = brendancuda::Binary::CountBitsB(ProbabilityOf1);
+    uint32_t ct = brendancuda::binary::CountBitsB(ProbabilityOf1);
     if (!ct) {
         return 0;
     }

--- a/rand_bits.h
+++ b/rand_bits.h
@@ -8,7 +8,7 @@
 #include <curand_kernel.h>
 
 namespace brendancuda {
-    namespace Random {
+    namespace random {
         template <std::uniform_random_bit_generator _TRNG>
         __host__ __forceinline uint32_t Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG);
         template <std::uniform_random_bit_generator _TRNG>
@@ -23,7 +23,7 @@ namespace brendancuda {
 }
 
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline uint32_t brendancuda::Random::Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
+__host__ __forceinline uint32_t brendancuda::random::Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
     uint32_t ct = brendancuda::binary::CountBitsB(ProbabilityOf1);
     if (!ct) {
         return 0;
@@ -42,7 +42,7 @@ __host__ __forceinline uint32_t brendancuda::Random::Get32Bits(uint32_t Probabil
     return cr;
 }
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline uint64_t brendancuda::Random::Get64Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
+__host__ __forceinline uint64_t brendancuda::random::Get64Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
     uint32_t ct = brendancuda::binary::CountBitsB(ProbabilityOf1);
     if (!ct) {
         return 0;
@@ -62,7 +62,7 @@ __host__ __forceinline uint64_t brendancuda::Random::Get64Bits(uint32_t Probabil
 }
 #ifdef __CUDACC__
 template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline uint32_t brendancuda::Random::Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
+__device__ __forceinline uint32_t brendancuda::random::Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
     uint32_t ct = brendancuda::binary::CountBitsB(ProbabilityOf1);
     if (!ct) {
         return 0;
@@ -80,7 +80,7 @@ __device__ __forceinline uint32_t brendancuda::Random::Get32Bits(uint32_t Probab
     return cr;
 }
 template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline uint64_t brendancuda::Random::Get64Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
+__device__ __forceinline uint64_t brendancuda::random::Get64Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
     uint32_t ct = brendancuda::binary::CountBitsB(ProbabilityOf1);
     if (!ct) {
         return 0;

--- a/rand_bits.h
+++ b/rand_bits.h
@@ -7,7 +7,7 @@
 #include <cuda_runtime.h>
 #include <curand_kernel.h>
 
-namespace brendancuda {
+namespace bcuda {
     namespace random {
         template <std::uniform_random_bit_generator _TRNG>
         __host__ __forceinline uint32_t Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG);
@@ -23,8 +23,8 @@ namespace brendancuda {
 }
 
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline uint32_t brendancuda::random::Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
-    uint32_t ct = brendancuda::binary::CountBitsB(ProbabilityOf1);
+__host__ __forceinline uint32_t bcuda::random::Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
+    uint32_t ct = bcuda::binary::CountBitsB(ProbabilityOf1);
     if (!ct) {
         return 0;
     }
@@ -42,8 +42,8 @@ __host__ __forceinline uint32_t brendancuda::random::Get32Bits(uint32_t Probabil
     return cr;
 }
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline uint64_t brendancuda::random::Get64Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
-    uint32_t ct = brendancuda::binary::CountBitsB(ProbabilityOf1);
+__host__ __forceinline uint64_t bcuda::random::Get64Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
+    uint32_t ct = bcuda::binary::CountBitsB(ProbabilityOf1);
     if (!ct) {
         return 0;
     }
@@ -61,9 +61,9 @@ __host__ __forceinline uint64_t brendancuda::random::Get64Bits(uint32_t Probabil
     return cr;
 }
 #ifdef __CUDACC__
-template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline uint32_t brendancuda::random::Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
-    uint32_t ct = brendancuda::binary::CountBitsB(ProbabilityOf1);
+template <bcuda::KernelCurandState _TRNG>
+__device__ __forceinline uint32_t bcuda::random::Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
+    uint32_t ct = bcuda::binary::CountBitsB(ProbabilityOf1);
     if (!ct) {
         return 0;
     }
@@ -79,9 +79,9 @@ __device__ __forceinline uint32_t brendancuda::random::Get32Bits(uint32_t Probab
     }
     return cr;
 }
-template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline uint64_t brendancuda::random::Get64Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
-    uint32_t ct = brendancuda::binary::CountBitsB(ProbabilityOf1);
+template <bcuda::KernelCurandState _TRNG>
+__device__ __forceinline uint64_t bcuda::random::Get64Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
+    uint32_t ct = bcuda::binary::CountBitsB(ProbabilityOf1);
     if (!ct) {
         return 0;
     }

--- a/rand_bits.h
+++ b/rand_bits.h
@@ -7,7 +7,7 @@
 #include <cuda_runtime.h>
 #include <curand_kernel.h>
 
-namespace BrendanCUDA {
+namespace brendancuda {
     namespace Random {
         template <std::uniform_random_bit_generator _TRNG>
         __host__ __forceinline uint32_t Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG);
@@ -23,8 +23,8 @@ namespace BrendanCUDA {
 }
 
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline uint32_t BrendanCUDA::Random::Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
-    uint32_t ct = BrendanCUDA::Binary::CountBitsB(ProbabilityOf1);
+__host__ __forceinline uint32_t brendancuda::Random::Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
+    uint32_t ct = brendancuda::Binary::CountBitsB(ProbabilityOf1);
     if (!ct) {
         return 0;
     }
@@ -42,8 +42,8 @@ __host__ __forceinline uint32_t BrendanCUDA::Random::Get32Bits(uint32_t Probabil
     return cr;
 }
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline uint64_t BrendanCUDA::Random::Get64Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
-    uint32_t ct = BrendanCUDA::Binary::CountBitsB(ProbabilityOf1);
+__host__ __forceinline uint64_t brendancuda::Random::Get64Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
+    uint32_t ct = brendancuda::Binary::CountBitsB(ProbabilityOf1);
     if (!ct) {
         return 0;
     }
@@ -61,9 +61,9 @@ __host__ __forceinline uint64_t BrendanCUDA::Random::Get64Bits(uint32_t Probabil
     return cr;
 }
 #ifdef __CUDACC__
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ __forceinline uint32_t BrendanCUDA::Random::Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
-    uint32_t ct = BrendanCUDA::Binary::CountBitsB(ProbabilityOf1);
+template <brendancuda::KernelCurandState _TRNG>
+__device__ __forceinline uint32_t brendancuda::Random::Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
+    uint32_t ct = brendancuda::Binary::CountBitsB(ProbabilityOf1);
     if (!ct) {
         return 0;
     }
@@ -79,9 +79,9 @@ __device__ __forceinline uint32_t BrendanCUDA::Random::Get32Bits(uint32_t Probab
     }
     return cr;
 }
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ __forceinline uint64_t BrendanCUDA::Random::Get64Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
-    uint32_t ct = BrendanCUDA::Binary::CountBitsB(ProbabilityOf1);
+template <brendancuda::KernelCurandState _TRNG>
+__device__ __forceinline uint64_t brendancuda::Random::Get64Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
+    uint32_t ct = brendancuda::Binary::CountBitsB(ProbabilityOf1);
     if (!ct) {
         return 0;
     }

--- a/rand_randomizer.cu
+++ b/rand_randomizer.cu
@@ -3,7 +3,7 @@
 #include <curand_kernel.h>
 #include <device_launch_parameters.h>
 
-__global__ void randomizeArrayKernel(brendancuda::Span<float> Array, float Scalar, uint64_t Seed, uint64_t Count) {
+__global__ void randomizeArrayKernel(bcuda::Span<float> Array, float Scalar, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
     if (idx >= Array.size)
         return;
@@ -14,7 +14,7 @@ __global__ void randomizeArrayKernel(brendancuda::Span<float> Array, float Scala
     for (; l < u; ++l)
         *l += Scalar * (curand_uniform(&state) - 0.5f);
 }
-__global__ void randomizeArrayKernel(brendancuda::Span<double> Array, double Scalar, uint64_t Seed, uint64_t Count) {
+__global__ void randomizeArrayKernel(bcuda::Span<double> Array, double Scalar, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
     if (idx >= Array.size)
         return;
@@ -25,7 +25,7 @@ __global__ void randomizeArrayKernel(brendancuda::Span<double> Array, double Sca
     for (; l < u; ++l)
         *l += Scalar * (curand_uniform(&state) - 0.5);
 }
-__global__ void randomizeArrayKernel(brendancuda::Span<float> Array, float Scalar, float Lower, float Upper, uint64_t Seed, uint64_t Count) {
+__global__ void randomizeArrayKernel(bcuda::Span<float> Array, float Scalar, float Lower, float Upper, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
     if (idx >= Array.size)
         return;
@@ -36,7 +36,7 @@ __global__ void randomizeArrayKernel(brendancuda::Span<float> Array, float Scala
     for (; l < u; ++l)
         *l += std::clamp(*l + curand_uniform(&state) * Scalar, Lower, Upper);
 }
-__global__ void randomizeArrayKernel(brendancuda::Span<double> Array, double Scalar, double Lower, double Upper, uint64_t Seed, uint64_t Count) {
+__global__ void randomizeArrayKernel(bcuda::Span<double> Array, double Scalar, double Lower, double Upper, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
     if (idx >= Array.size)
         return;
@@ -47,7 +47,7 @@ __global__ void randomizeArrayKernel(brendancuda::Span<double> Array, double Sca
     for (; l < u; ++l)
         *l += std::clamp(*l + curand_uniform(&state) * Scalar, Lower, Upper);
 }
-__global__ void randomizeArrayWFlipsKernel(brendancuda::Span<uint32_t> Array, uint32_t FlipProb, uint64_t Seed, uint64_t Count) {
+__global__ void randomizeArrayWFlipsKernel(bcuda::Span<uint32_t> Array, uint32_t FlipProb, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
     if (idx >= Array.size)
         return;
@@ -56,9 +56,9 @@ __global__ void randomizeArrayWFlipsKernel(brendancuda::Span<uint32_t> Array, ui
     uint32_t* l = Array.ptr + idx * Count;
     uint32_t* u = l + Count;
     for (; l < u; ++l)
-        *l = brendancuda::random::RandomizeWFlips(*l, FlipProb, state);
+        *l = bcuda::random::RandomizeWFlips(*l, FlipProb, state);
 }
-__global__ void randomizeArrayWTargetsKernel(brendancuda::Span<uint32_t> Array, uint32_t EachFlipProb, uint64_t Seed, uint64_t Count) {
+__global__ void randomizeArrayWTargetsKernel(bcuda::Span<uint32_t> Array, uint32_t EachFlipProb, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
     if (idx >= Array.size)
         return;
@@ -67,9 +67,9 @@ __global__ void randomizeArrayWTargetsKernel(brendancuda::Span<uint32_t> Array, 
     uint32_t* l = Array.ptr + idx * Count;
     uint32_t* u = l + Count;
     for (; l < u; ++l)
-        *l = brendancuda::random::RandomizeWTargets(*l, EachFlipProb, state);
+        *l = bcuda::random::RandomizeWTargets(*l, EachFlipProb, state);
 }
-__global__ void randomizeArrayWMutationsKernel(brendancuda::Span<uint32_t> Array, uint32_t MutationProb, uint64_t Seed, uint64_t Count) {
+__global__ void randomizeArrayWMutationsKernel(bcuda::Span<uint32_t> Array, uint32_t MutationProb, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
     if (idx >= Array.size)
         return;
@@ -78,9 +78,9 @@ __global__ void randomizeArrayWMutationsKernel(brendancuda::Span<uint32_t> Array
     uint32_t* l = Array.ptr + idx * Count;
     uint32_t* u = l + Count;
     for (; l < u; ++l)
-        *l = brendancuda::random::RandomizeWMutations(*l, MutationProb, state);
+        *l = bcuda::random::RandomizeWMutations(*l, MutationProb, state);
 }
-__global__ void randomizeArrayWMutationsKernel(brendancuda::Span<uint32_t> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, uint64_t Seed, uint64_t Count) {
+__global__ void randomizeArrayWMutationsKernel(bcuda::Span<uint32_t> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
     if (idx >= Array.size)
         return;
@@ -89,10 +89,10 @@ __global__ void randomizeArrayWMutationsKernel(brendancuda::Span<uint32_t> Array
     uint32_t* l = Array.ptr + idx * Count;
     uint32_t* u = l + Count;
     for (; l < u; ++l)
-        *l = brendancuda::random::RandomizeWMutations(*l, MutationProb, ProbabilityOf1, state);
+        *l = bcuda::random::RandomizeWMutations(*l, MutationProb, ProbabilityOf1, state);
 }
 
-__global__ void initArrayKernel(brendancuda::Span<float> Array, uint64_t Seed, uint64_t Count) {
+__global__ void initArrayKernel(bcuda::Span<float> Array, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
     if (idx >= Array.size)
         return;
@@ -103,7 +103,7 @@ __global__ void initArrayKernel(brendancuda::Span<float> Array, uint64_t Seed, u
     for (; l < u; ++l)
         *l = curand_uniform(&state);
 }
-__global__ void initArrayKernel(brendancuda::Span<double> Array, uint64_t Seed, uint64_t Count) {
+__global__ void initArrayKernel(bcuda::Span<double> Array, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
     if (idx >= Array.size)
         return;
@@ -114,7 +114,7 @@ __global__ void initArrayKernel(brendancuda::Span<double> Array, uint64_t Seed, 
     for (; l < u; ++l)
         *l = curand_uniform(&state);
 }
-__global__ void initArrayKernel(brendancuda::Span<float> Array, float Lower, float Range, uint64_t Seed, uint64_t Count) {
+__global__ void initArrayKernel(bcuda::Span<float> Array, float Lower, float Range, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
     if (idx >= Array.size)
         return;
@@ -125,7 +125,7 @@ __global__ void initArrayKernel(brendancuda::Span<float> Array, float Lower, flo
     for (; l < u; ++l)
         *l = curand_uniform(&state) * Range + Lower;
 }
-__global__ void initArrayKernel(brendancuda::Span<double> Array, double Lower, double Range, uint64_t Seed, uint64_t Count) {
+__global__ void initArrayKernel(bcuda::Span<double> Array, double Lower, double Range, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
     if (idx >= Array.size)
         return;
@@ -136,7 +136,7 @@ __global__ void initArrayKernel(brendancuda::Span<double> Array, double Lower, d
     for (; l < u; ++l)
         *l = curand_uniform(&state) * Range + Lower;
 }
-__global__ void initArrayKernel(brendancuda::Span<uint32_t> Array, uint64_t Seed, uint64_t Count) {
+__global__ void initArrayKernel(bcuda::Span<uint32_t> Array, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
     if (idx >= Array.size)
         return;
@@ -147,7 +147,7 @@ __global__ void initArrayKernel(brendancuda::Span<uint32_t> Array, uint64_t Seed
     for (; l < u; ++l)
         *l = curand(&state);
 }
-__global__ void initArrayKernel(brendancuda::Span<uint32_t> Array, uint32_t ProbOf1, uint64_t Seed, uint64_t Count) {
+__global__ void initArrayKernel(bcuda::Span<uint32_t> Array, uint32_t ProbOf1, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
     if (idx >= Array.size)
         return;
@@ -156,9 +156,9 @@ __global__ void initArrayKernel(brendancuda::Span<uint32_t> Array, uint32_t Prob
     uint32_t* l = Array.ptr + idx * Count;
     uint32_t* u = std::min(l + Count, Array.ptr + Array.size);
     for (; l < u; ++l)
-        *l = brendancuda::random::Get32Bits(ProbOf1, state);
+        *l = bcuda::random::Get32Bits(ProbOf1, state);
 }
-__global__ void clearArrayKernel(brendancuda::Span<float> Array, uint64_t Count) {
+__global__ void clearArrayKernel(bcuda::Span<float> Array, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
     if (idx >= Array.size)
         return;
@@ -167,7 +167,7 @@ __global__ void clearArrayKernel(brendancuda::Span<float> Array, uint64_t Count)
     for (; l < u; ++l)
         *l = 0.f;
 }
-__global__ void clearArrayKernel(brendancuda::Span<double> Array, uint64_t Count) {
+__global__ void clearArrayKernel(bcuda::Span<double> Array, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
     if (idx >= Array.size)
         return;
@@ -176,7 +176,7 @@ __global__ void clearArrayKernel(brendancuda::Span<double> Array, uint64_t Count
     for (; l < u; ++l)
         *l = 0.;
 }
-__global__ void clearArrayKernel(brendancuda::Span<uint64_t> Array, uint64_t Count) {
+__global__ void clearArrayKernel(bcuda::Span<uint64_t> Array, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
     if (idx >= Array.size)
         return;
@@ -213,119 +213,119 @@ void getKernelLaunchParams(uint64_t ElementCount, uint32_t& ElementsPerThread, u
     }
 }
 
-void brendancuda::details::RandomizeArray_CallKernel(Span<float> Array, float Scalar, uint64_t Seed) {
+void bcuda::details::RandomizeArray_CallKernel(Span<float> Array, float Scalar, uint64_t Seed) {
     uint32_t elementsPerThread;
     uint32_t threadsPerBlock;
     uint32_t blockCount;
     getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
     randomizeArrayKernel<<<blockCount, threadsPerBlock>>>(Array, Scalar * 2.f, Seed, elementsPerThread);
 }
-void brendancuda::details::RandomizeArray_CallKernel(Span<double> Array, double Scalar, uint64_t Seed) {
+void bcuda::details::RandomizeArray_CallKernel(Span<double> Array, double Scalar, uint64_t Seed) {
     uint32_t elementsPerThread;
     uint32_t threadsPerBlock;
     uint32_t blockCount;
     getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
     randomizeArrayKernel<<<blockCount, threadsPerBlock>>>(Array, Scalar * 2., Seed, elementsPerThread);
 }
-void brendancuda::details::RandomizeArray_CallKernel(Span<float> Array, float Scalar, float LowerBound, float UpperBound, uint64_t Seed) {
+void bcuda::details::RandomizeArray_CallKernel(Span<float> Array, float Scalar, float LowerBound, float UpperBound, uint64_t Seed) {
     uint32_t elementsPerThread;
     uint32_t threadsPerBlock;
     uint32_t blockCount;
     getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
     randomizeArrayKernel<<<blockCount, threadsPerBlock>>>(Array, Scalar * 2.f, LowerBound, UpperBound, Seed, elementsPerThread);
 }
-void brendancuda::details::RandomizeArray_CallKernel(Span<double> Array, double Scalar, double LowerBound, double UpperBound, uint64_t Seed) {
+void bcuda::details::RandomizeArray_CallKernel(Span<double> Array, double Scalar, double LowerBound, double UpperBound, uint64_t Seed) {
     uint32_t elementsPerThread;
     uint32_t threadsPerBlock;
     uint32_t blockCount;
     getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
     randomizeArrayKernel<<<blockCount, threadsPerBlock>>>(Array, Scalar * 2., LowerBound, UpperBound, Seed, elementsPerThread);
 }
-void brendancuda::details::RandomizeArrayWFlips_CallKernel(Span<uint32_t> Array, uint32_t FlipProbability, uint64_t Seed) {
+void bcuda::details::RandomizeArrayWFlips_CallKernel(Span<uint32_t> Array, uint32_t FlipProbability, uint64_t Seed) {
     uint32_t elementsPerThread;
     uint32_t threadsPerBlock;
     uint32_t blockCount;
     getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
     randomizeArrayWFlipsKernel<<<blockCount, threadsPerBlock>>>(Array, FlipProbability, Seed, elementsPerThread);
 }
-void brendancuda::details::RandomizeArrayWTargets_CallKernel(Span<uint32_t> Array, uint32_t EachFlipProbability, uint64_t Seed) {
+void bcuda::details::RandomizeArrayWTargets_CallKernel(Span<uint32_t> Array, uint32_t EachFlipProbability, uint64_t Seed) {
     uint32_t elementsPerThread;
     uint32_t threadsPerBlock;
     uint32_t blockCount;
     getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
     randomizeArrayWTargetsKernel<<<blockCount, threadsPerBlock>>>(Array, EachFlipProbability, Seed, elementsPerThread);
 }
-void brendancuda::details::RandomizeArrayWMutations_CallKernel(Span<uint32_t> Array, uint32_t MutationProbability, uint64_t Seed) {
+void bcuda::details::RandomizeArrayWMutations_CallKernel(Span<uint32_t> Array, uint32_t MutationProbability, uint64_t Seed) {
     uint32_t elementsPerThread;
     uint32_t threadsPerBlock;
     uint32_t blockCount;
     getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
     randomizeArrayWMutationsKernel<<<blockCount, threadsPerBlock>>>(Array, MutationProbability, Seed, elementsPerThread);
 }
-void brendancuda::details::RandomizeArrayWMutations_CallKernel(Span<uint32_t> Array, uint32_t MutationProbability, uint32_t ProbabilityOf1, uint64_t Seed) {
+void bcuda::details::RandomizeArrayWMutations_CallKernel(Span<uint32_t> Array, uint32_t MutationProbability, uint32_t ProbabilityOf1, uint64_t Seed) {
     uint32_t elementsPerThread;
     uint32_t threadsPerBlock;
     uint32_t blockCount;
     getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
     randomizeArrayWMutationsKernel<<<blockCount, threadsPerBlock>>>(Array, MutationProbability, ProbabilityOf1, Seed, elementsPerThread);
 }
-void brendancuda::details::InitArray_CallKernel(Span<float> Array, uint64_t Seed) {
+void bcuda::details::InitArray_CallKernel(Span<float> Array, uint64_t Seed) {
     uint32_t elementsPerThread;
     uint32_t threadsPerBlock;
     uint32_t blockCount;
     getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
     initArrayKernel<<<blockCount, threadsPerBlock>>>(Array, Seed, elementsPerThread);
 }
-void brendancuda::details::InitArray_CallKernel(Span<double> Array, uint64_t Seed) {
+void bcuda::details::InitArray_CallKernel(Span<double> Array, uint64_t Seed) {
     uint32_t elementsPerThread;
     uint32_t threadsPerBlock;
     uint32_t blockCount;
     getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
     initArrayKernel<<<blockCount, threadsPerBlock>>>(Array, Seed, elementsPerThread);
 }
-void brendancuda::details::InitArray_CallKernel(Span<float> Array, float LowerBound, float UpperBound, uint64_t Seed) {
+void bcuda::details::InitArray_CallKernel(Span<float> Array, float LowerBound, float UpperBound, uint64_t Seed) {
     uint32_t elementsPerThread;
     uint32_t threadsPerBlock;
     uint32_t blockCount;
     getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
     initArrayKernel<<<blockCount, threadsPerBlock>>>(Array, LowerBound, UpperBound - LowerBound, Seed, elementsPerThread);
 }
-void brendancuda::details::InitArray_CallKernel(Span<double> Array, double LowerBound, double UpperBound, uint64_t Seed) {
+void bcuda::details::InitArray_CallKernel(Span<double> Array, double LowerBound, double UpperBound, uint64_t Seed) {
     uint32_t elementsPerThread;
     uint32_t threadsPerBlock;
     uint32_t blockCount;
     getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
     initArrayKernel<<<blockCount, threadsPerBlock>>>(Array, LowerBound, UpperBound - LowerBound, Seed, elementsPerThread);
 }
-void brendancuda::details::InitArray_CallKernel(Span<uint32_t> Array, uint64_t Seed) {
+void bcuda::details::InitArray_CallKernel(Span<uint32_t> Array, uint64_t Seed) {
     uint32_t elementsPerThread;
     uint32_t threadsPerBlock;
     uint32_t blockCount;
     getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
     initArrayKernel<<<blockCount, threadsPerBlock>>>(Array, Seed, elementsPerThread);
 }
-void brendancuda::details::InitArray_CallKernel(Span<uint32_t> Array, uint32_t ProbabilityOf1, uint64_t Seed) {
+void bcuda::details::InitArray_CallKernel(Span<uint32_t> Array, uint32_t ProbabilityOf1, uint64_t Seed) {
     uint32_t elementsPerThread;
     uint32_t threadsPerBlock;
     uint32_t blockCount;
     getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
     initArrayKernel<<<blockCount, threadsPerBlock>>>(Array, ProbabilityOf1, Seed, elementsPerThread);
 }
-void brendancuda::details::ClearArray_CallKernel(Span<float> Array) {
+void bcuda::details::ClearArray_CallKernel(Span<float> Array) {
     uint32_t elementsPerThread;
     uint32_t threadsPerBlock;
     uint32_t blockCount;
     getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
     clearArrayKernel<<<blockCount, threadsPerBlock>>>(Array, elementsPerThread);
 }
-void brendancuda::details::ClearArray_CallKernel(Span<double> Array) {
+void bcuda::details::ClearArray_CallKernel(Span<double> Array) {
     uint32_t elementsPerThread;
     uint32_t threadsPerBlock;
     uint32_t blockCount;
     getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
     clearArrayKernel<<<blockCount, threadsPerBlock>>>(Array, elementsPerThread);
 }
-void brendancuda::details::ClearArray_CallKernel(Span<uint64_t> Array) {
+void bcuda::details::ClearArray_CallKernel(Span<uint64_t> Array) {
     uint32_t elementsPerThread;
     uint32_t threadsPerBlock;
     uint32_t blockCount;

--- a/rand_randomizer.cu
+++ b/rand_randomizer.cu
@@ -56,7 +56,7 @@ __global__ void randomizeArrayWFlipsKernel(brendancuda::Span<uint32_t> Array, ui
     uint32_t* l = Array.ptr + idx * Count;
     uint32_t* u = l + Count;
     for (; l < u; ++l)
-        *l = brendancuda::Random::RandomizeWFlips(*l, FlipProb, state);
+        *l = brendancuda::random::RandomizeWFlips(*l, FlipProb, state);
 }
 __global__ void randomizeArrayWTargetsKernel(brendancuda::Span<uint32_t> Array, uint32_t EachFlipProb, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
@@ -67,7 +67,7 @@ __global__ void randomizeArrayWTargetsKernel(brendancuda::Span<uint32_t> Array, 
     uint32_t* l = Array.ptr + idx * Count;
     uint32_t* u = l + Count;
     for (; l < u; ++l)
-        *l = brendancuda::Random::RandomizeWTargets(*l, EachFlipProb, state);
+        *l = brendancuda::random::RandomizeWTargets(*l, EachFlipProb, state);
 }
 __global__ void randomizeArrayWMutationsKernel(brendancuda::Span<uint32_t> Array, uint32_t MutationProb, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
@@ -78,7 +78,7 @@ __global__ void randomizeArrayWMutationsKernel(brendancuda::Span<uint32_t> Array
     uint32_t* l = Array.ptr + idx * Count;
     uint32_t* u = l + Count;
     for (; l < u; ++l)
-        *l = brendancuda::Random::RandomizeWMutations(*l, MutationProb, state);
+        *l = brendancuda::random::RandomizeWMutations(*l, MutationProb, state);
 }
 __global__ void randomizeArrayWMutationsKernel(brendancuda::Span<uint32_t> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
@@ -89,7 +89,7 @@ __global__ void randomizeArrayWMutationsKernel(brendancuda::Span<uint32_t> Array
     uint32_t* l = Array.ptr + idx * Count;
     uint32_t* u = l + Count;
     for (; l < u; ++l)
-        *l = brendancuda::Random::RandomizeWMutations(*l, MutationProb, ProbabilityOf1, state);
+        *l = brendancuda::random::RandomizeWMutations(*l, MutationProb, ProbabilityOf1, state);
 }
 
 __global__ void initArrayKernel(brendancuda::Span<float> Array, uint64_t Seed, uint64_t Count) {
@@ -156,7 +156,7 @@ __global__ void initArrayKernel(brendancuda::Span<uint32_t> Array, uint32_t Prob
     uint32_t* l = Array.ptr + idx * Count;
     uint32_t* u = std::min(l + Count, Array.ptr + Array.size);
     for (; l < u; ++l)
-        *l = brendancuda::Random::Get32Bits(ProbOf1, state);
+        *l = brendancuda::random::Get32Bits(ProbOf1, state);
 }
 __global__ void clearArrayKernel(brendancuda::Span<float> Array, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;

--- a/rand_randomizer.cu
+++ b/rand_randomizer.cu
@@ -3,7 +3,7 @@
 #include <curand_kernel.h>
 #include <device_launch_parameters.h>
 
-__global__ void randomizeArrayKernel(BrendanCUDA::Span<float> Array, float Scalar, uint64_t Seed, uint64_t Count) {
+__global__ void randomizeArrayKernel(brendancuda::Span<float> Array, float Scalar, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
     if (idx >= Array.size)
         return;
@@ -14,7 +14,7 @@ __global__ void randomizeArrayKernel(BrendanCUDA::Span<float> Array, float Scala
     for (; l < u; ++l)
         *l += Scalar * (curand_uniform(&state) - 0.5f);
 }
-__global__ void randomizeArrayKernel(BrendanCUDA::Span<double> Array, double Scalar, uint64_t Seed, uint64_t Count) {
+__global__ void randomizeArrayKernel(brendancuda::Span<double> Array, double Scalar, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
     if (idx >= Array.size)
         return;
@@ -25,7 +25,7 @@ __global__ void randomizeArrayKernel(BrendanCUDA::Span<double> Array, double Sca
     for (; l < u; ++l)
         *l += Scalar * (curand_uniform(&state) - 0.5);
 }
-__global__ void randomizeArrayKernel(BrendanCUDA::Span<float> Array, float Scalar, float Lower, float Upper, uint64_t Seed, uint64_t Count) {
+__global__ void randomizeArrayKernel(brendancuda::Span<float> Array, float Scalar, float Lower, float Upper, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
     if (idx >= Array.size)
         return;
@@ -36,7 +36,7 @@ __global__ void randomizeArrayKernel(BrendanCUDA::Span<float> Array, float Scala
     for (; l < u; ++l)
         *l += std::clamp(*l + curand_uniform(&state) * Scalar, Lower, Upper);
 }
-__global__ void randomizeArrayKernel(BrendanCUDA::Span<double> Array, double Scalar, double Lower, double Upper, uint64_t Seed, uint64_t Count) {
+__global__ void randomizeArrayKernel(brendancuda::Span<double> Array, double Scalar, double Lower, double Upper, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
     if (idx >= Array.size)
         return;
@@ -47,7 +47,7 @@ __global__ void randomizeArrayKernel(BrendanCUDA::Span<double> Array, double Sca
     for (; l < u; ++l)
         *l += std::clamp(*l + curand_uniform(&state) * Scalar, Lower, Upper);
 }
-__global__ void randomizeArrayWFlipsKernel(BrendanCUDA::Span<uint32_t> Array, uint32_t FlipProb, uint64_t Seed, uint64_t Count) {
+__global__ void randomizeArrayWFlipsKernel(brendancuda::Span<uint32_t> Array, uint32_t FlipProb, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
     if (idx >= Array.size)
         return;
@@ -56,9 +56,9 @@ __global__ void randomizeArrayWFlipsKernel(BrendanCUDA::Span<uint32_t> Array, ui
     uint32_t* l = Array.ptr + idx * Count;
     uint32_t* u = l + Count;
     for (; l < u; ++l)
-        *l = BrendanCUDA::Random::RandomizeWFlips(*l, FlipProb, state);
+        *l = brendancuda::Random::RandomizeWFlips(*l, FlipProb, state);
 }
-__global__ void randomizeArrayWTargetsKernel(BrendanCUDA::Span<uint32_t> Array, uint32_t EachFlipProb, uint64_t Seed, uint64_t Count) {
+__global__ void randomizeArrayWTargetsKernel(brendancuda::Span<uint32_t> Array, uint32_t EachFlipProb, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
     if (idx >= Array.size)
         return;
@@ -67,9 +67,9 @@ __global__ void randomizeArrayWTargetsKernel(BrendanCUDA::Span<uint32_t> Array, 
     uint32_t* l = Array.ptr + idx * Count;
     uint32_t* u = l + Count;
     for (; l < u; ++l)
-        *l = BrendanCUDA::Random::RandomizeWTargets(*l, EachFlipProb, state);
+        *l = brendancuda::Random::RandomizeWTargets(*l, EachFlipProb, state);
 }
-__global__ void randomizeArrayWMutationsKernel(BrendanCUDA::Span<uint32_t> Array, uint32_t MutationProb, uint64_t Seed, uint64_t Count) {
+__global__ void randomizeArrayWMutationsKernel(brendancuda::Span<uint32_t> Array, uint32_t MutationProb, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
     if (idx >= Array.size)
         return;
@@ -78,9 +78,9 @@ __global__ void randomizeArrayWMutationsKernel(BrendanCUDA::Span<uint32_t> Array
     uint32_t* l = Array.ptr + idx * Count;
     uint32_t* u = l + Count;
     for (; l < u; ++l)
-        *l = BrendanCUDA::Random::RandomizeWMutations(*l, MutationProb, state);
+        *l = brendancuda::Random::RandomizeWMutations(*l, MutationProb, state);
 }
-__global__ void randomizeArrayWMutationsKernel(BrendanCUDA::Span<uint32_t> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, uint64_t Seed, uint64_t Count) {
+__global__ void randomizeArrayWMutationsKernel(brendancuda::Span<uint32_t> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
     if (idx >= Array.size)
         return;
@@ -89,10 +89,10 @@ __global__ void randomizeArrayWMutationsKernel(BrendanCUDA::Span<uint32_t> Array
     uint32_t* l = Array.ptr + idx * Count;
     uint32_t* u = l + Count;
     for (; l < u; ++l)
-        *l = BrendanCUDA::Random::RandomizeWMutations(*l, MutationProb, ProbabilityOf1, state);
+        *l = brendancuda::Random::RandomizeWMutations(*l, MutationProb, ProbabilityOf1, state);
 }
 
-__global__ void initArrayKernel(BrendanCUDA::Span<float> Array, uint64_t Seed, uint64_t Count) {
+__global__ void initArrayKernel(brendancuda::Span<float> Array, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
     if (idx >= Array.size)
         return;
@@ -103,7 +103,7 @@ __global__ void initArrayKernel(BrendanCUDA::Span<float> Array, uint64_t Seed, u
     for (; l < u; ++l)
         *l = curand_uniform(&state);
 }
-__global__ void initArrayKernel(BrendanCUDA::Span<double> Array, uint64_t Seed, uint64_t Count) {
+__global__ void initArrayKernel(brendancuda::Span<double> Array, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
     if (idx >= Array.size)
         return;
@@ -114,7 +114,7 @@ __global__ void initArrayKernel(BrendanCUDA::Span<double> Array, uint64_t Seed, 
     for (; l < u; ++l)
         *l = curand_uniform(&state);
 }
-__global__ void initArrayKernel(BrendanCUDA::Span<float> Array, float Lower, float Range, uint64_t Seed, uint64_t Count) {
+__global__ void initArrayKernel(brendancuda::Span<float> Array, float Lower, float Range, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
     if (idx >= Array.size)
         return;
@@ -125,7 +125,7 @@ __global__ void initArrayKernel(BrendanCUDA::Span<float> Array, float Lower, flo
     for (; l < u; ++l)
         *l = curand_uniform(&state) * Range + Lower;
 }
-__global__ void initArrayKernel(BrendanCUDA::Span<double> Array, double Lower, double Range, uint64_t Seed, uint64_t Count) {
+__global__ void initArrayKernel(brendancuda::Span<double> Array, double Lower, double Range, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
     if (idx >= Array.size)
         return;
@@ -136,7 +136,7 @@ __global__ void initArrayKernel(BrendanCUDA::Span<double> Array, double Lower, d
     for (; l < u; ++l)
         *l = curand_uniform(&state) * Range + Lower;
 }
-__global__ void initArrayKernel(BrendanCUDA::Span<uint32_t> Array, uint64_t Seed, uint64_t Count) {
+__global__ void initArrayKernel(brendancuda::Span<uint32_t> Array, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
     if (idx >= Array.size)
         return;
@@ -147,7 +147,7 @@ __global__ void initArrayKernel(BrendanCUDA::Span<uint32_t> Array, uint64_t Seed
     for (; l < u; ++l)
         *l = curand(&state);
 }
-__global__ void initArrayKernel(BrendanCUDA::Span<uint32_t> Array, uint32_t ProbOf1, uint64_t Seed, uint64_t Count) {
+__global__ void initArrayKernel(brendancuda::Span<uint32_t> Array, uint32_t ProbOf1, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
     if (idx >= Array.size)
         return;
@@ -156,9 +156,9 @@ __global__ void initArrayKernel(BrendanCUDA::Span<uint32_t> Array, uint32_t Prob
     uint32_t* l = Array.ptr + idx * Count;
     uint32_t* u = std::min(l + Count, Array.ptr + Array.size);
     for (; l < u; ++l)
-        *l = BrendanCUDA::Random::Get32Bits(ProbOf1, state);
+        *l = brendancuda::Random::Get32Bits(ProbOf1, state);
 }
-__global__ void clearArrayKernel(BrendanCUDA::Span<float> Array, uint64_t Count) {
+__global__ void clearArrayKernel(brendancuda::Span<float> Array, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
     if (idx >= Array.size)
         return;
@@ -167,7 +167,7 @@ __global__ void clearArrayKernel(BrendanCUDA::Span<float> Array, uint64_t Count)
     for (; l < u; ++l)
         *l = 0.f;
 }
-__global__ void clearArrayKernel(BrendanCUDA::Span<double> Array, uint64_t Count) {
+__global__ void clearArrayKernel(brendancuda::Span<double> Array, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
     if (idx >= Array.size)
         return;
@@ -176,7 +176,7 @@ __global__ void clearArrayKernel(BrendanCUDA::Span<double> Array, uint64_t Count
     for (; l < u; ++l)
         *l = 0.;
 }
-__global__ void clearArrayKernel(BrendanCUDA::Span<uint64_t> Array, uint64_t Count) {
+__global__ void clearArrayKernel(brendancuda::Span<uint64_t> Array, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
     if (idx >= Array.size)
         return;
@@ -213,119 +213,119 @@ void getKernelLaunchParams(uint64_t ElementCount, uint32_t& ElementsPerThread, u
     }
 }
 
-void BrendanCUDA::details::RandomizeArray_CallKernel(Span<float> Array, float Scalar, uint64_t Seed) {
+void brendancuda::details::RandomizeArray_CallKernel(Span<float> Array, float Scalar, uint64_t Seed) {
     uint32_t elementsPerThread;
     uint32_t threadsPerBlock;
     uint32_t blockCount;
     getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
     randomizeArrayKernel<<<blockCount, threadsPerBlock>>>(Array, Scalar * 2.f, Seed, elementsPerThread);
 }
-void BrendanCUDA::details::RandomizeArray_CallKernel(Span<double> Array, double Scalar, uint64_t Seed) {
+void brendancuda::details::RandomizeArray_CallKernel(Span<double> Array, double Scalar, uint64_t Seed) {
     uint32_t elementsPerThread;
     uint32_t threadsPerBlock;
     uint32_t blockCount;
     getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
     randomizeArrayKernel<<<blockCount, threadsPerBlock>>>(Array, Scalar * 2., Seed, elementsPerThread);
 }
-void BrendanCUDA::details::RandomizeArray_CallKernel(Span<float> Array, float Scalar, float LowerBound, float UpperBound, uint64_t Seed) {
+void brendancuda::details::RandomizeArray_CallKernel(Span<float> Array, float Scalar, float LowerBound, float UpperBound, uint64_t Seed) {
     uint32_t elementsPerThread;
     uint32_t threadsPerBlock;
     uint32_t blockCount;
     getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
     randomizeArrayKernel<<<blockCount, threadsPerBlock>>>(Array, Scalar * 2.f, LowerBound, UpperBound, Seed, elementsPerThread);
 }
-void BrendanCUDA::details::RandomizeArray_CallKernel(Span<double> Array, double Scalar, double LowerBound, double UpperBound, uint64_t Seed) {
+void brendancuda::details::RandomizeArray_CallKernel(Span<double> Array, double Scalar, double LowerBound, double UpperBound, uint64_t Seed) {
     uint32_t elementsPerThread;
     uint32_t threadsPerBlock;
     uint32_t blockCount;
     getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
     randomizeArrayKernel<<<blockCount, threadsPerBlock>>>(Array, Scalar * 2., LowerBound, UpperBound, Seed, elementsPerThread);
 }
-void BrendanCUDA::details::RandomizeArrayWFlips_CallKernel(Span<uint32_t> Array, uint32_t FlipProbability, uint64_t Seed) {
+void brendancuda::details::RandomizeArrayWFlips_CallKernel(Span<uint32_t> Array, uint32_t FlipProbability, uint64_t Seed) {
     uint32_t elementsPerThread;
     uint32_t threadsPerBlock;
     uint32_t blockCount;
     getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
     randomizeArrayWFlipsKernel<<<blockCount, threadsPerBlock>>>(Array, FlipProbability, Seed, elementsPerThread);
 }
-void BrendanCUDA::details::RandomizeArrayWTargets_CallKernel(Span<uint32_t> Array, uint32_t EachFlipProbability, uint64_t Seed) {
+void brendancuda::details::RandomizeArrayWTargets_CallKernel(Span<uint32_t> Array, uint32_t EachFlipProbability, uint64_t Seed) {
     uint32_t elementsPerThread;
     uint32_t threadsPerBlock;
     uint32_t blockCount;
     getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
     randomizeArrayWTargetsKernel<<<blockCount, threadsPerBlock>>>(Array, EachFlipProbability, Seed, elementsPerThread);
 }
-void BrendanCUDA::details::RandomizeArrayWMutations_CallKernel(Span<uint32_t> Array, uint32_t MutationProbability, uint64_t Seed) {
+void brendancuda::details::RandomizeArrayWMutations_CallKernel(Span<uint32_t> Array, uint32_t MutationProbability, uint64_t Seed) {
     uint32_t elementsPerThread;
     uint32_t threadsPerBlock;
     uint32_t blockCount;
     getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
     randomizeArrayWMutationsKernel<<<blockCount, threadsPerBlock>>>(Array, MutationProbability, Seed, elementsPerThread);
 }
-void BrendanCUDA::details::RandomizeArrayWMutations_CallKernel(Span<uint32_t> Array, uint32_t MutationProbability, uint32_t ProbabilityOf1, uint64_t Seed) {
+void brendancuda::details::RandomizeArrayWMutations_CallKernel(Span<uint32_t> Array, uint32_t MutationProbability, uint32_t ProbabilityOf1, uint64_t Seed) {
     uint32_t elementsPerThread;
     uint32_t threadsPerBlock;
     uint32_t blockCount;
     getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
     randomizeArrayWMutationsKernel<<<blockCount, threadsPerBlock>>>(Array, MutationProbability, ProbabilityOf1, Seed, elementsPerThread);
 }
-void BrendanCUDA::details::InitArray_CallKernel(Span<float> Array, uint64_t Seed) {
+void brendancuda::details::InitArray_CallKernel(Span<float> Array, uint64_t Seed) {
     uint32_t elementsPerThread;
     uint32_t threadsPerBlock;
     uint32_t blockCount;
     getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
     initArrayKernel<<<blockCount, threadsPerBlock>>>(Array, Seed, elementsPerThread);
 }
-void BrendanCUDA::details::InitArray_CallKernel(Span<double> Array, uint64_t Seed) {
+void brendancuda::details::InitArray_CallKernel(Span<double> Array, uint64_t Seed) {
     uint32_t elementsPerThread;
     uint32_t threadsPerBlock;
     uint32_t blockCount;
     getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
     initArrayKernel<<<blockCount, threadsPerBlock>>>(Array, Seed, elementsPerThread);
 }
-void BrendanCUDA::details::InitArray_CallKernel(Span<float> Array, float LowerBound, float UpperBound, uint64_t Seed) {
+void brendancuda::details::InitArray_CallKernel(Span<float> Array, float LowerBound, float UpperBound, uint64_t Seed) {
     uint32_t elementsPerThread;
     uint32_t threadsPerBlock;
     uint32_t blockCount;
     getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
     initArrayKernel<<<blockCount, threadsPerBlock>>>(Array, LowerBound, UpperBound - LowerBound, Seed, elementsPerThread);
 }
-void BrendanCUDA::details::InitArray_CallKernel(Span<double> Array, double LowerBound, double UpperBound, uint64_t Seed) {
+void brendancuda::details::InitArray_CallKernel(Span<double> Array, double LowerBound, double UpperBound, uint64_t Seed) {
     uint32_t elementsPerThread;
     uint32_t threadsPerBlock;
     uint32_t blockCount;
     getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
     initArrayKernel<<<blockCount, threadsPerBlock>>>(Array, LowerBound, UpperBound - LowerBound, Seed, elementsPerThread);
 }
-void BrendanCUDA::details::InitArray_CallKernel(Span<uint32_t> Array, uint64_t Seed) {
+void brendancuda::details::InitArray_CallKernel(Span<uint32_t> Array, uint64_t Seed) {
     uint32_t elementsPerThread;
     uint32_t threadsPerBlock;
     uint32_t blockCount;
     getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
     initArrayKernel<<<blockCount, threadsPerBlock>>>(Array, Seed, elementsPerThread);
 }
-void BrendanCUDA::details::InitArray_CallKernel(Span<uint32_t> Array, uint32_t ProbabilityOf1, uint64_t Seed) {
+void brendancuda::details::InitArray_CallKernel(Span<uint32_t> Array, uint32_t ProbabilityOf1, uint64_t Seed) {
     uint32_t elementsPerThread;
     uint32_t threadsPerBlock;
     uint32_t blockCount;
     getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
     initArrayKernel<<<blockCount, threadsPerBlock>>>(Array, ProbabilityOf1, Seed, elementsPerThread);
 }
-void BrendanCUDA::details::ClearArray_CallKernel(Span<float> Array) {
+void brendancuda::details::ClearArray_CallKernel(Span<float> Array) {
     uint32_t elementsPerThread;
     uint32_t threadsPerBlock;
     uint32_t blockCount;
     getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
     clearArrayKernel<<<blockCount, threadsPerBlock>>>(Array, elementsPerThread);
 }
-void BrendanCUDA::details::ClearArray_CallKernel(Span<double> Array) {
+void brendancuda::details::ClearArray_CallKernel(Span<double> Array) {
     uint32_t elementsPerThread;
     uint32_t threadsPerBlock;
     uint32_t blockCount;
     getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
     clearArrayKernel<<<blockCount, threadsPerBlock>>>(Array, elementsPerThread);
 }
-void BrendanCUDA::details::ClearArray_CallKernel(Span<uint64_t> Array) {
+void brendancuda::details::ClearArray_CallKernel(Span<uint64_t> Array) {
     uint32_t elementsPerThread;
     uint32_t threadsPerBlock;
     uint32_t blockCount;

--- a/rand_randomizer.h
+++ b/rand_randomizer.h
@@ -9,7 +9,7 @@
 #include <cuda_runtime.h>
 #include <curand_kernel.h>
 
-namespace brendancuda {
+namespace bcuda {
     namespace details {
         template <std::integral _T>
         __host__ __device__ static __forceinline _T RandomizeWTargets_GetEditsOf1s(_T Value, uint32_t CountOf1s, uint32_t FlipProb, uint32_t RN1, uint32_t RN2);
@@ -36,25 +36,25 @@ namespace brendancuda {
         template <std::integral _T, std::uniform_random_bit_generator _TRNG>
         __host__ static __forceinline _T RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG);
 #ifdef __CUDACC__
-        template <std::integral _T, brendancuda::KernelCurandState _TRNG>
+        template <std::integral _T, bcuda::KernelCurandState _TRNG>
         __device__ static __forceinline _T RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG);
 #endif
         template <std::integral _T, std::uniform_random_bit_generator _TRNG>
         __host__ static __forceinline _T RandomizeWTargets(_T Value, uint32_t EachFlipProbability, _TRNG& RNG);
 #ifdef __CUDACC__
-        template <std::integral _T, brendancuda::KernelCurandState _TRNG>
+        template <std::integral _T, bcuda::KernelCurandState _TRNG>
         __device__ static __forceinline _T RandomizeWTargets(_T Value, uint32_t EachFlipProbability, _TRNG& RNG);
 #endif
         template <std::integral _T, std::uniform_random_bit_generator _TRNG>
         __host__ static __forceinline _T RandomizeWMutations(_T Value, uint32_t MutationProbability, _TRNG& RNG);
 #ifdef __CUDACC__
-        template <std::integral _T, brendancuda::KernelCurandState _TRNG>
+        template <std::integral _T, bcuda::KernelCurandState _TRNG>
         __device__ static __forceinline _T RandomizeWMutations(_T Value, uint32_t MutationProbability, _TRNG& RNG);
 #endif
         template <std::integral _T, std::uniform_random_bit_generator _TRNG>
         __host__ static __forceinline _T RandomizeWMutations(_T Value, uint32_t MutationProbability, uint32_t ProbabilityOf1, _TRNG& RNG);
 #ifdef __CUDACC__
-        template <std::integral _T, brendancuda::KernelCurandState _TRNG>
+        template <std::integral _T, bcuda::KernelCurandState _TRNG>
         __device__ static __forceinline _T RandomizeWMutations(_T Value, uint32_t MutationProbability, uint32_t ProbabilityOf1, _TRNG& RNG);
 #endif
         template <std::uniform_random_bit_generator _TRNG>
@@ -62,9 +62,9 @@ namespace brendancuda {
         template <std::uniform_random_bit_generator _TRNG>
         __host__ static __forceinline double Randomize(double Value, double Scalar, _TRNG& RNG);
 #ifdef __CUDACC__
-        template <brendancuda::KernelCurandState _TRNG>
+        template <bcuda::KernelCurandState _TRNG>
         __device__ static __forceinline float Randomize(float Value, float Scalar, _TRNG& RNG);
-        template <brendancuda::KernelCurandState _TRNG>
+        template <bcuda::KernelCurandState _TRNG>
         __device__ static __forceinline double Randomize(double Value, double Scalar, _TRNG& RNG);
 #endif
         template <std::uniform_random_bit_generator _TRNG>
@@ -72,47 +72,47 @@ namespace brendancuda {
         template <std::uniform_random_bit_generator _TRNG>
         __host__ static __forceinline double Randomize(double Value, double Scalar, double LowerBound, double UpperBound, _TRNG& RNG);
 #ifdef __CUDACC__
-        template <brendancuda::KernelCurandState _TRNG>
+        template <bcuda::KernelCurandState _TRNG>
         __device__ static __forceinline float Randomize(float Value, float Scalar, float LowerBound, float UpperBound, _TRNG& RNG);
-        template <brendancuda::KernelCurandState _TRNG>
+        template <bcuda::KernelCurandState _TRNG>
         __device__ static __forceinline double Randomize(double Value, double Scalar, double LowerBound, double UpperBound, _TRNG& RNG);
 #endif
 
         template <bool _MemoryOnHost, std::floating_point _T, std::uniform_random_bit_generator _TRNG>
         __host__ static __forceinline void RandomizeArray(Span<_T> Array, _T Scalar, _TRNG& RNG);
 #ifdef __CUDACC__
-        template <std::floating_point _T, brendancuda::KernelCurandState _TRNG>
+        template <std::floating_point _T, bcuda::KernelCurandState _TRNG>
         __device__ static __forceinline void RandomizeArray(Span<_T> Array, _T Scalar, _TRNG& RNG);
 #endif
         template <bool _MemoryOnHost, std::floating_point _T, std::uniform_random_bit_generator _TRNG>
         __host__ static __forceinline void RandomizeArray(Span<_T> Array, _T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG);
 #ifdef __CUDACC__
-        template <std::floating_point _T, brendancuda::KernelCurandState _TRNG>
+        template <std::floating_point _T, bcuda::KernelCurandState _TRNG>
         __device__ static __forceinline void RandomizeArray(Span<_T> Array, _T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG);
 #endif
 
         template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
         __host__ static __forceinline void RandomizeArrayWFlips(Span<_T> Array, uint32_t FlipProb, _TRNG& RNG);
 #ifdef __CUDACC__
-        template <std::integral _T, brendancuda::KernelCurandState _TRNG>
+        template <std::integral _T, bcuda::KernelCurandState _TRNG>
         __device__ static __forceinline void RandomizeArrayWFlips(Span<_T> Array, uint32_t FlipProb, _TRNG& RNG);
 #endif
         template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
         __host__ static __forceinline void RandomizeArrayWTargets(Span<_T> Array, uint32_t EachFlipProb, _TRNG& RNG);
 #ifdef __CUDACC__
-        template <std::integral _T, brendancuda::KernelCurandState _TRNG>
+        template <std::integral _T, bcuda::KernelCurandState _TRNG>
         __device__ static __forceinline void RandomizeArrayWTargets(Span<_T> Array, uint32_t EachFlipProb, _TRNG& RNG);
 #endif
         template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
         __host__ static __forceinline void RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, _TRNG& RNG);
 #ifdef __CUDACC__
-        template <std::integral _T, brendancuda::KernelCurandState _TRNG>
+        template <std::integral _T, bcuda::KernelCurandState _TRNG>
         __device__ static __forceinline void RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, _TRNG& RNG);
 #endif
         template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
         __host__ static __forceinline void RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, _TRNG& RNG);
 #ifdef __CUDACC__
-        template <std::integral _T, brendancuda::KernelCurandState _TRNG>
+        template <std::integral _T, bcuda::KernelCurandState _TRNG>
         __device__ static __forceinline void RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, _TRNG& RNG);
 #endif
 
@@ -120,20 +120,20 @@ namespace brendancuda {
             requires std::is_arithmetic_v<_T>
         __host__ static __forceinline void InitRandomArray(Span<_T> Array, _TRNG& RNG);
 #ifdef __CUDACC__
-        template <typename _T, brendancuda::KernelCurandState _TRNG>
+        template <typename _T, bcuda::KernelCurandState _TRNG>
             requires std::is_arithmetic_v<_T>
         __device__ static __forceinline void InitRandomArray(Span<_T> Array, _TRNG& RNG);
 #endif
         template <bool _MemoryOnHost, std::floating_point _T, std::uniform_random_bit_generator _TRNG>
         __host__ static __forceinline void InitRandomArray(Span<_T> Array, _T LowerBound, _T UpperBound, _TRNG& RNG);
 #ifdef __CUDACC__
-        template <std::floating_point _T, brendancuda::KernelCurandState _TRNG>
+        template <std::floating_point _T, bcuda::KernelCurandState _TRNG>
         __device__ static __forceinline void InitRandomArray(Span<_T> Array, _T LowerBound, _T UpperBound, _TRNG& RNG);
 #endif
         template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
         __host__ static __forceinline void InitRandomArray(Span<_T> Array, uint32_t ProbabilityOf1, _TRNG& RNG);
 #ifdef __CUDACC__
-        template <std::integral _T, brendancuda::KernelCurandState _TRNG>
+        template <std::integral _T, bcuda::KernelCurandState _TRNG>
         __device__ static __forceinline void InitRandomArray(Span<_T> Array, uint32_t ProbabilityOf1, _TRNG& RNG);
 #endif
 
@@ -149,7 +149,7 @@ namespace brendancuda {
 }
 
 template <std::integral _T>
-__host__ __device__ __forceinline _T brendancuda::details::RandomizeWTargets_GetEditsOf1s(_T Value, uint32_t CountOf1s, uint32_t FlipProb, uint32_t RN1, uint32_t RN2) {
+__host__ __device__ __forceinline _T bcuda::details::RandomizeWTargets_GetEditsOf1s(_T Value, uint32_t CountOf1s, uint32_t FlipProb, uint32_t RN1, uint32_t RN2) {
     if (RN1 < FlipProb) {
         uint32_t mrn = RN2 % CountOf1s;
 
@@ -166,19 +166,19 @@ __host__ __device__ __forceinline _T brendancuda::details::RandomizeWTargets_Get
 }
 
 template <std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline _T brendancuda::random::RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
+__host__ __forceinline _T bcuda::random::RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
     if constexpr (sizeof(_T) > 4) return Value ^ (_T)Get64Bits(FlipProbability, RNG);
     else return Value ^ (_T)Get32Bits(FlipProbability, RNG);
 }
 #ifdef __CUDACC__
-template <std::integral _T, brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline _T brendancuda::random::RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
+template <std::integral _T, bcuda::KernelCurandState _TRNG>
+__device__ __forceinline _T bcuda::random::RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
     if constexpr (sizeof(_T) > 4) return Value ^ (_T)Get64Bits(FlipProbability, RNG);
     else return Value ^ (_T)Get32Bits(FlipProbability, RNG);
 }
 #endif
 template <std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline _T brendancuda::random::RandomizeWTargets(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
+__host__ __forceinline _T bcuda::random::RandomizeWTargets(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
     constexpr uint32_t shiftMask = (sizeof(_T) << 3) - 1;
 
     std::uniform_int_distribution<uint32_t> dis32(0);
@@ -204,8 +204,8 @@ __host__ __forceinline _T brendancuda::random::RandomizeWTargets(_T Value, uint3
     }
 }
 #ifdef __CUDACC__
-template <std::integral _T, brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline _T brendancuda::random::RandomizeWTargets(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
+template <std::integral _T, bcuda::KernelCurandState _TRNG>
+__device__ __forceinline _T bcuda::random::RandomizeWTargets(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
     constexpr uint32_t shiftMask = (sizeof(_T) << 3) - 1;
 
     if (!Value) {
@@ -230,7 +230,7 @@ __device__ __forceinline _T brendancuda::random::RandomizeWTargets(_T Value, uin
 }
 #endif
 template <std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline _T brendancuda::random::RandomizeWMutations(_T Value, uint32_t MutationProbability, _TRNG& RNG) {
+__host__ __forceinline _T bcuda::random::RandomizeWMutations(_T Value, uint32_t MutationProbability, _TRNG& RNG) {
     std::uniform_int_distribution<uint32_t> dis32(0);
     if (dis32(RNG) < MutationProbability) {
         if constexpr (sizeof(_T) == 4) return (_T)dis32(RNG);
@@ -246,8 +246,8 @@ __host__ __forceinline _T brendancuda::random::RandomizeWMutations(_T Value, uin
     return Value;
 }
 #ifdef __CUDACC__
-template <std::integral _T, brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline _T brendancuda::random::RandomizeWMutations(_T Value, uint32_t MutationProbability, _TRNG& RNG) {
+template <std::integral _T, bcuda::KernelCurandState _TRNG>
+__device__ __forceinline _T bcuda::random::RandomizeWMutations(_T Value, uint32_t MutationProbability, _TRNG& RNG) {
     if (curand(&RNG) < MutationProbability) {
         if constexpr (sizeof(_T) > 4) return (_T)(((uint64_t)curand(&RNG) << 32) | curand(&RNG));
         else return (_T)curand(&RNG);
@@ -256,7 +256,7 @@ __device__ __forceinline _T brendancuda::random::RandomizeWMutations(_T Value, u
 }
 #endif
 template <std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline _T brendancuda::random::RandomizeWMutations(_T Value, uint32_t MutationProbability, uint32_t ProbabilityOf1, _TRNG& RNG) {
+__host__ __forceinline _T bcuda::random::RandomizeWMutations(_T Value, uint32_t MutationProbability, uint32_t ProbabilityOf1, _TRNG& RNG) {
     std::uniform_int_distribution<uint32_t> dis32(0);
     if (dis32(RNG) < MutationProbability) {
         if constexpr (sizeof(_T) > 4) return (_T)Get64Bits(ProbabilityOf1, RNG);
@@ -265,8 +265,8 @@ __host__ __forceinline _T brendancuda::random::RandomizeWMutations(_T Value, uin
     return Value;
 }
 #ifdef __CUDACC__
-template <std::integral _T, brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline _T brendancuda::random::RandomizeWMutations(_T Value, uint32_t MutationProbability, uint32_t ProbabilityOf1, _TRNG& RNG) {
+template <std::integral _T, bcuda::KernelCurandState _TRNG>
+__device__ __forceinline _T bcuda::random::RandomizeWMutations(_T Value, uint32_t MutationProbability, uint32_t ProbabilityOf1, _TRNG& RNG) {
     if (curand(&RNG) < MutationProbability) {
         if constexpr (sizeof(_T) > 4) return (_T)Get64Bits(ProbabilityOf1, RNG);
         else return (_T)Get32Bits(ProbabilityOf1, RNG);
@@ -275,48 +275,48 @@ __device__ __forceinline _T brendancuda::random::RandomizeWMutations(_T Value, u
 }
 #endif
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline float brendancuda::random::Randomize(float Value, float Scalar, _TRNG& RNG) {
+__host__ __forceinline float bcuda::random::Randomize(float Value, float Scalar, _TRNG& RNG) {
     std::uniform_real_distribution<float> dis(-Scalar, Scalar);
     return Value + dis(RNG);
 }
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline double brendancuda::random::Randomize(double Value, double Scalar, _TRNG& RNG) {
+__host__ __forceinline double bcuda::random::Randomize(double Value, double Scalar, _TRNG& RNG) {
     std::uniform_real_distribution<double> dis(-Scalar, Scalar);
     return Value + dis(RNG);
 }
 #ifdef __CUDACC__
-template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline float brendancuda::random::Randomize(float Value, float Scalar, _TRNG& RNG) {
+template <bcuda::KernelCurandState _TRNG>
+__device__ __forceinline float bcuda::random::Randomize(float Value, float Scalar, _TRNG& RNG) {
     return Value + Scalar * 2.f * (curand_uniform(&RNG) - 0.5f);
 }
-template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline double brendancuda::random::Randomize(double Value, double Scalar, _TRNG& RNG) {
+template <bcuda::KernelCurandState _TRNG>
+__device__ __forceinline double bcuda::random::Randomize(double Value, double Scalar, _TRNG& RNG) {
     return Value + Scalar * 2. * (curand_uniform_double(&RNG) - 0.5);
 }
 #endif
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline float brendancuda::random::Randomize(float Value, float Scalar, float LowerBound, float UpperBound, _TRNG& RNG) {
+__host__ __forceinline float bcuda::random::Randomize(float Value, float Scalar, float LowerBound, float UpperBound, _TRNG& RNG) {
     std::uniform_real_distribution<float> dis(-Scalar, Scalar);
     return std::clamp(Value + dis(RNG), LowerBound, UpperBound);
 }
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline double brendancuda::random::Randomize(double Value, double Scalar, double LowerBound, double UpperBound, _TRNG& RNG) {
+__host__ __forceinline double bcuda::random::Randomize(double Value, double Scalar, double LowerBound, double UpperBound, _TRNG& RNG) {
     std::uniform_real_distribution<double> dis(-Scalar, Scalar);
     return std::clamp(Value + dis(RNG), LowerBound, UpperBound);
 }
 #ifdef __CUDACC__
-template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline float brendancuda::random::Randomize(float Value, float Scalar, float LowerBound, float UpperBound, _TRNG& RNG) {
+template <bcuda::KernelCurandState _TRNG>
+__device__ __forceinline float bcuda::random::Randomize(float Value, float Scalar, float LowerBound, float UpperBound, _TRNG& RNG) {
     return std::clamp(Value + Scalar * 2.f * (curand_uniform(&RNG) - 0.5f), LowerBound, UpperBound);
 }
-template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline double brendancuda::random::Randomize(double Value, double Scalar, double LowerBound, double UpperBound, _TRNG& RNG) {
+template <bcuda::KernelCurandState _TRNG>
+__device__ __forceinline double bcuda::random::Randomize(double Value, double Scalar, double LowerBound, double UpperBound, _TRNG& RNG) {
     return std::clamp(Value + Scalar * 2. * (curand_uniform_double(&RNG) - 0.5), LowerBound, UpperBound);
 }
 #endif
 
 template <bool _MemoryOnHost, std::floating_point _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::random::RandomizeArray(Span<_T> Array, _T Scalar, _TRNG& RNG) {
+__host__ __forceinline void bcuda::random::RandomizeArray(Span<_T> Array, _T Scalar, _TRNG& RNG) {
     if constexpr (_MemoryOnHost) {
         Scalar *= 2.f;
         std::uniform_real_distribution<_T> dis(-Scalar, Scalar);
@@ -330,8 +330,8 @@ __host__ __forceinline void brendancuda::random::RandomizeArray(Span<_T> Array, 
     }
 }
 #ifdef __CUDACC__
-template <std::floating_point _T, brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::random::RandomizeArray(Span<_T> Array, _T Scalar, _TRNG& RNG) {
+template <std::floating_point _T, bcuda::KernelCurandState _TRNG>
+__device__ __forceinline void bcuda::random::RandomizeArray(Span<_T> Array, _T Scalar, _TRNG& RNG) {
     if constexpr (std::same_as<_T, float>) {
         Scalar *= 2.f;
         float* l = Array.ptr;
@@ -347,7 +347,7 @@ __device__ __forceinline void brendancuda::random::RandomizeArray(Span<_T> Array
 }
 #endif
 template <bool _MemoryOnHost, std::floating_point _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::random::RandomizeArray(Span<_T> Array, _T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__host__ __forceinline void bcuda::random::RandomizeArray(Span<_T> Array, _T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     if constexpr (_MemoryOnHost) {
         Scalar *= 2.f;
         std::uniform_real_distribution<_T> dis(-Scalar, Scalar);
@@ -361,8 +361,8 @@ __host__ __forceinline void brendancuda::random::RandomizeArray(Span<_T> Array, 
     }
 }
 #ifdef __CUDACC__
-template <std::floating_point _T, brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::random::RandomizeArray(Span<_T> Array, _T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+template <std::floating_point _T, bcuda::KernelCurandState _TRNG>
+__device__ __forceinline void bcuda::random::RandomizeArray(Span<_T> Array, _T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     if constexpr (std::same_as<_T, float>) {
         Scalar *= 2.f;
         float* l = Array.ptr;
@@ -379,7 +379,7 @@ __device__ __forceinline void brendancuda::random::RandomizeArray(Span<_T> Array
 #endif
 
 template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::random::RandomizeArrayWFlips(Span<_T> Array, uint32_t FlipProb, _TRNG& RNG) {
+__host__ __forceinline void bcuda::random::RandomizeArrayWFlips(Span<_T> Array, uint32_t FlipProb, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         if constexpr (_MemoryOnHost) {
             uint64_t* l64 = (uint64_t*)Array.ptr;
@@ -416,8 +416,8 @@ __host__ __forceinline void brendancuda::random::RandomizeArrayWFlips(Span<_T> A
     }
 }
 #ifdef __CUDACC__
-template <std::integral _T, brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::random::RandomizeArrayWFlips(Span<_T> Array, uint32_t FlipProb, _TRNG& RNG) {
+template <std::integral _T, bcuda::KernelCurandState _TRNG>
+__device__ __forceinline void bcuda::random::RandomizeArrayWFlips(Span<_T> Array, uint32_t FlipProb, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         uint64_t* l64 = (uint64_t*)Array.ptr;
         uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
@@ -438,7 +438,7 @@ __device__ __forceinline void brendancuda::random::RandomizeArrayWFlips(Span<_T>
 }
 #endif
 template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::random::RandomizeArrayWTargets(Span<_T> Array, uint32_t EachFlipProb, _TRNG& RNG) {
+__host__ __forceinline void bcuda::random::RandomizeArrayWTargets(Span<_T> Array, uint32_t EachFlipProb, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         if constexpr (_MemoryOnHost) {
             uint64_t* l64 = (uint64_t*)Array.ptr;
@@ -475,8 +475,8 @@ __host__ __forceinline void brendancuda::random::RandomizeArrayWTargets(Span<_T>
     }
 }
 #ifdef __CUDACC__
-template <std::integral _T, brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::random::RandomizeArrayWTargets(Span<_T> Array, uint32_t EachFlipProb, _TRNG& RNG) {
+template <std::integral _T, bcuda::KernelCurandState _TRNG>
+__device__ __forceinline void bcuda::random::RandomizeArrayWTargets(Span<_T> Array, uint32_t EachFlipProb, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         uint64_t* l64 = (uint64_t*)Array.ptr;
         uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
@@ -497,7 +497,7 @@ __device__ __forceinline void brendancuda::random::RandomizeArrayWTargets(Span<_
 }
 #endif
 template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::random::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, _TRNG& RNG) {
+__host__ __forceinline void bcuda::random::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         if constexpr (_MemoryOnHost) {
             uint64_t* l64 = (uint64_t*)Array.ptr;
@@ -534,8 +534,8 @@ __host__ __forceinline void brendancuda::random::RandomizeArrayWMutations(Span<_
     }
 }
 #ifdef __CUDACC__
-template <std::integral _T, brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::random::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, _TRNG& RNG) {
+template <std::integral _T, bcuda::KernelCurandState _TRNG>
+__device__ __forceinline void bcuda::random::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         uint64_t* l64 = (uint64_t*)Array.ptr;
         uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
@@ -556,7 +556,7 @@ __device__ __forceinline void brendancuda::random::RandomizeArrayWMutations(Span
 }
 #endif
 template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::random::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, _TRNG& RNG) {
+__host__ __forceinline void bcuda::random::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         if constexpr (_MemoryOnHost) {
             uint64_t* l64 = (uint64_t*)Array.ptr;
@@ -593,8 +593,8 @@ __host__ __forceinline void brendancuda::random::RandomizeArrayWMutations(Span<_
     }
 }
 #ifdef __CUDACC__
-template <std::integral _T, brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::random::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, _TRNG& RNG) {
+template <std::integral _T, bcuda::KernelCurandState _TRNG>
+__device__ __forceinline void bcuda::random::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         uint64_t* l64 = (uint64_t*)Array.ptr;
         uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
@@ -617,7 +617,7 @@ __device__ __forceinline void brendancuda::random::RandomizeArrayWMutations(Span
 
 template <bool _MemoryOnHost, typename _T, std::uniform_random_bit_generator _TRNG>
     requires std::is_arithmetic_v<_T>
-__host__ __forceinline void brendancuda::random::InitRandomArray(Span<_T> Array, _TRNG& RNG) {
+__host__ __forceinline void bcuda::random::InitRandomArray(Span<_T> Array, _TRNG& RNG) {
     if constexpr (std::floating_point<_T>) {
         if constexpr (_MemoryOnHost) {
             std::uniform_real_distribution<_T> dis(-1., 1.);
@@ -661,9 +661,9 @@ __host__ __forceinline void brendancuda::random::InitRandomArray(Span<_T> Array,
     }
 }
 #ifdef __CUDACC__
-template <typename _T, brendancuda::KernelCurandState _TRNG>
+template <typename _T, bcuda::KernelCurandState _TRNG>
     requires std::is_arithmetic_v<_T>
-__device__ __forceinline void brendancuda::random::InitRandomArray(Span<_T> Array, _TRNG& RNG) {
+__device__ __forceinline void bcuda::random::InitRandomArray(Span<_T> Array, _TRNG& RNG) {
     if constexpr (std::same_as<_T, float>) {
         float* l = Array.ptr;
         float* u = Array.ptr + Array.size;
@@ -690,7 +690,7 @@ __device__ __forceinline void brendancuda::random::InitRandomArray(Span<_T> Arra
 
 #endif
 template <bool _MemoryOnHost, std::floating_point _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::random::InitRandomArray(Span<_T> Array, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__host__ __forceinline void bcuda::random::InitRandomArray(Span<_T> Array, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     if constexpr (_MemoryOnHost) {
         std::uniform_real_distribution<_T> dis(LowerBound, UpperBound);
         _T* l = Array.ptr;
@@ -703,8 +703,8 @@ __host__ __forceinline void brendancuda::random::InitRandomArray(Span<_T> Array,
     }
 }
 #ifdef __CUDACC__
-template <std::floating_point _T, brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::random::InitRandomArray(Span<_T> Array, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+template <std::floating_point _T, bcuda::KernelCurandState _TRNG>
+__device__ __forceinline void bcuda::random::InitRandomArray(Span<_T> Array, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     if constexpr (std::same_as<_T, float>) {
         float range = UpperBound - LowerBound;
         float* l = Array.ptr;
@@ -721,7 +721,7 @@ __device__ __forceinline void brendancuda::random::InitRandomArray(Span<_T> Arra
 #endif
 
 template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::random::InitRandomArray(Span<_T> Array, uint32_t ProbabilityOf1, _TRNG& RNG) {
+__host__ __forceinline void bcuda::random::InitRandomArray(Span<_T> Array, uint32_t ProbabilityOf1, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         if constexpr (_MemoryOnHost) {
             uint64_t* l64 = (uint64_t*)Array.ptr;
@@ -752,8 +752,8 @@ __host__ __forceinline void brendancuda::random::InitRandomArray(Span<_T> Array,
     }
 }
 #ifdef __CUDACC__
-template <std::integral _T, brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::random::InitRandomArray(Span<_T> Array, uint32_t ProbabilityOf1, _TRNG& RNG) {
+template <std::integral _T, bcuda::KernelCurandState _TRNG>
+__device__ __forceinline void bcuda::random::InitRandomArray(Span<_T> Array, uint32_t ProbabilityOf1, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         uint32_t* l32 = (uint32_t*)Array.ptr;
         uint32_t* u32 = ((uint32_t*)Array.ptr) + (Array.size >> 2);
@@ -773,7 +773,7 @@ __device__ __forceinline void brendancuda::random::InitRandomArray(Span<_T> Arra
 
 template <bool _MemoryOnHost, typename _T>
     requires std::is_arithmetic_v<_T>
-__host__ __forceinline void brendancuda::random::ClearArray(Span<_T> Array) {
+__host__ __forceinline void bcuda::random::ClearArray(Span<_T> Array) {
     if constexpr (std::floating_point<_T>) {
         if constexpr (_MemoryOnHost) {
             _T* l = Array.ptr;
@@ -813,7 +813,7 @@ __host__ __forceinline void brendancuda::random::ClearArray(Span<_T> Array) {
 #ifdef __CUDACC__
 template <typename _T>
     requires std::is_arithmetic_v<_T>
-__device__ __forceinline void brendancuda::random::ClearArray(Span<_T> Array) {
+__device__ __forceinline void bcuda::random::ClearArray(Span<_T> Array) {
     if constexpr (std::floating_point<_T>) {
         _T* l = Array.ptr;
         _T* u = Array.ptr + Array.size;

--- a/rand_randomizer.h
+++ b/rand_randomizer.h
@@ -9,7 +9,7 @@
 #include <cuda_runtime.h>
 #include <curand_kernel.h>
 
-namespace BrendanCUDA {
+namespace brendancuda {
     namespace details {
         template <std::integral _T>
         __host__ __device__ static __forceinline _T RandomizeWTargets_GetEditsOf1s(_T Value, uint32_t CountOf1s, uint32_t FlipProb, uint32_t RN1, uint32_t RN2);
@@ -36,25 +36,25 @@ namespace BrendanCUDA {
         template <std::integral _T, std::uniform_random_bit_generator _TRNG>
         __host__ static __forceinline _T RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG);
 #ifdef __CUDACC__
-        template <std::integral _T, BrendanCUDA::KernelCurandState _TRNG>
+        template <std::integral _T, brendancuda::KernelCurandState _TRNG>
         __device__ static __forceinline _T RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG);
 #endif
         template <std::integral _T, std::uniform_random_bit_generator _TRNG>
         __host__ static __forceinline _T RandomizeWTargets(_T Value, uint32_t EachFlipProbability, _TRNG& RNG);
 #ifdef __CUDACC__
-        template <std::integral _T, BrendanCUDA::KernelCurandState _TRNG>
+        template <std::integral _T, brendancuda::KernelCurandState _TRNG>
         __device__ static __forceinline _T RandomizeWTargets(_T Value, uint32_t EachFlipProbability, _TRNG& RNG);
 #endif
         template <std::integral _T, std::uniform_random_bit_generator _TRNG>
         __host__ static __forceinline _T RandomizeWMutations(_T Value, uint32_t MutationProbability, _TRNG& RNG);
 #ifdef __CUDACC__
-        template <std::integral _T, BrendanCUDA::KernelCurandState _TRNG>
+        template <std::integral _T, brendancuda::KernelCurandState _TRNG>
         __device__ static __forceinline _T RandomizeWMutations(_T Value, uint32_t MutationProbability, _TRNG& RNG);
 #endif
         template <std::integral _T, std::uniform_random_bit_generator _TRNG>
         __host__ static __forceinline _T RandomizeWMutations(_T Value, uint32_t MutationProbability, uint32_t ProbabilityOf1, _TRNG& RNG);
 #ifdef __CUDACC__
-        template <std::integral _T, BrendanCUDA::KernelCurandState _TRNG>
+        template <std::integral _T, brendancuda::KernelCurandState _TRNG>
         __device__ static __forceinline _T RandomizeWMutations(_T Value, uint32_t MutationProbability, uint32_t ProbabilityOf1, _TRNG& RNG);
 #endif
         template <std::uniform_random_bit_generator _TRNG>
@@ -62,9 +62,9 @@ namespace BrendanCUDA {
         template <std::uniform_random_bit_generator _TRNG>
         __host__ static __forceinline double Randomize(double Value, double Scalar, _TRNG& RNG);
 #ifdef __CUDACC__
-        template <BrendanCUDA::KernelCurandState _TRNG>
+        template <brendancuda::KernelCurandState _TRNG>
         __device__ static __forceinline float Randomize(float Value, float Scalar, _TRNG& RNG);
-        template <BrendanCUDA::KernelCurandState _TRNG>
+        template <brendancuda::KernelCurandState _TRNG>
         __device__ static __forceinline double Randomize(double Value, double Scalar, _TRNG& RNG);
 #endif
         template <std::uniform_random_bit_generator _TRNG>
@@ -72,47 +72,47 @@ namespace BrendanCUDA {
         template <std::uniform_random_bit_generator _TRNG>
         __host__ static __forceinline double Randomize(double Value, double Scalar, double LowerBound, double UpperBound, _TRNG& RNG);
 #ifdef __CUDACC__
-        template <BrendanCUDA::KernelCurandState _TRNG>
+        template <brendancuda::KernelCurandState _TRNG>
         __device__ static __forceinline float Randomize(float Value, float Scalar, float LowerBound, float UpperBound, _TRNG& RNG);
-        template <BrendanCUDA::KernelCurandState _TRNG>
+        template <brendancuda::KernelCurandState _TRNG>
         __device__ static __forceinline double Randomize(double Value, double Scalar, double LowerBound, double UpperBound, _TRNG& RNG);
 #endif
 
         template <bool _MemoryOnHost, std::floating_point _T, std::uniform_random_bit_generator _TRNG>
         __host__ static __forceinline void RandomizeArray(Span<_T> Array, _T Scalar, _TRNG& RNG);
 #ifdef __CUDACC__
-        template <std::floating_point _T, BrendanCUDA::KernelCurandState _TRNG>
+        template <std::floating_point _T, brendancuda::KernelCurandState _TRNG>
         __device__ static __forceinline void RandomizeArray(Span<_T> Array, _T Scalar, _TRNG& RNG);
 #endif
         template <bool _MemoryOnHost, std::floating_point _T, std::uniform_random_bit_generator _TRNG>
         __host__ static __forceinline void RandomizeArray(Span<_T> Array, _T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG);
 #ifdef __CUDACC__
-        template <std::floating_point _T, BrendanCUDA::KernelCurandState _TRNG>
+        template <std::floating_point _T, brendancuda::KernelCurandState _TRNG>
         __device__ static __forceinline void RandomizeArray(Span<_T> Array, _T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG);
 #endif
 
         template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
         __host__ static __forceinline void RandomizeArrayWFlips(Span<_T> Array, uint32_t FlipProb, _TRNG& RNG);
 #ifdef __CUDACC__
-        template <std::integral _T, BrendanCUDA::KernelCurandState _TRNG>
+        template <std::integral _T, brendancuda::KernelCurandState _TRNG>
         __device__ static __forceinline void RandomizeArrayWFlips(Span<_T> Array, uint32_t FlipProb, _TRNG& RNG);
 #endif
         template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
         __host__ static __forceinline void RandomizeArrayWTargets(Span<_T> Array, uint32_t EachFlipProb, _TRNG& RNG);
 #ifdef __CUDACC__
-        template <std::integral _T, BrendanCUDA::KernelCurandState _TRNG>
+        template <std::integral _T, brendancuda::KernelCurandState _TRNG>
         __device__ static __forceinline void RandomizeArrayWTargets(Span<_T> Array, uint32_t EachFlipProb, _TRNG& RNG);
 #endif
         template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
         __host__ static __forceinline void RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, _TRNG& RNG);
 #ifdef __CUDACC__
-        template <std::integral _T, BrendanCUDA::KernelCurandState _TRNG>
+        template <std::integral _T, brendancuda::KernelCurandState _TRNG>
         __device__ static __forceinline void RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, _TRNG& RNG);
 #endif
         template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
         __host__ static __forceinline void RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, _TRNG& RNG);
 #ifdef __CUDACC__
-        template <std::integral _T, BrendanCUDA::KernelCurandState _TRNG>
+        template <std::integral _T, brendancuda::KernelCurandState _TRNG>
         __device__ static __forceinline void RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, _TRNG& RNG);
 #endif
 
@@ -120,20 +120,20 @@ namespace BrendanCUDA {
             requires std::is_arithmetic_v<_T>
         __host__ static __forceinline void InitRandomArray(Span<_T> Array, _TRNG& RNG);
 #ifdef __CUDACC__
-        template <typename _T, BrendanCUDA::KernelCurandState _TRNG>
+        template <typename _T, brendancuda::KernelCurandState _TRNG>
             requires std::is_arithmetic_v<_T>
         __device__ static __forceinline void InitRandomArray(Span<_T> Array, _TRNG& RNG);
 #endif
         template <bool _MemoryOnHost, std::floating_point _T, std::uniform_random_bit_generator _TRNG>
         __host__ static __forceinline void InitRandomArray(Span<_T> Array, _T LowerBound, _T UpperBound, _TRNG& RNG);
 #ifdef __CUDACC__
-        template <std::floating_point _T, BrendanCUDA::KernelCurandState _TRNG>
+        template <std::floating_point _T, brendancuda::KernelCurandState _TRNG>
         __device__ static __forceinline void InitRandomArray(Span<_T> Array, _T LowerBound, _T UpperBound, _TRNG& RNG);
 #endif
         template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
         __host__ static __forceinline void InitRandomArray(Span<_T> Array, uint32_t ProbabilityOf1, _TRNG& RNG);
 #ifdef __CUDACC__
-        template <std::integral _T, BrendanCUDA::KernelCurandState _TRNG>
+        template <std::integral _T, brendancuda::KernelCurandState _TRNG>
         __device__ static __forceinline void InitRandomArray(Span<_T> Array, uint32_t ProbabilityOf1, _TRNG& RNG);
 #endif
 
@@ -149,7 +149,7 @@ namespace BrendanCUDA {
 }
 
 template <std::integral _T>
-__host__ __device__ __forceinline _T BrendanCUDA::details::RandomizeWTargets_GetEditsOf1s(_T Value, uint32_t CountOf1s, uint32_t FlipProb, uint32_t RN1, uint32_t RN2) {
+__host__ __device__ __forceinline _T brendancuda::details::RandomizeWTargets_GetEditsOf1s(_T Value, uint32_t CountOf1s, uint32_t FlipProb, uint32_t RN1, uint32_t RN2) {
     if (RN1 < FlipProb) {
         uint32_t mrn = RN2 % CountOf1s;
 
@@ -166,19 +166,19 @@ __host__ __device__ __forceinline _T BrendanCUDA::details::RandomizeWTargets_Get
 }
 
 template <std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline _T BrendanCUDA::Random::RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
+__host__ __forceinline _T brendancuda::Random::RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
     if constexpr (sizeof(_T) > 4) return Value ^ (_T)Get64Bits(FlipProbability, RNG);
     else return Value ^ (_T)Get32Bits(FlipProbability, RNG);
 }
 #ifdef __CUDACC__
-template <std::integral _T, BrendanCUDA::KernelCurandState _TRNG>
-__device__ __forceinline _T BrendanCUDA::Random::RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
+template <std::integral _T, brendancuda::KernelCurandState _TRNG>
+__device__ __forceinline _T brendancuda::Random::RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
     if constexpr (sizeof(_T) > 4) return Value ^ (_T)Get64Bits(FlipProbability, RNG);
     else return Value ^ (_T)Get32Bits(FlipProbability, RNG);
 }
 #endif
 template <std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline _T BrendanCUDA::Random::RandomizeWTargets(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
+__host__ __forceinline _T brendancuda::Random::RandomizeWTargets(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
     constexpr uint32_t shiftMask = (sizeof(_T) << 3) - 1;
 
     std::uniform_int_distribution<uint32_t> dis32(0);
@@ -204,8 +204,8 @@ __host__ __forceinline _T BrendanCUDA::Random::RandomizeWTargets(_T Value, uint3
     }
 }
 #ifdef __CUDACC__
-template <std::integral _T, BrendanCUDA::KernelCurandState _TRNG>
-__device__ __forceinline _T BrendanCUDA::Random::RandomizeWTargets(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
+template <std::integral _T, brendancuda::KernelCurandState _TRNG>
+__device__ __forceinline _T brendancuda::Random::RandomizeWTargets(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
     constexpr uint32_t shiftMask = (sizeof(_T) << 3) - 1;
 
     if (!Value) {
@@ -230,7 +230,7 @@ __device__ __forceinline _T BrendanCUDA::Random::RandomizeWTargets(_T Value, uin
 }
 #endif
 template <std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline _T BrendanCUDA::Random::RandomizeWMutations(_T Value, uint32_t MutationProbability, _TRNG& RNG) {
+__host__ __forceinline _T brendancuda::Random::RandomizeWMutations(_T Value, uint32_t MutationProbability, _TRNG& RNG) {
     std::uniform_int_distribution<uint32_t> dis32(0);
     if (dis32(RNG) < MutationProbability) {
         if constexpr (sizeof(_T) == 4) return (_T)dis32(RNG);
@@ -246,8 +246,8 @@ __host__ __forceinline _T BrendanCUDA::Random::RandomizeWMutations(_T Value, uin
     return Value;
 }
 #ifdef __CUDACC__
-template <std::integral _T, BrendanCUDA::KernelCurandState _TRNG>
-__device__ __forceinline _T BrendanCUDA::Random::RandomizeWMutations(_T Value, uint32_t MutationProbability, _TRNG& RNG) {
+template <std::integral _T, brendancuda::KernelCurandState _TRNG>
+__device__ __forceinline _T brendancuda::Random::RandomizeWMutations(_T Value, uint32_t MutationProbability, _TRNG& RNG) {
     if (curand(&RNG) < MutationProbability) {
         if constexpr (sizeof(_T) > 4) return (_T)(((uint64_t)curand(&RNG) << 32) | curand(&RNG));
         else return (_T)curand(&RNG);
@@ -256,7 +256,7 @@ __device__ __forceinline _T BrendanCUDA::Random::RandomizeWMutations(_T Value, u
 }
 #endif
 template <std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline _T BrendanCUDA::Random::RandomizeWMutations(_T Value, uint32_t MutationProbability, uint32_t ProbabilityOf1, _TRNG& RNG) {
+__host__ __forceinline _T brendancuda::Random::RandomizeWMutations(_T Value, uint32_t MutationProbability, uint32_t ProbabilityOf1, _TRNG& RNG) {
     std::uniform_int_distribution<uint32_t> dis32(0);
     if (dis32(RNG) < MutationProbability) {
         if constexpr (sizeof(_T) > 4) return (_T)Get64Bits(ProbabilityOf1, RNG);
@@ -265,8 +265,8 @@ __host__ __forceinline _T BrendanCUDA::Random::RandomizeWMutations(_T Value, uin
     return Value;
 }
 #ifdef __CUDACC__
-template <std::integral _T, BrendanCUDA::KernelCurandState _TRNG>
-__device__ __forceinline _T BrendanCUDA::Random::RandomizeWMutations(_T Value, uint32_t MutationProbability, uint32_t ProbabilityOf1, _TRNG& RNG) {
+template <std::integral _T, brendancuda::KernelCurandState _TRNG>
+__device__ __forceinline _T brendancuda::Random::RandomizeWMutations(_T Value, uint32_t MutationProbability, uint32_t ProbabilityOf1, _TRNG& RNG) {
     if (curand(&RNG) < MutationProbability) {
         if constexpr (sizeof(_T) > 4) return (_T)Get64Bits(ProbabilityOf1, RNG);
         else return (_T)Get32Bits(ProbabilityOf1, RNG);
@@ -275,48 +275,48 @@ __device__ __forceinline _T BrendanCUDA::Random::RandomizeWMutations(_T Value, u
 }
 #endif
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline float BrendanCUDA::Random::Randomize(float Value, float Scalar, _TRNG& RNG) {
+__host__ __forceinline float brendancuda::Random::Randomize(float Value, float Scalar, _TRNG& RNG) {
     std::uniform_real_distribution<float> dis(-Scalar, Scalar);
     return Value + dis(RNG);
 }
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline double BrendanCUDA::Random::Randomize(double Value, double Scalar, _TRNG& RNG) {
+__host__ __forceinline double brendancuda::Random::Randomize(double Value, double Scalar, _TRNG& RNG) {
     std::uniform_real_distribution<double> dis(-Scalar, Scalar);
     return Value + dis(RNG);
 }
 #ifdef __CUDACC__
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ __forceinline float BrendanCUDA::Random::Randomize(float Value, float Scalar, _TRNG& RNG) {
+template <brendancuda::KernelCurandState _TRNG>
+__device__ __forceinline float brendancuda::Random::Randomize(float Value, float Scalar, _TRNG& RNG) {
     return Value + Scalar * 2.f * (curand_uniform(&RNG) - 0.5f);
 }
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ __forceinline double BrendanCUDA::Random::Randomize(double Value, double Scalar, _TRNG& RNG) {
+template <brendancuda::KernelCurandState _TRNG>
+__device__ __forceinline double brendancuda::Random::Randomize(double Value, double Scalar, _TRNG& RNG) {
     return Value + Scalar * 2. * (curand_uniform_double(&RNG) - 0.5);
 }
 #endif
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline float BrendanCUDA::Random::Randomize(float Value, float Scalar, float LowerBound, float UpperBound, _TRNG& RNG) {
+__host__ __forceinline float brendancuda::Random::Randomize(float Value, float Scalar, float LowerBound, float UpperBound, _TRNG& RNG) {
     std::uniform_real_distribution<float> dis(-Scalar, Scalar);
     return std::clamp(Value + dis(RNG), LowerBound, UpperBound);
 }
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline double BrendanCUDA::Random::Randomize(double Value, double Scalar, double LowerBound, double UpperBound, _TRNG& RNG) {
+__host__ __forceinline double brendancuda::Random::Randomize(double Value, double Scalar, double LowerBound, double UpperBound, _TRNG& RNG) {
     std::uniform_real_distribution<double> dis(-Scalar, Scalar);
     return std::clamp(Value + dis(RNG), LowerBound, UpperBound);
 }
 #ifdef __CUDACC__
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ __forceinline float BrendanCUDA::Random::Randomize(float Value, float Scalar, float LowerBound, float UpperBound, _TRNG& RNG) {
+template <brendancuda::KernelCurandState _TRNG>
+__device__ __forceinline float brendancuda::Random::Randomize(float Value, float Scalar, float LowerBound, float UpperBound, _TRNG& RNG) {
     return std::clamp(Value + Scalar * 2.f * (curand_uniform(&RNG) - 0.5f), LowerBound, UpperBound);
 }
-template <BrendanCUDA::KernelCurandState _TRNG>
-__device__ __forceinline double BrendanCUDA::Random::Randomize(double Value, double Scalar, double LowerBound, double UpperBound, _TRNG& RNG) {
+template <brendancuda::KernelCurandState _TRNG>
+__device__ __forceinline double brendancuda::Random::Randomize(double Value, double Scalar, double LowerBound, double UpperBound, _TRNG& RNG) {
     return std::clamp(Value + Scalar * 2. * (curand_uniform_double(&RNG) - 0.5), LowerBound, UpperBound);
 }
 #endif
 
 template <bool _MemoryOnHost, std::floating_point _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void BrendanCUDA::Random::RandomizeArray(Span<_T> Array, _T Scalar, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::Random::RandomizeArray(Span<_T> Array, _T Scalar, _TRNG& RNG) {
     if constexpr (_MemoryOnHost) {
         Scalar *= 2.f;
         std::uniform_real_distribution<_T> dis(-Scalar, Scalar);
@@ -330,8 +330,8 @@ __host__ __forceinline void BrendanCUDA::Random::RandomizeArray(Span<_T> Array, 
     }
 }
 #ifdef __CUDACC__
-template <std::floating_point _T, BrendanCUDA::KernelCurandState _TRNG>
-__device__ __forceinline void BrendanCUDA::Random::RandomizeArray(Span<_T> Array, _T Scalar, _TRNG& RNG) {
+template <std::floating_point _T, brendancuda::KernelCurandState _TRNG>
+__device__ __forceinline void brendancuda::Random::RandomizeArray(Span<_T> Array, _T Scalar, _TRNG& RNG) {
     if constexpr (std::same_as<_T, float>) {
         Scalar *= 2.f;
         float* l = Array.ptr;
@@ -347,7 +347,7 @@ __device__ __forceinline void BrendanCUDA::Random::RandomizeArray(Span<_T> Array
 }
 #endif
 template <bool _MemoryOnHost, std::floating_point _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void BrendanCUDA::Random::RandomizeArray(Span<_T> Array, _T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::Random::RandomizeArray(Span<_T> Array, _T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     if constexpr (_MemoryOnHost) {
         Scalar *= 2.f;
         std::uniform_real_distribution<_T> dis(-Scalar, Scalar);
@@ -361,8 +361,8 @@ __host__ __forceinline void BrendanCUDA::Random::RandomizeArray(Span<_T> Array, 
     }
 }
 #ifdef __CUDACC__
-template <std::floating_point _T, BrendanCUDA::KernelCurandState _TRNG>
-__device__ __forceinline void BrendanCUDA::Random::RandomizeArray(Span<_T> Array, _T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+template <std::floating_point _T, brendancuda::KernelCurandState _TRNG>
+__device__ __forceinline void brendancuda::Random::RandomizeArray(Span<_T> Array, _T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     if constexpr (std::same_as<_T, float>) {
         Scalar *= 2.f;
         float* l = Array.ptr;
@@ -379,7 +379,7 @@ __device__ __forceinline void BrendanCUDA::Random::RandomizeArray(Span<_T> Array
 #endif
 
 template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void BrendanCUDA::Random::RandomizeArrayWFlips(Span<_T> Array, uint32_t FlipProb, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::Random::RandomizeArrayWFlips(Span<_T> Array, uint32_t FlipProb, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         if constexpr (_MemoryOnHost) {
             uint64_t* l64 = (uint64_t*)Array.ptr;
@@ -416,8 +416,8 @@ __host__ __forceinline void BrendanCUDA::Random::RandomizeArrayWFlips(Span<_T> A
     }
 }
 #ifdef __CUDACC__
-template <std::integral _T, BrendanCUDA::KernelCurandState _TRNG>
-__device__ __forceinline void BrendanCUDA::Random::RandomizeArrayWFlips(Span<_T> Array, uint32_t FlipProb, _TRNG& RNG) {
+template <std::integral _T, brendancuda::KernelCurandState _TRNG>
+__device__ __forceinline void brendancuda::Random::RandomizeArrayWFlips(Span<_T> Array, uint32_t FlipProb, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         uint64_t* l64 = (uint64_t*)Array.ptr;
         uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
@@ -438,7 +438,7 @@ __device__ __forceinline void BrendanCUDA::Random::RandomizeArrayWFlips(Span<_T>
 }
 #endif
 template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void BrendanCUDA::Random::RandomizeArrayWTargets(Span<_T> Array, uint32_t EachFlipProb, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::Random::RandomizeArrayWTargets(Span<_T> Array, uint32_t EachFlipProb, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         if constexpr (_MemoryOnHost) {
             uint64_t* l64 = (uint64_t*)Array.ptr;
@@ -475,8 +475,8 @@ __host__ __forceinline void BrendanCUDA::Random::RandomizeArrayWTargets(Span<_T>
     }
 }
 #ifdef __CUDACC__
-template <std::integral _T, BrendanCUDA::KernelCurandState _TRNG>
-__device__ __forceinline void BrendanCUDA::Random::RandomizeArrayWTargets(Span<_T> Array, uint32_t EachFlipProb, _TRNG& RNG) {
+template <std::integral _T, brendancuda::KernelCurandState _TRNG>
+__device__ __forceinline void brendancuda::Random::RandomizeArrayWTargets(Span<_T> Array, uint32_t EachFlipProb, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         uint64_t* l64 = (uint64_t*)Array.ptr;
         uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
@@ -497,7 +497,7 @@ __device__ __forceinline void BrendanCUDA::Random::RandomizeArrayWTargets(Span<_
 }
 #endif
 template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void BrendanCUDA::Random::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::Random::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         if constexpr (_MemoryOnHost) {
             uint64_t* l64 = (uint64_t*)Array.ptr;
@@ -534,8 +534,8 @@ __host__ __forceinline void BrendanCUDA::Random::RandomizeArrayWMutations(Span<_
     }
 }
 #ifdef __CUDACC__
-template <std::integral _T, BrendanCUDA::KernelCurandState _TRNG>
-__device__ __forceinline void BrendanCUDA::Random::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, _TRNG& RNG) {
+template <std::integral _T, brendancuda::KernelCurandState _TRNG>
+__device__ __forceinline void brendancuda::Random::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         uint64_t* l64 = (uint64_t*)Array.ptr;
         uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
@@ -556,7 +556,7 @@ __device__ __forceinline void BrendanCUDA::Random::RandomizeArrayWMutations(Span
 }
 #endif
 template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void BrendanCUDA::Random::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::Random::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         if constexpr (_MemoryOnHost) {
             uint64_t* l64 = (uint64_t*)Array.ptr;
@@ -593,8 +593,8 @@ __host__ __forceinline void BrendanCUDA::Random::RandomizeArrayWMutations(Span<_
     }
 }
 #ifdef __CUDACC__
-template <std::integral _T, BrendanCUDA::KernelCurandState _TRNG>
-__device__ __forceinline void BrendanCUDA::Random::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, _TRNG& RNG) {
+template <std::integral _T, brendancuda::KernelCurandState _TRNG>
+__device__ __forceinline void brendancuda::Random::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         uint64_t* l64 = (uint64_t*)Array.ptr;
         uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
@@ -617,7 +617,7 @@ __device__ __forceinline void BrendanCUDA::Random::RandomizeArrayWMutations(Span
 
 template <bool _MemoryOnHost, typename _T, std::uniform_random_bit_generator _TRNG>
     requires std::is_arithmetic_v<_T>
-__host__ __forceinline void BrendanCUDA::Random::InitRandomArray(Span<_T> Array, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::Random::InitRandomArray(Span<_T> Array, _TRNG& RNG) {
     if constexpr (std::floating_point<_T>) {
         if constexpr (_MemoryOnHost) {
             std::uniform_real_distribution<_T> dis(-1., 1.);
@@ -661,9 +661,9 @@ __host__ __forceinline void BrendanCUDA::Random::InitRandomArray(Span<_T> Array,
     }
 }
 #ifdef __CUDACC__
-template <typename _T, BrendanCUDA::KernelCurandState _TRNG>
+template <typename _T, brendancuda::KernelCurandState _TRNG>
     requires std::is_arithmetic_v<_T>
-__device__ __forceinline void BrendanCUDA::Random::InitRandomArray(Span<_T> Array, _TRNG& RNG) {
+__device__ __forceinline void brendancuda::Random::InitRandomArray(Span<_T> Array, _TRNG& RNG) {
     if constexpr (std::same_as<_T, float>) {
         float* l = Array.ptr;
         float* u = Array.ptr + Array.size;
@@ -690,7 +690,7 @@ __device__ __forceinline void BrendanCUDA::Random::InitRandomArray(Span<_T> Arra
 
 #endif
 template <bool _MemoryOnHost, std::floating_point _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void BrendanCUDA::Random::InitRandomArray(Span<_T> Array, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::Random::InitRandomArray(Span<_T> Array, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     if constexpr (_MemoryOnHost) {
         std::uniform_real_distribution<_T> dis(LowerBound, UpperBound);
         _T* l = Array.ptr;
@@ -703,8 +703,8 @@ __host__ __forceinline void BrendanCUDA::Random::InitRandomArray(Span<_T> Array,
     }
 }
 #ifdef __CUDACC__
-template <std::floating_point _T, BrendanCUDA::KernelCurandState _TRNG>
-__device__ __forceinline void BrendanCUDA::Random::InitRandomArray(Span<_T> Array, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+template <std::floating_point _T, brendancuda::KernelCurandState _TRNG>
+__device__ __forceinline void brendancuda::Random::InitRandomArray(Span<_T> Array, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     if constexpr (std::same_as<_T, float>) {
         float range = UpperBound - LowerBound;
         float* l = Array.ptr;
@@ -721,7 +721,7 @@ __device__ __forceinline void BrendanCUDA::Random::InitRandomArray(Span<_T> Arra
 #endif
 
 template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void BrendanCUDA::Random::InitRandomArray(Span<_T> Array, uint32_t ProbabilityOf1, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::Random::InitRandomArray(Span<_T> Array, uint32_t ProbabilityOf1, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         if constexpr (_MemoryOnHost) {
             uint64_t* l64 = (uint64_t*)Array.ptr;
@@ -752,8 +752,8 @@ __host__ __forceinline void BrendanCUDA::Random::InitRandomArray(Span<_T> Array,
     }
 }
 #ifdef __CUDACC__
-template <std::integral _T, BrendanCUDA::KernelCurandState _TRNG>
-__device__ __forceinline void BrendanCUDA::Random::InitRandomArray(Span<_T> Array, uint32_t ProbabilityOf1, _TRNG& RNG) {
+template <std::integral _T, brendancuda::KernelCurandState _TRNG>
+__device__ __forceinline void brendancuda::Random::InitRandomArray(Span<_T> Array, uint32_t ProbabilityOf1, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         uint32_t* l32 = (uint32_t*)Array.ptr;
         uint32_t* u32 = ((uint32_t*)Array.ptr) + (Array.size >> 2);
@@ -773,7 +773,7 @@ __device__ __forceinline void BrendanCUDA::Random::InitRandomArray(Span<_T> Arra
 
 template <bool _MemoryOnHost, typename _T>
     requires std::is_arithmetic_v<_T>
-__host__ __forceinline void BrendanCUDA::Random::ClearArray(Span<_T> Array) {
+__host__ __forceinline void brendancuda::Random::ClearArray(Span<_T> Array) {
     if constexpr (std::floating_point<_T>) {
         if constexpr (_MemoryOnHost) {
             _T* l = Array.ptr;
@@ -813,7 +813,7 @@ __host__ __forceinline void BrendanCUDA::Random::ClearArray(Span<_T> Array) {
 #ifdef __CUDACC__
 template <typename _T>
     requires std::is_arithmetic_v<_T>
-__device__ __forceinline void BrendanCUDA::Random::ClearArray(Span<_T> Array) {
+__device__ __forceinline void brendancuda::Random::ClearArray(Span<_T> Array) {
     if constexpr (std::floating_point<_T>) {
         _T* l = Array.ptr;
         _T* u = Array.ptr + Array.size;

--- a/rand_randomizer.h
+++ b/rand_randomizer.h
@@ -32,7 +32,7 @@ namespace brendancuda {
         void ClearArray_CallKernel(Span<double> Array);
         void ClearArray_CallKernel(Span<uint64_t> Array);
     }
-    namespace Random {
+    namespace random {
         template <std::integral _T, std::uniform_random_bit_generator _TRNG>
         __host__ static __forceinline _T RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG);
 #ifdef __CUDACC__
@@ -166,19 +166,19 @@ __host__ __device__ __forceinline _T brendancuda::details::RandomizeWTargets_Get
 }
 
 template <std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline _T brendancuda::Random::RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
+__host__ __forceinline _T brendancuda::random::RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
     if constexpr (sizeof(_T) > 4) return Value ^ (_T)Get64Bits(FlipProbability, RNG);
     else return Value ^ (_T)Get32Bits(FlipProbability, RNG);
 }
 #ifdef __CUDACC__
 template <std::integral _T, brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline _T brendancuda::Random::RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
+__device__ __forceinline _T brendancuda::random::RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
     if constexpr (sizeof(_T) > 4) return Value ^ (_T)Get64Bits(FlipProbability, RNG);
     else return Value ^ (_T)Get32Bits(FlipProbability, RNG);
 }
 #endif
 template <std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline _T brendancuda::Random::RandomizeWTargets(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
+__host__ __forceinline _T brendancuda::random::RandomizeWTargets(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
     constexpr uint32_t shiftMask = (sizeof(_T) << 3) - 1;
 
     std::uniform_int_distribution<uint32_t> dis32(0);
@@ -205,7 +205,7 @@ __host__ __forceinline _T brendancuda::Random::RandomizeWTargets(_T Value, uint3
 }
 #ifdef __CUDACC__
 template <std::integral _T, brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline _T brendancuda::Random::RandomizeWTargets(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
+__device__ __forceinline _T brendancuda::random::RandomizeWTargets(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
     constexpr uint32_t shiftMask = (sizeof(_T) << 3) - 1;
 
     if (!Value) {
@@ -230,7 +230,7 @@ __device__ __forceinline _T brendancuda::Random::RandomizeWTargets(_T Value, uin
 }
 #endif
 template <std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline _T brendancuda::Random::RandomizeWMutations(_T Value, uint32_t MutationProbability, _TRNG& RNG) {
+__host__ __forceinline _T brendancuda::random::RandomizeWMutations(_T Value, uint32_t MutationProbability, _TRNG& RNG) {
     std::uniform_int_distribution<uint32_t> dis32(0);
     if (dis32(RNG) < MutationProbability) {
         if constexpr (sizeof(_T) == 4) return (_T)dis32(RNG);
@@ -247,7 +247,7 @@ __host__ __forceinline _T brendancuda::Random::RandomizeWMutations(_T Value, uin
 }
 #ifdef __CUDACC__
 template <std::integral _T, brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline _T brendancuda::Random::RandomizeWMutations(_T Value, uint32_t MutationProbability, _TRNG& RNG) {
+__device__ __forceinline _T brendancuda::random::RandomizeWMutations(_T Value, uint32_t MutationProbability, _TRNG& RNG) {
     if (curand(&RNG) < MutationProbability) {
         if constexpr (sizeof(_T) > 4) return (_T)(((uint64_t)curand(&RNG) << 32) | curand(&RNG));
         else return (_T)curand(&RNG);
@@ -256,7 +256,7 @@ __device__ __forceinline _T brendancuda::Random::RandomizeWMutations(_T Value, u
 }
 #endif
 template <std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline _T brendancuda::Random::RandomizeWMutations(_T Value, uint32_t MutationProbability, uint32_t ProbabilityOf1, _TRNG& RNG) {
+__host__ __forceinline _T brendancuda::random::RandomizeWMutations(_T Value, uint32_t MutationProbability, uint32_t ProbabilityOf1, _TRNG& RNG) {
     std::uniform_int_distribution<uint32_t> dis32(0);
     if (dis32(RNG) < MutationProbability) {
         if constexpr (sizeof(_T) > 4) return (_T)Get64Bits(ProbabilityOf1, RNG);
@@ -266,7 +266,7 @@ __host__ __forceinline _T brendancuda::Random::RandomizeWMutations(_T Value, uin
 }
 #ifdef __CUDACC__
 template <std::integral _T, brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline _T brendancuda::Random::RandomizeWMutations(_T Value, uint32_t MutationProbability, uint32_t ProbabilityOf1, _TRNG& RNG) {
+__device__ __forceinline _T brendancuda::random::RandomizeWMutations(_T Value, uint32_t MutationProbability, uint32_t ProbabilityOf1, _TRNG& RNG) {
     if (curand(&RNG) < MutationProbability) {
         if constexpr (sizeof(_T) > 4) return (_T)Get64Bits(ProbabilityOf1, RNG);
         else return (_T)Get32Bits(ProbabilityOf1, RNG);
@@ -275,48 +275,48 @@ __device__ __forceinline _T brendancuda::Random::RandomizeWMutations(_T Value, u
 }
 #endif
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline float brendancuda::Random::Randomize(float Value, float Scalar, _TRNG& RNG) {
+__host__ __forceinline float brendancuda::random::Randomize(float Value, float Scalar, _TRNG& RNG) {
     std::uniform_real_distribution<float> dis(-Scalar, Scalar);
     return Value + dis(RNG);
 }
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline double brendancuda::Random::Randomize(double Value, double Scalar, _TRNG& RNG) {
+__host__ __forceinline double brendancuda::random::Randomize(double Value, double Scalar, _TRNG& RNG) {
     std::uniform_real_distribution<double> dis(-Scalar, Scalar);
     return Value + dis(RNG);
 }
 #ifdef __CUDACC__
 template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline float brendancuda::Random::Randomize(float Value, float Scalar, _TRNG& RNG) {
+__device__ __forceinline float brendancuda::random::Randomize(float Value, float Scalar, _TRNG& RNG) {
     return Value + Scalar * 2.f * (curand_uniform(&RNG) - 0.5f);
 }
 template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline double brendancuda::Random::Randomize(double Value, double Scalar, _TRNG& RNG) {
+__device__ __forceinline double brendancuda::random::Randomize(double Value, double Scalar, _TRNG& RNG) {
     return Value + Scalar * 2. * (curand_uniform_double(&RNG) - 0.5);
 }
 #endif
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline float brendancuda::Random::Randomize(float Value, float Scalar, float LowerBound, float UpperBound, _TRNG& RNG) {
+__host__ __forceinline float brendancuda::random::Randomize(float Value, float Scalar, float LowerBound, float UpperBound, _TRNG& RNG) {
     std::uniform_real_distribution<float> dis(-Scalar, Scalar);
     return std::clamp(Value + dis(RNG), LowerBound, UpperBound);
 }
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline double brendancuda::Random::Randomize(double Value, double Scalar, double LowerBound, double UpperBound, _TRNG& RNG) {
+__host__ __forceinline double brendancuda::random::Randomize(double Value, double Scalar, double LowerBound, double UpperBound, _TRNG& RNG) {
     std::uniform_real_distribution<double> dis(-Scalar, Scalar);
     return std::clamp(Value + dis(RNG), LowerBound, UpperBound);
 }
 #ifdef __CUDACC__
 template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline float brendancuda::Random::Randomize(float Value, float Scalar, float LowerBound, float UpperBound, _TRNG& RNG) {
+__device__ __forceinline float brendancuda::random::Randomize(float Value, float Scalar, float LowerBound, float UpperBound, _TRNG& RNG) {
     return std::clamp(Value + Scalar * 2.f * (curand_uniform(&RNG) - 0.5f), LowerBound, UpperBound);
 }
 template <brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline double brendancuda::Random::Randomize(double Value, double Scalar, double LowerBound, double UpperBound, _TRNG& RNG) {
+__device__ __forceinline double brendancuda::random::Randomize(double Value, double Scalar, double LowerBound, double UpperBound, _TRNG& RNG) {
     return std::clamp(Value + Scalar * 2. * (curand_uniform_double(&RNG) - 0.5), LowerBound, UpperBound);
 }
 #endif
 
 template <bool _MemoryOnHost, std::floating_point _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::Random::RandomizeArray(Span<_T> Array, _T Scalar, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::random::RandomizeArray(Span<_T> Array, _T Scalar, _TRNG& RNG) {
     if constexpr (_MemoryOnHost) {
         Scalar *= 2.f;
         std::uniform_real_distribution<_T> dis(-Scalar, Scalar);
@@ -331,7 +331,7 @@ __host__ __forceinline void brendancuda::Random::RandomizeArray(Span<_T> Array, 
 }
 #ifdef __CUDACC__
 template <std::floating_point _T, brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::Random::RandomizeArray(Span<_T> Array, _T Scalar, _TRNG& RNG) {
+__device__ __forceinline void brendancuda::random::RandomizeArray(Span<_T> Array, _T Scalar, _TRNG& RNG) {
     if constexpr (std::same_as<_T, float>) {
         Scalar *= 2.f;
         float* l = Array.ptr;
@@ -347,7 +347,7 @@ __device__ __forceinline void brendancuda::Random::RandomizeArray(Span<_T> Array
 }
 #endif
 template <bool _MemoryOnHost, std::floating_point _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::Random::RandomizeArray(Span<_T> Array, _T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::random::RandomizeArray(Span<_T> Array, _T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     if constexpr (_MemoryOnHost) {
         Scalar *= 2.f;
         std::uniform_real_distribution<_T> dis(-Scalar, Scalar);
@@ -362,7 +362,7 @@ __host__ __forceinline void brendancuda::Random::RandomizeArray(Span<_T> Array, 
 }
 #ifdef __CUDACC__
 template <std::floating_point _T, brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::Random::RandomizeArray(Span<_T> Array, _T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__device__ __forceinline void brendancuda::random::RandomizeArray(Span<_T> Array, _T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     if constexpr (std::same_as<_T, float>) {
         Scalar *= 2.f;
         float* l = Array.ptr;
@@ -379,7 +379,7 @@ __device__ __forceinline void brendancuda::Random::RandomizeArray(Span<_T> Array
 #endif
 
 template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::Random::RandomizeArrayWFlips(Span<_T> Array, uint32_t FlipProb, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::random::RandomizeArrayWFlips(Span<_T> Array, uint32_t FlipProb, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         if constexpr (_MemoryOnHost) {
             uint64_t* l64 = (uint64_t*)Array.ptr;
@@ -417,7 +417,7 @@ __host__ __forceinline void brendancuda::Random::RandomizeArrayWFlips(Span<_T> A
 }
 #ifdef __CUDACC__
 template <std::integral _T, brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::Random::RandomizeArrayWFlips(Span<_T> Array, uint32_t FlipProb, _TRNG& RNG) {
+__device__ __forceinline void brendancuda::random::RandomizeArrayWFlips(Span<_T> Array, uint32_t FlipProb, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         uint64_t* l64 = (uint64_t*)Array.ptr;
         uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
@@ -438,7 +438,7 @@ __device__ __forceinline void brendancuda::Random::RandomizeArrayWFlips(Span<_T>
 }
 #endif
 template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::Random::RandomizeArrayWTargets(Span<_T> Array, uint32_t EachFlipProb, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::random::RandomizeArrayWTargets(Span<_T> Array, uint32_t EachFlipProb, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         if constexpr (_MemoryOnHost) {
             uint64_t* l64 = (uint64_t*)Array.ptr;
@@ -476,7 +476,7 @@ __host__ __forceinline void brendancuda::Random::RandomizeArrayWTargets(Span<_T>
 }
 #ifdef __CUDACC__
 template <std::integral _T, brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::Random::RandomizeArrayWTargets(Span<_T> Array, uint32_t EachFlipProb, _TRNG& RNG) {
+__device__ __forceinline void brendancuda::random::RandomizeArrayWTargets(Span<_T> Array, uint32_t EachFlipProb, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         uint64_t* l64 = (uint64_t*)Array.ptr;
         uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
@@ -497,7 +497,7 @@ __device__ __forceinline void brendancuda::Random::RandomizeArrayWTargets(Span<_
 }
 #endif
 template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::Random::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::random::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         if constexpr (_MemoryOnHost) {
             uint64_t* l64 = (uint64_t*)Array.ptr;
@@ -535,7 +535,7 @@ __host__ __forceinline void brendancuda::Random::RandomizeArrayWMutations(Span<_
 }
 #ifdef __CUDACC__
 template <std::integral _T, brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::Random::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, _TRNG& RNG) {
+__device__ __forceinline void brendancuda::random::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         uint64_t* l64 = (uint64_t*)Array.ptr;
         uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
@@ -556,7 +556,7 @@ __device__ __forceinline void brendancuda::Random::RandomizeArrayWMutations(Span
 }
 #endif
 template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::Random::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::random::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         if constexpr (_MemoryOnHost) {
             uint64_t* l64 = (uint64_t*)Array.ptr;
@@ -594,7 +594,7 @@ __host__ __forceinline void brendancuda::Random::RandomizeArrayWMutations(Span<_
 }
 #ifdef __CUDACC__
 template <std::integral _T, brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::Random::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, _TRNG& RNG) {
+__device__ __forceinline void brendancuda::random::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         uint64_t* l64 = (uint64_t*)Array.ptr;
         uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
@@ -617,7 +617,7 @@ __device__ __forceinline void brendancuda::Random::RandomizeArrayWMutations(Span
 
 template <bool _MemoryOnHost, typename _T, std::uniform_random_bit_generator _TRNG>
     requires std::is_arithmetic_v<_T>
-__host__ __forceinline void brendancuda::Random::InitRandomArray(Span<_T> Array, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::random::InitRandomArray(Span<_T> Array, _TRNG& RNG) {
     if constexpr (std::floating_point<_T>) {
         if constexpr (_MemoryOnHost) {
             std::uniform_real_distribution<_T> dis(-1., 1.);
@@ -663,7 +663,7 @@ __host__ __forceinline void brendancuda::Random::InitRandomArray(Span<_T> Array,
 #ifdef __CUDACC__
 template <typename _T, brendancuda::KernelCurandState _TRNG>
     requires std::is_arithmetic_v<_T>
-__device__ __forceinline void brendancuda::Random::InitRandomArray(Span<_T> Array, _TRNG& RNG) {
+__device__ __forceinline void brendancuda::random::InitRandomArray(Span<_T> Array, _TRNG& RNG) {
     if constexpr (std::same_as<_T, float>) {
         float* l = Array.ptr;
         float* u = Array.ptr + Array.size;
@@ -690,7 +690,7 @@ __device__ __forceinline void brendancuda::Random::InitRandomArray(Span<_T> Arra
 
 #endif
 template <bool _MemoryOnHost, std::floating_point _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::Random::InitRandomArray(Span<_T> Array, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::random::InitRandomArray(Span<_T> Array, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     if constexpr (_MemoryOnHost) {
         std::uniform_real_distribution<_T> dis(LowerBound, UpperBound);
         _T* l = Array.ptr;
@@ -704,7 +704,7 @@ __host__ __forceinline void brendancuda::Random::InitRandomArray(Span<_T> Array,
 }
 #ifdef __CUDACC__
 template <std::floating_point _T, brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::Random::InitRandomArray(Span<_T> Array, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__device__ __forceinline void brendancuda::random::InitRandomArray(Span<_T> Array, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     if constexpr (std::same_as<_T, float>) {
         float range = UpperBound - LowerBound;
         float* l = Array.ptr;
@@ -721,7 +721,7 @@ __device__ __forceinline void brendancuda::Random::InitRandomArray(Span<_T> Arra
 #endif
 
 template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void brendancuda::Random::InitRandomArray(Span<_T> Array, uint32_t ProbabilityOf1, _TRNG& RNG) {
+__host__ __forceinline void brendancuda::random::InitRandomArray(Span<_T> Array, uint32_t ProbabilityOf1, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         if constexpr (_MemoryOnHost) {
             uint64_t* l64 = (uint64_t*)Array.ptr;
@@ -753,7 +753,7 @@ __host__ __forceinline void brendancuda::Random::InitRandomArray(Span<_T> Array,
 }
 #ifdef __CUDACC__
 template <std::integral _T, brendancuda::KernelCurandState _TRNG>
-__device__ __forceinline void brendancuda::Random::InitRandomArray(Span<_T> Array, uint32_t ProbabilityOf1, _TRNG& RNG) {
+__device__ __forceinline void brendancuda::random::InitRandomArray(Span<_T> Array, uint32_t ProbabilityOf1, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         uint32_t* l32 = (uint32_t*)Array.ptr;
         uint32_t* u32 = ((uint32_t*)Array.ptr) + (Array.size >> 2);
@@ -773,7 +773,7 @@ __device__ __forceinline void brendancuda::Random::InitRandomArray(Span<_T> Arra
 
 template <bool _MemoryOnHost, typename _T>
     requires std::is_arithmetic_v<_T>
-__host__ __forceinline void brendancuda::Random::ClearArray(Span<_T> Array) {
+__host__ __forceinline void brendancuda::random::ClearArray(Span<_T> Array) {
     if constexpr (std::floating_point<_T>) {
         if constexpr (_MemoryOnHost) {
             _T* l = Array.ptr;
@@ -813,7 +813,7 @@ __host__ __forceinline void brendancuda::Random::ClearArray(Span<_T> Array) {
 #ifdef __CUDACC__
 template <typename _T>
     requires std::is_arithmetic_v<_T>
-__device__ __forceinline void brendancuda::Random::ClearArray(Span<_T> Array) {
+__device__ __forceinline void brendancuda::random::ClearArray(Span<_T> Array) {
     if constexpr (std::floating_point<_T>) {
         _T* l = Array.ptr;
         _T* u = Array.ptr + Array.size;

--- a/threadid.h
+++ b/threadid.h
@@ -4,7 +4,7 @@
 #include "cuda_runtime.h"
 #include "device_launch_parameters.h"
 
-namespace BrendanCUDA {
+namespace brendancuda {
 #ifdef __CUDACC__
     __device__ __forceinline uint64_t GetThreadID1();
     __device__ __forceinline uint64_t GetThreadID2();
@@ -13,13 +13,13 @@ namespace BrendanCUDA {
 }
 
 #ifdef __CUDACC__
-__device__ __forceinline uint64_t BrendanCUDA::GetThreadID1() {
+__device__ __forceinline uint64_t brendancuda::GetThreadID1() {
     uint64_t t = 0;
     t = t * gridDim.x + blockIdx.x;
     t = t * blockDim.x + threadIdx.x;
     return t;
 }
-__device__ __forceinline uint64_t BrendanCUDA::GetThreadID2() {
+__device__ __forceinline uint64_t brendancuda::GetThreadID2() {
     uint64_t t = 0;
     t = t * gridDim.y + blockIdx.y;
     t = t * blockDim.y + threadIdx.y;
@@ -27,7 +27,7 @@ __device__ __forceinline uint64_t BrendanCUDA::GetThreadID2() {
     t = t * blockDim.x + threadIdx.x;
     return t;
 }
-__device__ __forceinline uint64_t BrendanCUDA::GetThreadID3() {
+__device__ __forceinline uint64_t brendancuda::GetThreadID3() {
     uint64_t t = 0;
     t = t * gridDim.z + blockIdx.z;
     t = t * blockDim.z + threadIdx.z;

--- a/threadid.h
+++ b/threadid.h
@@ -4,7 +4,7 @@
 #include "cuda_runtime.h"
 #include "device_launch_parameters.h"
 
-namespace brendancuda {
+namespace bcuda {
 #ifdef __CUDACC__
     __device__ __forceinline uint64_t GetThreadID1();
     __device__ __forceinline uint64_t GetThreadID2();
@@ -13,13 +13,13 @@ namespace brendancuda {
 }
 
 #ifdef __CUDACC__
-__device__ __forceinline uint64_t brendancuda::GetThreadID1() {
+__device__ __forceinline uint64_t bcuda::GetThreadID1() {
     uint64_t t = 0;
     t = t * gridDim.x + blockIdx.x;
     t = t * blockDim.x + threadIdx.x;
     return t;
 }
-__device__ __forceinline uint64_t brendancuda::GetThreadID2() {
+__device__ __forceinline uint64_t bcuda::GetThreadID2() {
     uint64_t t = 0;
     t = t * gridDim.y + blockIdx.y;
     t = t * blockDim.y + threadIdx.y;
@@ -27,7 +27,7 @@ __device__ __forceinline uint64_t brendancuda::GetThreadID2() {
     t = t * blockDim.x + threadIdx.x;
     return t;
 }
-__device__ __forceinline uint64_t brendancuda::GetThreadID3() {
+__device__ __forceinline uint64_t bcuda::GetThreadID3() {
     uint64_t t = 0;
     t = t * gridDim.z + blockIdx.z;
     t = t * blockDim.z + threadIdx.z;


### PR DESCRIPTION
Making namespace names lowercase and, in some cases, shorter. These have been the changes thus far:

* `BrendanCUDA` -> `bcuda`
* `BrendanCUDA::AI` -> `bcuda::ai`
* `BrendanCUDA::AI::Evolution` -> `bcuda::ai::evol`
* `BrendanCUDA::AI::Evolution::Evaluation` -> `bcuda::ai::evol::eval`
* `BrendanCUDA::AI::Evolution::Evaluation::Output` -> `bcuda::ai::evol::eval::output`
* `BrendanCUDA::AI::Genetics` -> `bcuda::ai::genes`
* `BrendanCUDA::AI::MLP` -> `bcuda::ai::mlp`
* `BrendanCUDA::AI::MLPB` -> `bcuda::ai::mlpb`
* `BrendanCUDA::Binary` -> `bcuda::binary`
* `BrendanCUDA::Exprs` -> `bcuda::exprs`
* `BrendanCUDA::Fields` -> `bcuda::fields`
* `BrendanCUDA::Math` -> `bcuda::math`
* `BrendanCUDA::Nets` -> `bcuda::nets`
* `BrendanCUDA::Packs` -> `bcuda::packs`
* `BrendanCUDA::Random` -> `bcuda::rand`