### PR TITLE
Renaming namespace `bcuda::random` to `rand`

### DIFF
--- a/ai_evol_eval_output_impl_proliferation.h
+++ b/ai_evol_eval_output_impl_proliferation.h
@@ -17,8 +17,8 @@ namespace bcuda {
                         size_t outputCount;
                         _T mask;
                         void* sd_ci;
-                        bcuda::random::AnyRNG<uint64_t> rng;
-                        __forceinline Evaluate_Proliferation_SD(bcuda::random::AnyRNG<uint64_t> RNG);
+                        bcuda::rand::AnyRNG<uint64_t> rng;
+                        __forceinline Evaluate_Proliferation_SD(bcuda::rand::AnyRNG<uint64_t> RNG);
                     };
                     template <>
                     struct Evaluate_Proliferation_SD<float> final {
@@ -28,8 +28,8 @@ namespace bcuda {
                         size_t inputCount;
                         size_t outputCount;
                         void* sd_ci;
-                        bcuda::random::AnyRNG<uint64_t> rng;
-                        __forceinline Evaluate_Proliferation_SD(bcuda::random::AnyRNG<uint64_t> RNG);
+                        bcuda::rand::AnyRNG<uint64_t> rng;
+                        __forceinline Evaluate_Proliferation_SD(bcuda::rand::AnyRNG<uint64_t> RNG);
                     };
                     template <>
                     struct Evaluate_Proliferation_SD<double> final {
@@ -39,8 +39,8 @@ namespace bcuda {
                         size_t inputCount;
                         size_t outputCount;
                         void* sd_ci;
-                        bcuda::random::AnyRNG<uint64_t> rng;
-                        __forceinline Evaluate_Proliferation_SD(bcuda::random::AnyRNG<uint64_t> RNG);
+                        bcuda::rand::AnyRNG<uint64_t> rng;
+                        __forceinline Evaluate_Proliferation_SD(bcuda::rand::AnyRNG<uint64_t> RNG);
                     };
 
                     template <typename _T>
@@ -54,7 +54,7 @@ namespace bcuda {
 }
 
 template <typename _T>
-__forceinline bcuda::ai::evol::eval::output::Evaluate_Proliferation_SD<_T>::Evaluate_Proliferation_SD(bcuda::random::AnyRNG<uint64_t> RNG)
+__forceinline bcuda::ai::evol::eval::output::Evaluate_Proliferation_SD<_T>::Evaluate_Proliferation_SD(bcuda::rand::AnyRNG<uint64_t> RNG)
     : rng(RNG),
     instanceFunctions() {
     iterationsPerRound = 0;
@@ -64,7 +64,7 @@ __forceinline bcuda::ai::evol::eval::output::Evaluate_Proliferation_SD<_T>::Eval
     mask = 0;
     sd_ci = 0;
 }
-__forceinline bcuda::ai::evol::eval::output::Evaluate_Proliferation_SD<float>::Evaluate_Proliferation_SD(bcuda::random::AnyRNG<uint64_t> RNG)
+__forceinline bcuda::ai::evol::eval::output::Evaluate_Proliferation_SD<float>::Evaluate_Proliferation_SD(bcuda::rand::AnyRNG<uint64_t> RNG)
     : rng(RNG),
     instanceFunctions() {
     iterationsPerRound = 0;
@@ -73,7 +73,7 @@ __forceinline bcuda::ai::evol::eval::output::Evaluate_Proliferation_SD<float>::E
     outputCount = 0;
     sd_ci = 0;
 }
-__forceinline bcuda::ai::evol::eval::output::Evaluate_Proliferation_SD<double>::Evaluate_Proliferation_SD(bcuda::random::AnyRNG<uint64_t> RNG)
+__forceinline bcuda::ai::evol::eval::output::Evaluate_Proliferation_SD<double>::Evaluate_Proliferation_SD(bcuda::rand::AnyRNG<uint64_t> RNG)
     : rng(RNG),
     instanceFunctions() {
     iterationsPerRound = 0;

--- a/ai_genetics_genefixedmlp.h
+++ b/ai_genetics_genefixedmlp.h
@@ -84,25 +84,25 @@ void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Outpu
 template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
 void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _TRNG& RNG) {
-    random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, RNG);
+    rand::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, RNG);
     mlp.Randomize(Scalar, RNG);
 }
 template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
 void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
-    random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, LowerBound, UpperBound, RNG);
+    rand::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, LowerBound, UpperBound, RNG);
     mlp.Randomize(Scalar, LowerBound, UpperBound, RNG);
 }
 template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
 void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
-    random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, RNG);
+    rand::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, RNG);
     mlp.Randomize(Scalar_MLP, RNG);
 }
 template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
 void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
-    random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, LowerBound, UpperBound, RNG);
+    rand::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, LowerBound, UpperBound, RNG);
     mlp.Randomize(Scalar_MLP, LowerBound, UpperBound, RNG);
 }
 template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
@@ -136,25 +136,25 @@ bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Cou
 template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <bcuda::KernelCurandState _TRNG>
 __device__ void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _TRNG& RNG) {
-    random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, RNG);
+    rand::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, RNG);
     mlp.Randomize(Scalar, RNG);
 }
 template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <bcuda::KernelCurandState _TRNG>
 __device__ void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
-    random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, LowerBound, UpperBound, RNG);
+    rand::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, LowerBound, UpperBound, RNG);
     mlp.Randomize(Scalar, LowerBound, UpperBound, RNG);
 }
 template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <bcuda::KernelCurandState _TRNG>
 __device__ void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
-    random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, RNG);
+    rand::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, RNG);
     mlp.Randomize(Scalar_MLP, RNG);
 }
 template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <bcuda::KernelCurandState _TRNG>
 __device__ void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
-    random::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, LowerBound, UpperBound, RNG);
+    rand::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, LowerBound, UpperBound, RNG);
     mlp.Randomize(Scalar_MLP, LowerBound, UpperBound, RNG);
 }
 template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
@@ -187,30 +187,30 @@ __device__ bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, 
 }
 template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::ZeroOverwrite() {
-    random::ClearArray<false, _T>(Span<_T>(base, mlp.InputLength()));
+    rand::ClearArray<false, _T>(Span<_T>(base, mlp.InputLength()));
     mlp.ZeroOverwrite();
 }
 template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
 void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_TRNG& RNG) {
-    random::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), RNG);
+    rand::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), RNG);
     mlp.RandomOverwrite(RNG);
 }
 template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <std::uniform_random_bit_generator _TRNG>
 void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_T LowerBound, _T UpperBound, _TRNG& RNG) {
-    random::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), LowerBound, UpperBound, RNG);
+    rand::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), LowerBound, UpperBound, RNG);
     mlp.RandomOverwrite(LowerBound, UpperBound, RNG);
 }
 template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <bcuda::KernelCurandState _TRNG>
 __device__ void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_TRNG& RNG) {
-    random::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), RNG);
+    rand::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), RNG);
     mlp.RandomOverwrite(RNG);
 }
 template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
 template <bcuda::KernelCurandState _TRNG>
 __device__ void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_T LowerBound, _T UpperBound, _TRNG& RNG) {
-    random::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), LowerBound, UpperBound, RNG);
+    rand::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), LowerBound, UpperBound, RNG);
     mlp.RandomOverwrite(LowerBound, UpperBound, RNG);
 }

--- a/ai_mlp_fixedmlp.h
+++ b/ai_mlp_fixedmlp.h
@@ -798,48 +798,48 @@ template <bcuda::ai::mlp::IsFixedMLPL _TFixedMLPL>
 void bcuda::ai::mlp::FixedMLPL_FillWith0(_TFixedMLPL* MLPL) {
     using element_t = typename _TFixedMLPL::element_t;
 
-    random::ClearArray<false, element_t>(FixedMLPL_GetElementSpan(MLPL));
+    rand::ClearArray<false, element_t>(FixedMLPL_GetElementSpan(MLPL));
 }
 template <bcuda::ai::mlp::IsFixedMLPL _TFixedMLPL, std::uniform_random_bit_generator _TRNG>
 void bcuda::ai::mlp::FixedMLPL_FillWithRandom(_TFixedMLPL* MLPL, _TRNG& RNG) {
     using element_t = typename _TFixedMLPL::element_t;
 
-    random::InitRandomArray<false, element_t, _TRNG>(FixedMLPL_GetElementSpan(MLPL), RNG);
+    rand::InitRandomArray<false, element_t, _TRNG>(FixedMLPL_GetElementSpan(MLPL), RNG);
 }
 template <bcuda::ai::mlp::IsFixedMLPL _TFixedMLPL, std::uniform_random_bit_generator _TRNG>
 void bcuda::ai::mlp::FixedMLPL_ChangeWithRandom(_TFixedMLPL* MLPL, typename _TFixedMLPL::element_t Scalar, _TRNG& RNG) {
     using element_t = typename _TFixedMLPL::element_t;
 
-    random::RandomizeArray<false, element_t, _TRNG>(FixedMLPL_GetElementSpan(MLPL), Scalar, RNG);
+    rand::RandomizeArray<false, element_t, _TRNG>(FixedMLPL_GetElementSpan(MLPL), Scalar, RNG);
 }
 template <bcuda::ai::mlp::IsFixedMLPL _TFixedMLPL, std::uniform_random_bit_generator _TRNG>
 void bcuda::ai::mlp::FixedMLPL_ChangeWithRandom(_TFixedMLPL* MLPL, typename _TFixedMLPL::element_t Scalar, typename _TFixedMLPL::element_t LowerBound, typename _TFixedMLPL::element_t UpperBound, _TRNG& RNG) {
     using element_t = typename _TFixedMLPL::element_t;
 
-    random::RandomizeArray<false, element_t, _TRNG>(FixedMLPL_GetElementSpan(MLPL), Scalar, LowerBound, UpperBound, RNG);
+    rand::RandomizeArray<false, element_t, _TRNG>(FixedMLPL_GetElementSpan(MLPL), Scalar, LowerBound, UpperBound, RNG);
 }
 
 template <bcuda::ai::mlp::IsFixedMLP _TFixedMLP>
 void bcuda::ai::mlp::FixedMLP_FillWith0(_TFixedMLP* MLP) {
     using element_t = typename _TFixedMLP::element_t;
 
-    random::ClearArray<false, element_t>(FixedMLP_GetElementSpan(MLP));
+    rand::ClearArray<false, element_t>(FixedMLP_GetElementSpan(MLP));
 }
 template <bcuda::ai::mlp::IsFixedMLP _TFixedMLP, std::uniform_random_bit_generator _TRNG>
 void bcuda::ai::mlp::FixedMLP_FillWithRandom(_TFixedMLP* MLP, _TRNG& RNG) {
     using element_t = typename _TFixedMLP::element_t;
 
-    random::InitRandomArray<false, element_t, _TRNG>(FixedMLP_GetElementSpan(MLP), RNG);
+    rand::InitRandomArray<false, element_t, _TRNG>(FixedMLP_GetElementSpan(MLP), RNG);
 }
 template <bcuda::ai::mlp::IsFixedMLP _TFixedMLP, std::uniform_random_bit_generator _TRNG>
 void bcuda::ai::mlp::FixedMLP_ChangeWithRandom(_TFixedMLP* MLP, typename _TFixedMLP::element_t Scalar, _TRNG& RNG) {
     using element_t = typename _TFixedMLP::element_t;
 
-    random::RandomizeArray<false, element_t, _TRNG>(FixedMLP_GetElementSpan(MLP), Scalar, RNG);
+    rand::RandomizeArray<false, element_t, _TRNG>(FixedMLP_GetElementSpan(MLP), Scalar, RNG);
 }
 template <bcuda::ai::mlp::IsFixedMLP _TFixedMLP, std::uniform_random_bit_generator _TRNG>
 void bcuda::ai::mlp::FixedMLP_ChangeWithRandom(_TFixedMLP* MLP, typename _TFixedMLP::element_t Scalar, typename _TFixedMLP::element_t LowerBound, typename _TFixedMLP::element_t UpperBound, _TRNG& RNG) {
     using element_t = typename _TFixedMLP::element_t;
 
-    random::RandomizeArray<false, element_t, _TRNG>(FixedMLP_GetElementSpan(MLP), Scalar, LowerBound, UpperBound, RNG);
+    rand::RandomizeArray<false, element_t, _TRNG>(FixedMLP_GetElementSpan(MLP), Scalar, LowerBound, UpperBound, RNG);
 }

--- a/ai_mlpb_fixedmlpb.h
+++ b/ai_mlpb_fixedmlpb.h
@@ -223,8 +223,8 @@ template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <std::uniform_random_bit_generator _TRNG>
 __host__ __forceinline void bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
-        weights[i] = bcuda::random::RandomizeWFlips(weights[i], WeightsFlipProb, RNG);
-    bias = bcuda::random::RandomizeWFlips(bias, BiasFlipProb, RNG);
+        weights[i] = bcuda::rand::RandomizeWFlips(weights[i], WeightsFlipProb, RNG);
+    bias = bcuda::rand::RandomizeWFlips(bias, BiasFlipProb, RNG);
 }
 
 #ifdef __CUDACC__
@@ -232,8 +232,8 @@ template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <bcuda::KernelCurandState _TRNG>
 __device__ __forceinline void bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
-        weights[i] = bcuda::random::RandomizeWFlips(weights[i], WeightsFlipProb, RNG);
-    bias = bcuda::random::RandomizeWFlips(bias, BiasFlipProb, RNG);
+        weights[i] = bcuda::rand::RandomizeWFlips(weights[i], WeightsFlipProb, RNG);
+    bias = bcuda::rand::RandomizeWFlips(bias, BiasFlipProb, RNG);
 }
 #endif
 
@@ -241,8 +241,8 @@ template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <std::uniform_random_bit_generator _TRNG>
 __host__ __forceinline void bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
-        weights[i] = bcuda::random::RandomizeWTargets(weights[i], WeightsFlipProb, RNG);
-    bias = bcuda::random::RandomizeWTargets(bias, BiasFlipProb, RNG);
+        weights[i] = bcuda::rand::RandomizeWTargets(weights[i], WeightsFlipProb, RNG);
+    bias = bcuda::rand::RandomizeWTargets(bias, BiasFlipProb, RNG);
 }
 
 #ifdef __CUDACC__
@@ -250,8 +250,8 @@ template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <bcuda::KernelCurandState _TRNG>
 __device__ __forceinline void bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
-        weights[i] = bcuda::random::RandomizeWTargets(weights[i], WeightsFlipProb, RNG);
-    bias = bcuda::random::RandomizeWTargets(bias, BiasFlipProb, RNG);
+        weights[i] = bcuda::rand::RandomizeWTargets(weights[i], WeightsFlipProb, RNG);
+    bias = bcuda::rand::RandomizeWTargets(bias, BiasFlipProb, RNG);
 }
 #endif
 
@@ -259,8 +259,8 @@ template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <std::uniform_random_bit_generator _TRNG>
 __host__ __forceinline void bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
-        weights[i] = bcuda::random::RandomizeWMutations(weights[i], WeightsProbOf1, RNG);
-    bias = bcuda::random::RandomizeWMutations(bias, BiasProbOf1, RNG);
+        weights[i] = bcuda::rand::RandomizeWMutations(weights[i], WeightsProbOf1, RNG);
+    bias = bcuda::rand::RandomizeWMutations(bias, BiasProbOf1, RNG);
 }
 
 #ifdef __CUDACC__
@@ -268,8 +268,8 @@ template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
 template <bcuda::KernelCurandState _TRNG>
 __device__ __forceinline void bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
     for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
-        weights[i] = bcuda::random::RandomizeWMutations(weights[i], WeightsProbOf1, RNG);
-    bias = bcuda::random::RandomizeWMutations(bias, BiasProbOf1, RNG);
+        weights[i] = bcuda::rand::RandomizeWMutations(weights[i], WeightsProbOf1, RNG);
+    bias = bcuda::rand::RandomizeWMutations(bias, BiasProbOf1, RNG);
 }
 #endif
 

--- a/fields_instance.h
+++ b/fields_instance.h
@@ -14,7 +14,7 @@ namespace bcuda {
             ArrayV<size_t> outputs;
             void* obj;
             void* objectRunner_sharedData;
-            random::AnyRNG<uint32_t> rng;
+            rand::AnyRNG<uint32_t> rng;
         };
     }
     namespace fields {
@@ -23,7 +23,7 @@ namespace bcuda {
         template <typename _T, size_t _DimensionCount>
         using fieldInstance_createField_t = DField<_T, _DimensionCount>*(*)(void* SharedData);
         struct FieldInstance_Construct_Settings final {
-            random::AnyRNG<uint32_t> rng;
+            rand::AnyRNG<uint32_t> rng;
             void* objectRunner_sharedData;
             void* createField_sharedData;
             size_t inputCount;
@@ -54,7 +54,7 @@ namespace bcuda {
 template <typename _T, size_t _DimensionCount, bcuda::fields::fieldInstance_createField_t<_T, _DimensionCount> _CreateField>
 void* bcuda::fields::FieldInstance_Construct(void* Object, void* Settings) {
     FieldInstance_Construct_Settings settings = *(FieldInstance_Construct_Settings*)Settings;
-    random::AnyRNG<uint32_t>& rng = settings.rng;
+    rand::AnyRNG<uint32_t>& rng = settings.rng;
 
     details::FieldInstance_CurrentInstance<_T, _DimensionCount>* p_rv = new details::FieldInstance_CurrentInstance<_T, _DimensionCount>{ _CreateField(settings.createField_sharedData), ArrayV<uint32_3>(settings.inputCount), ArrayV<uint32_3>(settings.outputCount), Object, settings.objectRunner_sharedData, rng };
     details::FieldInstance_CurrentInstance<_T, _DimensionCount>& rv = *p_rv;

--- a/nets_makenet.cu
+++ b/nets_makenet.cu
@@ -189,10 +189,10 @@ __global__ void disposeOfBuckets(BucketTS* buckets) {
     delete[] buckets[blockIdx.x].data;
 }
 
-bcuda::nets::Net bcuda::nets::MakeNet_3D(size_t NodeCount, float ConnectionRange, random::AnyRNG<uint64_t> RNG, thrust::device_vector<float_3>** NodePoints) {
+bcuda::nets::Net bcuda::nets::MakeNet_3D(size_t NodeCount, float ConnectionRange, rand::AnyRNG<uint64_t> RNG, thrust::device_vector<float_3>** NodePoints) {
     thrust::device_vector<float_3>* dv = new thrust::device_vector<float_3>(NodeCount);
 
-    random::InitRandomArray<false, float, random::AnyRNG<uint64_t>>(Span<float>((float*)(dv->data().get()), NodeCount * 3), RNG);
+    rand::InitRandomArray<false, float, rand::AnyRNG<uint64_t>>(Span<float>((float*)(dv->data().get()), NodeCount * 3), RNG);
 
     constexpr size_t bucketCountPerD = 10;
 

--- a/nets_makenet.h
+++ b/nets_makenet.h
@@ -7,6 +7,6 @@
 namespace bcuda {
     namespace nets {
         //Creates a bcuda::nets::Net by creating NodeCount points in a rectangular prism such that all coordinates are in the range of [0, 1], and then connecting up the nodes cooresponding to any points within a distance of ConnectionRange from each other. If NodePoints is non-null, the value it points to will be assigned the vector of points -- otherwise, the vector of points will be disposed of.
-        Net MakeNet_3D(size_t NodeCount, float ConnectionRange, bcuda::random::AnyRNG<uint64_t> RNG, thrust::device_vector<float_3>** NodePoints);
+        Net MakeNet_3D(size_t NodeCount, float ConnectionRange, bcuda::rand::AnyRNG<uint64_t> RNG, thrust::device_vector<float_3>** NodePoints);
     }
 }

--- a/rand_anyrng.h
+++ b/rand_anyrng.h
@@ -15,7 +15,7 @@ namespace bcuda {
         template <typename _TOutputType>
         using runRNGFunc_t = _TOutputType(*)(void*);
     }
-    namespace random {
+    namespace rand {
         template <std::unsigned_integral _TOutputType>
         class AnyRNG {
         public:

--- a/rand_bits.h
+++ b/rand_bits.h
@@ -8,7 +8,7 @@
 #include <curand_kernel.h>
 
 namespace bcuda {
-    namespace random {
+    namespace rand {
         template <std::uniform_random_bit_generator _TRNG>
         __host__ __forceinline uint32_t Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG);
         template <std::uniform_random_bit_generator _TRNG>
@@ -23,7 +23,7 @@ namespace bcuda {
 }
 
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline uint32_t bcuda::random::Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
+__host__ __forceinline uint32_t bcuda::rand::Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
     uint32_t ct = bcuda::binary::CountBitsB(ProbabilityOf1);
     if (!ct) {
         return 0;
@@ -42,7 +42,7 @@ __host__ __forceinline uint32_t bcuda::random::Get32Bits(uint32_t ProbabilityOf1
     return cr;
 }
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline uint64_t bcuda::random::Get64Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
+__host__ __forceinline uint64_t bcuda::rand::Get64Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
     uint32_t ct = bcuda::binary::CountBitsB(ProbabilityOf1);
     if (!ct) {
         return 0;
@@ -62,7 +62,7 @@ __host__ __forceinline uint64_t bcuda::random::Get64Bits(uint32_t ProbabilityOf1
 }
 #ifdef __CUDACC__
 template <bcuda::KernelCurandState _TRNG>
-__device__ __forceinline uint32_t bcuda::random::Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
+__device__ __forceinline uint32_t bcuda::rand::Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
     uint32_t ct = bcuda::binary::CountBitsB(ProbabilityOf1);
     if (!ct) {
         return 0;
@@ -80,7 +80,7 @@ __device__ __forceinline uint32_t bcuda::random::Get32Bits(uint32_t ProbabilityO
     return cr;
 }
 template <bcuda::KernelCurandState _TRNG>
-__device__ __forceinline uint64_t bcuda::random::Get64Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
+__device__ __forceinline uint64_t bcuda::rand::Get64Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
     uint32_t ct = bcuda::binary::CountBitsB(ProbabilityOf1);
     if (!ct) {
         return 0;

--- a/rand_randomizer.cu
+++ b/rand_randomizer.cu
@@ -56,7 +56,7 @@ __global__ void randomizeArrayWFlipsKernel(bcuda::Span<uint32_t> Array, uint32_t
     uint32_t* l = Array.ptr + idx * Count;
     uint32_t* u = l + Count;
     for (; l < u; ++l)
-        *l = bcuda::random::RandomizeWFlips(*l, FlipProb, state);
+        *l = bcuda::rand::RandomizeWFlips(*l, FlipProb, state);
 }
 __global__ void randomizeArrayWTargetsKernel(bcuda::Span<uint32_t> Array, uint32_t EachFlipProb, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
@@ -67,7 +67,7 @@ __global__ void randomizeArrayWTargetsKernel(bcuda::Span<uint32_t> Array, uint32
     uint32_t* l = Array.ptr + idx * Count;
     uint32_t* u = l + Count;
     for (; l < u; ++l)
-        *l = bcuda::random::RandomizeWTargets(*l, EachFlipProb, state);
+        *l = bcuda::rand::RandomizeWTargets(*l, EachFlipProb, state);
 }
 __global__ void randomizeArrayWMutationsKernel(bcuda::Span<uint32_t> Array, uint32_t MutationProb, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
@@ -78,7 +78,7 @@ __global__ void randomizeArrayWMutationsKernel(bcuda::Span<uint32_t> Array, uint
     uint32_t* l = Array.ptr + idx * Count;
     uint32_t* u = l + Count;
     for (; l < u; ++l)
-        *l = bcuda::random::RandomizeWMutations(*l, MutationProb, state);
+        *l = bcuda::rand::RandomizeWMutations(*l, MutationProb, state);
 }
 __global__ void randomizeArrayWMutationsKernel(bcuda::Span<uint32_t> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
@@ -89,7 +89,7 @@ __global__ void randomizeArrayWMutationsKernel(bcuda::Span<uint32_t> Array, uint
     uint32_t* l = Array.ptr + idx * Count;
     uint32_t* u = l + Count;
     for (; l < u; ++l)
-        *l = bcuda::random::RandomizeWMutations(*l, MutationProb, ProbabilityOf1, state);
+        *l = bcuda::rand::RandomizeWMutations(*l, MutationProb, ProbabilityOf1, state);
 }
 
 __global__ void initArrayKernel(bcuda::Span<float> Array, uint64_t Seed, uint64_t Count) {
@@ -156,7 +156,7 @@ __global__ void initArrayKernel(bcuda::Span<uint32_t> Array, uint32_t ProbOf1, u
     uint32_t* l = Array.ptr + idx * Count;
     uint32_t* u = std::min(l + Count, Array.ptr + Array.size);
     for (; l < u; ++l)
-        *l = bcuda::random::Get32Bits(ProbOf1, state);
+        *l = bcuda::rand::Get32Bits(ProbOf1, state);
 }
 __global__ void clearArrayKernel(bcuda::Span<float> Array, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;

--- a/rand_randomizer.h
+++ b/rand_randomizer.h
@@ -32,7 +32,7 @@ namespace bcuda {
         void ClearArray_CallKernel(Span<double> Array);
         void ClearArray_CallKernel(Span<uint64_t> Array);
     }
-    namespace random {
+    namespace rand {
         template <std::integral _T, std::uniform_random_bit_generator _TRNG>
         __host__ static __forceinline _T RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG);
 #ifdef __CUDACC__
@@ -166,19 +166,19 @@ __host__ __device__ __forceinline _T bcuda::details::RandomizeWTargets_GetEditsO
 }
 
 template <std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline _T bcuda::random::RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
+__host__ __forceinline _T bcuda::rand::RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
     if constexpr (sizeof(_T) > 4) return Value ^ (_T)Get64Bits(FlipProbability, RNG);
     else return Value ^ (_T)Get32Bits(FlipProbability, RNG);
 }
 #ifdef __CUDACC__
 template <std::integral _T, bcuda::KernelCurandState _TRNG>
-__device__ __forceinline _T bcuda::random::RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
+__device__ __forceinline _T bcuda::rand::RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
     if constexpr (sizeof(_T) > 4) return Value ^ (_T)Get64Bits(FlipProbability, RNG);
     else return Value ^ (_T)Get32Bits(FlipProbability, RNG);
 }
 #endif
 template <std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline _T bcuda::random::RandomizeWTargets(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
+__host__ __forceinline _T bcuda::rand::RandomizeWTargets(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
     constexpr uint32_t shiftMask = (sizeof(_T) << 3) - 1;
 
     std::uniform_int_distribution<uint32_t> dis32(0);
@@ -205,7 +205,7 @@ __host__ __forceinline _T bcuda::random::RandomizeWTargets(_T Value, uint32_t Fl
 }
 #ifdef __CUDACC__
 template <std::integral _T, bcuda::KernelCurandState _TRNG>
-__device__ __forceinline _T bcuda::random::RandomizeWTargets(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
+__device__ __forceinline _T bcuda::rand::RandomizeWTargets(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
     constexpr uint32_t shiftMask = (sizeof(_T) << 3) - 1;
 
     if (!Value) {
@@ -230,7 +230,7 @@ __device__ __forceinline _T bcuda::random::RandomizeWTargets(_T Value, uint32_t 
 }
 #endif
 template <std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline _T bcuda::random::RandomizeWMutations(_T Value, uint32_t MutationProbability, _TRNG& RNG) {
+__host__ __forceinline _T bcuda::rand::RandomizeWMutations(_T Value, uint32_t MutationProbability, _TRNG& RNG) {
     std::uniform_int_distribution<uint32_t> dis32(0);
     if (dis32(RNG) < MutationProbability) {
         if constexpr (sizeof(_T) == 4) return (_T)dis32(RNG);
@@ -247,7 +247,7 @@ __host__ __forceinline _T bcuda::random::RandomizeWMutations(_T Value, uint32_t 
 }
 #ifdef __CUDACC__
 template <std::integral _T, bcuda::KernelCurandState _TRNG>
-__device__ __forceinline _T bcuda::random::RandomizeWMutations(_T Value, uint32_t MutationProbability, _TRNG& RNG) {
+__device__ __forceinline _T bcuda::rand::RandomizeWMutations(_T Value, uint32_t MutationProbability, _TRNG& RNG) {
     if (curand(&RNG) < MutationProbability) {
         if constexpr (sizeof(_T) > 4) return (_T)(((uint64_t)curand(&RNG) << 32) | curand(&RNG));
         else return (_T)curand(&RNG);
@@ -256,7 +256,7 @@ __device__ __forceinline _T bcuda::random::RandomizeWMutations(_T Value, uint32_
 }
 #endif
 template <std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline _T bcuda::random::RandomizeWMutations(_T Value, uint32_t MutationProbability, uint32_t ProbabilityOf1, _TRNG& RNG) {
+__host__ __forceinline _T bcuda::rand::RandomizeWMutations(_T Value, uint32_t MutationProbability, uint32_t ProbabilityOf1, _TRNG& RNG) {
     std::uniform_int_distribution<uint32_t> dis32(0);
     if (dis32(RNG) < MutationProbability) {
         if constexpr (sizeof(_T) > 4) return (_T)Get64Bits(ProbabilityOf1, RNG);
@@ -266,7 +266,7 @@ __host__ __forceinline _T bcuda::random::RandomizeWMutations(_T Value, uint32_t 
 }
 #ifdef __CUDACC__
 template <std::integral _T, bcuda::KernelCurandState _TRNG>
-__device__ __forceinline _T bcuda::random::RandomizeWMutations(_T Value, uint32_t MutationProbability, uint32_t ProbabilityOf1, _TRNG& RNG) {
+__device__ __forceinline _T bcuda::rand::RandomizeWMutations(_T Value, uint32_t MutationProbability, uint32_t ProbabilityOf1, _TRNG& RNG) {
     if (curand(&RNG) < MutationProbability) {
         if constexpr (sizeof(_T) > 4) return (_T)Get64Bits(ProbabilityOf1, RNG);
         else return (_T)Get32Bits(ProbabilityOf1, RNG);
@@ -275,48 +275,48 @@ __device__ __forceinline _T bcuda::random::RandomizeWMutations(_T Value, uint32_
 }
 #endif
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline float bcuda::random::Randomize(float Value, float Scalar, _TRNG& RNG) {
+__host__ __forceinline float bcuda::rand::Randomize(float Value, float Scalar, _TRNG& RNG) {
     std::uniform_real_distribution<float> dis(-Scalar, Scalar);
     return Value + dis(RNG);
 }
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline double bcuda::random::Randomize(double Value, double Scalar, _TRNG& RNG) {
+__host__ __forceinline double bcuda::rand::Randomize(double Value, double Scalar, _TRNG& RNG) {
     std::uniform_real_distribution<double> dis(-Scalar, Scalar);
     return Value + dis(RNG);
 }
 #ifdef __CUDACC__
 template <bcuda::KernelCurandState _TRNG>
-__device__ __forceinline float bcuda::random::Randomize(float Value, float Scalar, _TRNG& RNG) {
+__device__ __forceinline float bcuda::rand::Randomize(float Value, float Scalar, _TRNG& RNG) {
     return Value + Scalar * 2.f * (curand_uniform(&RNG) - 0.5f);
 }
 template <bcuda::KernelCurandState _TRNG>
-__device__ __forceinline double bcuda::random::Randomize(double Value, double Scalar, _TRNG& RNG) {
+__device__ __forceinline double bcuda::rand::Randomize(double Value, double Scalar, _TRNG& RNG) {
     return Value + Scalar * 2. * (curand_uniform_double(&RNG) - 0.5);
 }
 #endif
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline float bcuda::random::Randomize(float Value, float Scalar, float LowerBound, float UpperBound, _TRNG& RNG) {
+__host__ __forceinline float bcuda::rand::Randomize(float Value, float Scalar, float LowerBound, float UpperBound, _TRNG& RNG) {
     std::uniform_real_distribution<float> dis(-Scalar, Scalar);
     return std::clamp(Value + dis(RNG), LowerBound, UpperBound);
 }
 template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline double bcuda::random::Randomize(double Value, double Scalar, double LowerBound, double UpperBound, _TRNG& RNG) {
+__host__ __forceinline double bcuda::rand::Randomize(double Value, double Scalar, double LowerBound, double UpperBound, _TRNG& RNG) {
     std::uniform_real_distribution<double> dis(-Scalar, Scalar);
     return std::clamp(Value + dis(RNG), LowerBound, UpperBound);
 }
 #ifdef __CUDACC__
 template <bcuda::KernelCurandState _TRNG>
-__device__ __forceinline float bcuda::random::Randomize(float Value, float Scalar, float LowerBound, float UpperBound, _TRNG& RNG) {
+__device__ __forceinline float bcuda::rand::Randomize(float Value, float Scalar, float LowerBound, float UpperBound, _TRNG& RNG) {
     return std::clamp(Value + Scalar * 2.f * (curand_uniform(&RNG) - 0.5f), LowerBound, UpperBound);
 }
 template <bcuda::KernelCurandState _TRNG>
-__device__ __forceinline double bcuda::random::Randomize(double Value, double Scalar, double LowerBound, double UpperBound, _TRNG& RNG) {
+__device__ __forceinline double bcuda::rand::Randomize(double Value, double Scalar, double LowerBound, double UpperBound, _TRNG& RNG) {
     return std::clamp(Value + Scalar * 2. * (curand_uniform_double(&RNG) - 0.5), LowerBound, UpperBound);
 }
 #endif
 
 template <bool _MemoryOnHost, std::floating_point _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void bcuda::random::RandomizeArray(Span<_T> Array, _T Scalar, _TRNG& RNG) {
+__host__ __forceinline void bcuda::rand::RandomizeArray(Span<_T> Array, _T Scalar, _TRNG& RNG) {
     if constexpr (_MemoryOnHost) {
         Scalar *= 2.f;
         std::uniform_real_distribution<_T> dis(-Scalar, Scalar);
@@ -331,7 +331,7 @@ __host__ __forceinline void bcuda::random::RandomizeArray(Span<_T> Array, _T Sca
 }
 #ifdef __CUDACC__
 template <std::floating_point _T, bcuda::KernelCurandState _TRNG>
-__device__ __forceinline void bcuda::random::RandomizeArray(Span<_T> Array, _T Scalar, _TRNG& RNG) {
+__device__ __forceinline void bcuda::rand::RandomizeArray(Span<_T> Array, _T Scalar, _TRNG& RNG) {
     if constexpr (std::same_as<_T, float>) {
         Scalar *= 2.f;
         float* l = Array.ptr;
@@ -347,7 +347,7 @@ __device__ __forceinline void bcuda::random::RandomizeArray(Span<_T> Array, _T S
 }
 #endif
 template <bool _MemoryOnHost, std::floating_point _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void bcuda::random::RandomizeArray(Span<_T> Array, _T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__host__ __forceinline void bcuda::rand::RandomizeArray(Span<_T> Array, _T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     if constexpr (_MemoryOnHost) {
         Scalar *= 2.f;
         std::uniform_real_distribution<_T> dis(-Scalar, Scalar);
@@ -362,7 +362,7 @@ __host__ __forceinline void bcuda::random::RandomizeArray(Span<_T> Array, _T Sca
 }
 #ifdef __CUDACC__
 template <std::floating_point _T, bcuda::KernelCurandState _TRNG>
-__device__ __forceinline void bcuda::random::RandomizeArray(Span<_T> Array, _T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__device__ __forceinline void bcuda::rand::RandomizeArray(Span<_T> Array, _T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     if constexpr (std::same_as<_T, float>) {
         Scalar *= 2.f;
         float* l = Array.ptr;
@@ -379,7 +379,7 @@ __device__ __forceinline void bcuda::random::RandomizeArray(Span<_T> Array, _T S
 #endif
 
 template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void bcuda::random::RandomizeArrayWFlips(Span<_T> Array, uint32_t FlipProb, _TRNG& RNG) {
+__host__ __forceinline void bcuda::rand::RandomizeArrayWFlips(Span<_T> Array, uint32_t FlipProb, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         if constexpr (_MemoryOnHost) {
             uint64_t* l64 = (uint64_t*)Array.ptr;
@@ -417,7 +417,7 @@ __host__ __forceinline void bcuda::random::RandomizeArrayWFlips(Span<_T> Array, 
 }
 #ifdef __CUDACC__
 template <std::integral _T, bcuda::KernelCurandState _TRNG>
-__device__ __forceinline void bcuda::random::RandomizeArrayWFlips(Span<_T> Array, uint32_t FlipProb, _TRNG& RNG) {
+__device__ __forceinline void bcuda::rand::RandomizeArrayWFlips(Span<_T> Array, uint32_t FlipProb, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         uint64_t* l64 = (uint64_t*)Array.ptr;
         uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
@@ -438,7 +438,7 @@ __device__ __forceinline void bcuda::random::RandomizeArrayWFlips(Span<_T> Array
 }
 #endif
 template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void bcuda::random::RandomizeArrayWTargets(Span<_T> Array, uint32_t EachFlipProb, _TRNG& RNG) {
+__host__ __forceinline void bcuda::rand::RandomizeArrayWTargets(Span<_T> Array, uint32_t EachFlipProb, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         if constexpr (_MemoryOnHost) {
             uint64_t* l64 = (uint64_t*)Array.ptr;
@@ -476,7 +476,7 @@ __host__ __forceinline void bcuda::random::RandomizeArrayWTargets(Span<_T> Array
 }
 #ifdef __CUDACC__
 template <std::integral _T, bcuda::KernelCurandState _TRNG>
-__device__ __forceinline void bcuda::random::RandomizeArrayWTargets(Span<_T> Array, uint32_t EachFlipProb, _TRNG& RNG) {
+__device__ __forceinline void bcuda::rand::RandomizeArrayWTargets(Span<_T> Array, uint32_t EachFlipProb, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         uint64_t* l64 = (uint64_t*)Array.ptr;
         uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
@@ -497,7 +497,7 @@ __device__ __forceinline void bcuda::random::RandomizeArrayWTargets(Span<_T> Arr
 }
 #endif
 template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void bcuda::random::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, _TRNG& RNG) {
+__host__ __forceinline void bcuda::rand::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         if constexpr (_MemoryOnHost) {
             uint64_t* l64 = (uint64_t*)Array.ptr;
@@ -535,7 +535,7 @@ __host__ __forceinline void bcuda::random::RandomizeArrayWMutations(Span<_T> Arr
 }
 #ifdef __CUDACC__
 template <std::integral _T, bcuda::KernelCurandState _TRNG>
-__device__ __forceinline void bcuda::random::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, _TRNG& RNG) {
+__device__ __forceinline void bcuda::rand::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         uint64_t* l64 = (uint64_t*)Array.ptr;
         uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
@@ -556,7 +556,7 @@ __device__ __forceinline void bcuda::random::RandomizeArrayWMutations(Span<_T> A
 }
 #endif
 template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void bcuda::random::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, _TRNG& RNG) {
+__host__ __forceinline void bcuda::rand::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         if constexpr (_MemoryOnHost) {
             uint64_t* l64 = (uint64_t*)Array.ptr;
@@ -594,7 +594,7 @@ __host__ __forceinline void bcuda::random::RandomizeArrayWMutations(Span<_T> Arr
 }
 #ifdef __CUDACC__
 template <std::integral _T, bcuda::KernelCurandState _TRNG>
-__device__ __forceinline void bcuda::random::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, _TRNG& RNG) {
+__device__ __forceinline void bcuda::rand::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         uint64_t* l64 = (uint64_t*)Array.ptr;
         uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
@@ -617,7 +617,7 @@ __device__ __forceinline void bcuda::random::RandomizeArrayWMutations(Span<_T> A
 
 template <bool _MemoryOnHost, typename _T, std::uniform_random_bit_generator _TRNG>
     requires std::is_arithmetic_v<_T>
-__host__ __forceinline void bcuda::random::InitRandomArray(Span<_T> Array, _TRNG& RNG) {
+__host__ __forceinline void bcuda::rand::InitRandomArray(Span<_T> Array, _TRNG& RNG) {
     if constexpr (std::floating_point<_T>) {
         if constexpr (_MemoryOnHost) {
             std::uniform_real_distribution<_T> dis(-1., 1.);
@@ -663,7 +663,7 @@ __host__ __forceinline void bcuda::random::InitRandomArray(Span<_T> Array, _TRNG
 #ifdef __CUDACC__
 template <typename _T, bcuda::KernelCurandState _TRNG>
     requires std::is_arithmetic_v<_T>
-__device__ __forceinline void bcuda::random::InitRandomArray(Span<_T> Array, _TRNG& RNG) {
+__device__ __forceinline void bcuda::rand::InitRandomArray(Span<_T> Array, _TRNG& RNG) {
     if constexpr (std::same_as<_T, float>) {
         float* l = Array.ptr;
         float* u = Array.ptr + Array.size;
@@ -690,7 +690,7 @@ __device__ __forceinline void bcuda::random::InitRandomArray(Span<_T> Array, _TR
 
 #endif
 template <bool _MemoryOnHost, std::floating_point _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void bcuda::random::InitRandomArray(Span<_T> Array, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__host__ __forceinline void bcuda::rand::InitRandomArray(Span<_T> Array, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     if constexpr (_MemoryOnHost) {
         std::uniform_real_distribution<_T> dis(LowerBound, UpperBound);
         _T* l = Array.ptr;
@@ -704,7 +704,7 @@ __host__ __forceinline void bcuda::random::InitRandomArray(Span<_T> Array, _T Lo
 }
 #ifdef __CUDACC__
 template <std::floating_point _T, bcuda::KernelCurandState _TRNG>
-__device__ __forceinline void bcuda::random::InitRandomArray(Span<_T> Array, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+__device__ __forceinline void bcuda::rand::InitRandomArray(Span<_T> Array, _T LowerBound, _T UpperBound, _TRNG& RNG) {
     if constexpr (std::same_as<_T, float>) {
         float range = UpperBound - LowerBound;
         float* l = Array.ptr;
@@ -721,7 +721,7 @@ __device__ __forceinline void bcuda::random::InitRandomArray(Span<_T> Array, _T 
 #endif
 
 template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void bcuda::random::InitRandomArray(Span<_T> Array, uint32_t ProbabilityOf1, _TRNG& RNG) {
+__host__ __forceinline void bcuda::rand::InitRandomArray(Span<_T> Array, uint32_t ProbabilityOf1, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         if constexpr (_MemoryOnHost) {
             uint64_t* l64 = (uint64_t*)Array.ptr;
@@ -753,7 +753,7 @@ __host__ __forceinline void bcuda::random::InitRandomArray(Span<_T> Array, uint3
 }
 #ifdef __CUDACC__
 template <std::integral _T, bcuda::KernelCurandState _TRNG>
-__device__ __forceinline void bcuda::random::InitRandomArray(Span<_T> Array, uint32_t ProbabilityOf1, _TRNG& RNG) {
+__device__ __forceinline void bcuda::rand::InitRandomArray(Span<_T> Array, uint32_t ProbabilityOf1, _TRNG& RNG) {
     if constexpr (std::same_as<_T, uint8_t>) {
         uint32_t* l32 = (uint32_t*)Array.ptr;
         uint32_t* u32 = ((uint32_t*)Array.ptr) + (Array.size >> 2);
@@ -773,7 +773,7 @@ __device__ __forceinline void bcuda::random::InitRandomArray(Span<_T> Array, uin
 
 template <bool _MemoryOnHost, typename _T>
     requires std::is_arithmetic_v<_T>
-__host__ __forceinline void bcuda::random::ClearArray(Span<_T> Array) {
+__host__ __forceinline void bcuda::rand::ClearArray(Span<_T> Array) {
     if constexpr (std::floating_point<_T>) {
         if constexpr (_MemoryOnHost) {
             _T* l = Array.ptr;
@@ -813,7 +813,7 @@ __host__ __forceinline void bcuda::random::ClearArray(Span<_T> Array) {
 #ifdef __CUDACC__
 template <typename _T>
     requires std::is_arithmetic_v<_T>
-__device__ __forceinline void bcuda::random::ClearArray(Span<_T> Array) {
+__device__ __forceinline void bcuda::rand::ClearArray(Span<_T> Array) {
     if constexpr (std::floating_point<_T>) {
         _T* l = Array.ptr;
         _T* u = Array.ptr + Array.size;


### PR DESCRIPTION
`bcuda::random` (then `BrendanCUDA::Random`) was intended to be renamed to `bcuda::rand` back in #16, but it was renamed to `bcuda::random` instead, by accident. Now, it will be renamed to `bcuda::rand` after all.