### PR TITLE
Correcting bounds checking for `rand_randomizer.cu`

### DIFF
--- a/rand_randomizer.cu
+++ b/rand_randomizer.cu
@@ -10,7 +10,7 @@ __global__ void randomizeArrayKernel(bcuda::Span<float> Array, float Scalar, uin
     curandState state;
     curand_init(Seed, idx, 0, &state);
     float* l = Array.ptr + idx * Count;
-    float* u = l + Count;
+    float* u = std::min(l + Count, Array.ptr + Array.size);
     for (; l < u; ++l)
         *l += Scalar * (curand_uniform(&state) - 0.5f);
 }
@@ -21,7 +21,7 @@ __global__ void randomizeArrayKernel(bcuda::Span<double> Array, double Scalar, u
     curandState state;
     curand_init(Seed, idx, 0, &state);
     double* l = Array.ptr + idx * Count;
-    double* u = l + Count;
+    double* u = std::min(l + Count, Array.ptr + Array.size);
     for (; l < u; ++l)
         *l += Scalar * (curand_uniform(&state) - 0.5);
 }
@@ -32,7 +32,7 @@ __global__ void randomizeArrayKernel(bcuda::Span<float> Array, float Scalar, flo
     curandState state;
     curand_init(Seed, idx, 0, &state);
     float* l = Array.ptr + idx * Count;
-    float* u = l + Count;
+    float* u = std::min(l + Count, Array.ptr + Array.size);
     for (; l < u; ++l)
         *l += std::clamp(*l + curand_uniform(&state) * Scalar, Lower, Upper);
 }
@@ -43,7 +43,7 @@ __global__ void randomizeArrayKernel(bcuda::Span<double> Array, double Scalar, d
     curandState state;
     curand_init(Seed, idx, 0, &state);
     double* l = Array.ptr + idx * Count;
-    double* u = l + Count;
+    double* u = std::min(l + Count, Array.ptr + Array.size);
     for (; l < u; ++l)
         *l += std::clamp(*l + curand_uniform(&state) * Scalar, Lower, Upper);
 }
@@ -54,7 +54,7 @@ __global__ void randomizeArrayWFlipsKernel(bcuda::Span<uint32_t> Array, uint32_t
     curandState state;
     curand_init(Seed, idx, 0, &state);
     uint32_t* l = Array.ptr + idx * Count;
-    uint32_t* u = l + Count;
+    uint32_t* u = std::min(l + Count, Array.ptr + Array.size);
     for (; l < u; ++l)
         *l = bcuda::rand::RandomizeWFlips(*l, FlipProb, state);
 }
@@ -65,7 +65,7 @@ __global__ void randomizeArrayWTargetsKernel(bcuda::Span<uint32_t> Array, uint32
     curandState state;
     curand_init(Seed, idx, 0, &state);
     uint32_t* l = Array.ptr + idx * Count;
-    uint32_t* u = l + Count;
+    uint32_t* u = std::min(l + Count, Array.ptr + Array.size);
     for (; l < u; ++l)
         *l = bcuda::rand::RandomizeWTargets(*l, EachFlipProb, state);
 }
@@ -76,7 +76,7 @@ __global__ void randomizeArrayWMutationsKernel(bcuda::Span<uint32_t> Array, uint
     curandState state;
     curand_init(Seed, idx, 0, &state);
     uint32_t* l = Array.ptr + idx * Count;
-    uint32_t* u = l + Count;
+    uint32_t* u = std::min(l + Count, Array.ptr + Array.size);
     for (; l < u; ++l)
         *l = bcuda::rand::RandomizeWMutations(*l, MutationProb, state);
 }
@@ -87,7 +87,7 @@ __global__ void randomizeArrayWMutationsKernel(bcuda::Span<uint32_t> Array, uint
     curandState state;
     curand_init(Seed, idx, 0, &state);
     uint32_t* l = Array.ptr + idx * Count;
-    uint32_t* u = l + Count;
+    uint32_t* u = std::min(l + Count, Array.ptr + Array.size);
     for (; l < u; ++l)
         *l = bcuda::rand::RandomizeWMutations(*l, MutationProb, ProbabilityOf1, state);
 }
@@ -99,7 +99,7 @@ __global__ void initArrayKernel(bcuda::Span<float> Array, uint64_t Seed, uint64_
     curandState state;
     curand_init(Seed, idx, 0, &state);
     float* l = Array.ptr + idx * Count;
-    float* u = l + Count;
+    float* u = std::min(l + Count, Array.ptr + Array.size);
     for (; l < u; ++l)
         *l = curand_uniform(&state);
 }
@@ -110,7 +110,7 @@ __global__ void initArrayKernel(bcuda::Span<double> Array, uint64_t Seed, uint64
     curandState state;
     curand_init(Seed, idx, 0, &state);
     double* l = Array.ptr + idx * Count;
-    double* u = l + Count;
+    double* u = std::min(l + Count, Array.ptr + Array.size);
     for (; l < u; ++l)
         *l = curand_uniform(&state);
 }
@@ -121,7 +121,7 @@ __global__ void initArrayKernel(bcuda::Span<float> Array, float Lower, float Ran
     curandState state;
     curand_init(Seed, idx, 0, &state);
     float* l = Array.ptr + idx * Count;
-    float* u = l + Count;
+    float* u = std::min(l + Count, Array.ptr + Array.size);
     for (; l < u; ++l)
         *l = curand_uniform(&state) * Range + Lower;
 }
@@ -132,7 +132,7 @@ __global__ void initArrayKernel(bcuda::Span<double> Array, double Lower, double 
     curandState state;
     curand_init(Seed, idx, 0, &state);
     double* l = Array.ptr + idx * Count;
-    double* u = l + Count;
+    double* u = std::min(l + Count, Array.ptr + Array.size);
     for (; l < u; ++l)
         *l = curand_uniform(&state) * Range + Lower;
 }

--- a/rand_randomizer.cu
+++ b/rand_randomizer.cu
@@ -5,8 +5,6 @@
 
 __global__ void randomizeArrayKernel(bcuda::Span<float> Array, float Scalar, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
-    if (idx >= Array.size)
-        return;
     curandState state;
     curand_init(Seed, idx, 0, &state);
     float* l = Array.ptr + idx * Count;
@@ -16,8 +14,6 @@ __global__ void randomizeArrayKernel(bcuda::Span<float> Array, float Scalar, uin
 }
 __global__ void randomizeArrayKernel(bcuda::Span<double> Array, double Scalar, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
-    if (idx >= Array.size)
-        return;
     curandState state;
     curand_init(Seed, idx, 0, &state);
     double* l = Array.ptr + idx * Count;
@@ -27,8 +23,6 @@ __global__ void randomizeArrayKernel(bcuda::Span<double> Array, double Scalar, u
 }
 __global__ void randomizeArrayKernel(bcuda::Span<float> Array, float Scalar, float Lower, float Upper, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
-    if (idx >= Array.size)
-        return;
     curandState state;
     curand_init(Seed, idx, 0, &state);
     float* l = Array.ptr + idx * Count;
@@ -38,8 +32,6 @@ __global__ void randomizeArrayKernel(bcuda::Span<float> Array, float Scalar, flo
 }
 __global__ void randomizeArrayKernel(bcuda::Span<double> Array, double Scalar, double Lower, double Upper, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
-    if (idx >= Array.size)
-        return;
     curandState state;
     curand_init(Seed, idx, 0, &state);
     double* l = Array.ptr + idx * Count;
@@ -49,8 +41,6 @@ __global__ void randomizeArrayKernel(bcuda::Span<double> Array, double Scalar, d
 }
 __global__ void randomizeArrayWFlipsKernel(bcuda::Span<uint32_t> Array, uint32_t FlipProb, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
-    if (idx >= Array.size)
-        return;
     curandState state;
     curand_init(Seed, idx, 0, &state);
     uint32_t* l = Array.ptr + idx * Count;
@@ -60,8 +50,6 @@ __global__ void randomizeArrayWFlipsKernel(bcuda::Span<uint32_t> Array, uint32_t
 }
 __global__ void randomizeArrayWTargetsKernel(bcuda::Span<uint32_t> Array, uint32_t EachFlipProb, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
-    if (idx >= Array.size)
-        return;
     curandState state;
     curand_init(Seed, idx, 0, &state);
     uint32_t* l = Array.ptr + idx * Count;
@@ -71,8 +59,6 @@ __global__ void randomizeArrayWTargetsKernel(bcuda::Span<uint32_t> Array, uint32
 }
 __global__ void randomizeArrayWMutationsKernel(bcuda::Span<uint32_t> Array, uint32_t MutationProb, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
-    if (idx >= Array.size)
-        return;
     curandState state;
     curand_init(Seed, idx, 0, &state);
     uint32_t* l = Array.ptr + idx * Count;
@@ -82,8 +68,6 @@ __global__ void randomizeArrayWMutationsKernel(bcuda::Span<uint32_t> Array, uint
 }
 __global__ void randomizeArrayWMutationsKernel(bcuda::Span<uint32_t> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
-    if (idx >= Array.size)
-        return;
     curandState state;
     curand_init(Seed, idx, 0, &state);
     uint32_t* l = Array.ptr + idx * Count;
@@ -94,8 +78,6 @@ __global__ void randomizeArrayWMutationsKernel(bcuda::Span<uint32_t> Array, uint
 
 __global__ void initArrayKernel(bcuda::Span<float> Array, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
-    if (idx >= Array.size)
-        return;
     curandState state;
     curand_init(Seed, idx, 0, &state);
     float* l = Array.ptr + idx * Count;
@@ -105,8 +87,6 @@ __global__ void initArrayKernel(bcuda::Span<float> Array, uint64_t Seed, uint64_
 }
 __global__ void initArrayKernel(bcuda::Span<double> Array, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
-    if (idx >= Array.size)
-        return;
     curandState state;
     curand_init(Seed, idx, 0, &state);
     double* l = Array.ptr + idx * Count;
@@ -116,8 +96,6 @@ __global__ void initArrayKernel(bcuda::Span<double> Array, uint64_t Seed, uint64
 }
 __global__ void initArrayKernel(bcuda::Span<float> Array, float Lower, float Range, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
-    if (idx >= Array.size)
-        return;
     curandState state;
     curand_init(Seed, idx, 0, &state);
     float* l = Array.ptr + idx * Count;
@@ -127,8 +105,6 @@ __global__ void initArrayKernel(bcuda::Span<float> Array, float Lower, float Ran
 }
 __global__ void initArrayKernel(bcuda::Span<double> Array, double Lower, double Range, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
-    if (idx >= Array.size)
-        return;
     curandState state;
     curand_init(Seed, idx, 0, &state);
     double* l = Array.ptr + idx * Count;
@@ -138,8 +114,6 @@ __global__ void initArrayKernel(bcuda::Span<double> Array, double Lower, double 
 }
 __global__ void initArrayKernel(bcuda::Span<uint32_t> Array, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
-    if (idx >= Array.size)
-        return;
     curandState state;
     curand_init(Seed, idx, 0, &state);
     uint32_t* l = Array.ptr + idx * Count;
@@ -149,8 +123,6 @@ __global__ void initArrayKernel(bcuda::Span<uint32_t> Array, uint64_t Seed, uint
 }
 __global__ void initArrayKernel(bcuda::Span<uint32_t> Array, uint32_t ProbOf1, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
-    if (idx >= Array.size)
-        return;
     curandState state;
     curand_init(Seed, idx, 0, &state);
     uint32_t* l = Array.ptr + idx * Count;
@@ -160,8 +132,6 @@ __global__ void initArrayKernel(bcuda::Span<uint32_t> Array, uint32_t ProbOf1, u
 }
 __global__ void clearArrayKernel(bcuda::Span<float> Array, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
-    if (idx >= Array.size)
-        return;
     float* l = Array.ptr + idx * Count;
     float* u = std::min(l + Count, Array.ptr + Array.size);
     for (; l < u; ++l)
@@ -169,8 +139,6 @@ __global__ void clearArrayKernel(bcuda::Span<float> Array, uint64_t Count) {
 }
 __global__ void clearArrayKernel(bcuda::Span<double> Array, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
-    if (idx >= Array.size)
-        return;
     double* l = Array.ptr + idx * Count;
     double* u = std::min(l + Count, Array.ptr + Array.size);
     for (; l < u; ++l)
@@ -178,8 +146,6 @@ __global__ void clearArrayKernel(bcuda::Span<double> Array, uint64_t Count) {
 }
 __global__ void clearArrayKernel(bcuda::Span<uint64_t> Array, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
-    if (idx >= Array.size)
-        return;
     uint64_t* l = Array.ptr + idx * Count;
     uint64_t* u = std::min(l + Count, Array.ptr + Array.size);
     for (; l < u; ++l)

--- a/rand_randomizer.cu
+++ b/rand_randomizer.cu
@@ -5,130 +5,144 @@
 
 __global__ void randomizeArrayKernel(bcuda::Span<float> Array, float Scalar, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
-    curandState state;
-    curand_init(Seed, idx, 0, &state);
     float* l = Array.ptr + idx * Count;
     float* u = std::min(l + Count, Array.ptr + Array.size);
-    for (; l < u; ++l)
-        *l += Scalar * (curand_uniform(&state) - 0.5f);
+    if (l >= u) return;
+    curandState state;
+    curand_init(Seed, idx, 0, &state);
+    do *l += Scalar * (curand_uniform(&state) - 0.5f);
+    while (++l < u);
 }
 __global__ void randomizeArrayKernel(bcuda::Span<double> Array, double Scalar, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
-    curandState state;
-    curand_init(Seed, idx, 0, &state);
     double* l = Array.ptr + idx * Count;
     double* u = std::min(l + Count, Array.ptr + Array.size);
-    for (; l < u; ++l)
-        *l += Scalar * (curand_uniform(&state) - 0.5);
+    if (l >= u) return;
+    curandState state;
+    curand_init(Seed, idx, 0, &state);
+    do *l += Scalar * (curand_uniform(&state) - 0.5);
+    while (++l < u);
 }
 __global__ void randomizeArrayKernel(bcuda::Span<float> Array, float Scalar, float Lower, float Upper, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
-    curandState state;
-    curand_init(Seed, idx, 0, &state);
     float* l = Array.ptr + idx * Count;
     float* u = std::min(l + Count, Array.ptr + Array.size);
-    for (; l < u; ++l)
-        *l += std::clamp(*l + curand_uniform(&state) * Scalar, Lower, Upper);
+    if (l >= u) return;
+    curandState state;
+    curand_init(Seed, idx, 0, &state);
+    do *l += std::clamp(*l + curand_uniform(&state) * Scalar, Lower, Upper);
+    while (++l < u);
 }
 __global__ void randomizeArrayKernel(bcuda::Span<double> Array, double Scalar, double Lower, double Upper, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
-    curandState state;
-    curand_init(Seed, idx, 0, &state);
     double* l = Array.ptr + idx * Count;
     double* u = std::min(l + Count, Array.ptr + Array.size);
-    for (; l < u; ++l)
-        *l += std::clamp(*l + curand_uniform(&state) * Scalar, Lower, Upper);
+    if (l >= u) return;
+    curandState state;
+    curand_init(Seed, idx, 0, &state);
+    do *l += std::clamp(*l + curand_uniform(&state) * Scalar, Lower, Upper);
+    while (++l < u);
 }
 __global__ void randomizeArrayWFlipsKernel(bcuda::Span<uint32_t> Array, uint32_t FlipProb, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
-    curandState state;
-    curand_init(Seed, idx, 0, &state);
     uint32_t* l = Array.ptr + idx * Count;
     uint32_t* u = std::min(l + Count, Array.ptr + Array.size);
-    for (; l < u; ++l)
-        *l = bcuda::rand::RandomizeWFlips(*l, FlipProb, state);
+    if (l >= u) return;
+    curandState state;
+    curand_init(Seed, idx, 0, &state);
+    do *l = bcuda::rand::RandomizeWFlips(*l, FlipProb, state);
+    while (++l < u);
 }
 __global__ void randomizeArrayWTargetsKernel(bcuda::Span<uint32_t> Array, uint32_t EachFlipProb, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
-    curandState state;
-    curand_init(Seed, idx, 0, &state);
     uint32_t* l = Array.ptr + idx * Count;
     uint32_t* u = std::min(l + Count, Array.ptr + Array.size);
-    for (; l < u; ++l)
-        *l = bcuda::rand::RandomizeWTargets(*l, EachFlipProb, state);
+    if (l >= u) return;
+    curandState state;
+    curand_init(Seed, idx, 0, &state);
+    do *l = bcuda::rand::RandomizeWTargets(*l, EachFlipProb, state);
+    while (++l < u);
 }
 __global__ void randomizeArrayWMutationsKernel(bcuda::Span<uint32_t> Array, uint32_t MutationProb, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
-    curandState state;
-    curand_init(Seed, idx, 0, &state);
     uint32_t* l = Array.ptr + idx * Count;
     uint32_t* u = std::min(l + Count, Array.ptr + Array.size);
-    for (; l < u; ++l)
-        *l = bcuda::rand::RandomizeWMutations(*l, MutationProb, state);
+    if (l >= u) return;
+    curandState state;
+    curand_init(Seed, idx, 0, &state);
+    do *l = bcuda::rand::RandomizeWMutations(*l, MutationProb, state);
+    while (++l < u);
 }
 __global__ void randomizeArrayWMutationsKernel(bcuda::Span<uint32_t> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
-    curandState state;
-    curand_init(Seed, idx, 0, &state);
     uint32_t* l = Array.ptr + idx * Count;
     uint32_t* u = std::min(l + Count, Array.ptr + Array.size);
-    for (; l < u; ++l)
-        *l = bcuda::rand::RandomizeWMutations(*l, MutationProb, ProbabilityOf1, state);
+    if (l >= u) return;
+    curandState state;
+    curand_init(Seed, idx, 0, &state);
+    do *l = bcuda::rand::RandomizeWMutations(*l, MutationProb, ProbabilityOf1, state);
+    while (++l < u);
 }
 
 __global__ void initArrayKernel(bcuda::Span<float> Array, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
-    curandState state;
-    curand_init(Seed, idx, 0, &state);
     float* l = Array.ptr + idx * Count;
     float* u = std::min(l + Count, Array.ptr + Array.size);
-    for (; l < u; ++l)
-        *l = curand_uniform(&state);
+    if (l >= u) return;
+    curandState state;
+    curand_init(Seed, idx, 0, &state);
+    do *l = curand_uniform(&state);
+    while (++l < u);
 }
 __global__ void initArrayKernel(bcuda::Span<double> Array, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
-    curandState state;
-    curand_init(Seed, idx, 0, &state);
     double* l = Array.ptr + idx * Count;
     double* u = std::min(l + Count, Array.ptr + Array.size);
-    for (; l < u; ++l)
-        *l = curand_uniform(&state);
+    if (l >= u) return;
+    curandState state;
+    curand_init(Seed, idx, 0, &state);
+    do *l = curand_uniform(&state);
+    while (++l < u);
 }
 __global__ void initArrayKernel(bcuda::Span<float> Array, float Lower, float Range, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
-    curandState state;
-    curand_init(Seed, idx, 0, &state);
     float* l = Array.ptr + idx * Count;
     float* u = std::min(l + Count, Array.ptr + Array.size);
-    for (; l < u; ++l)
-        *l = curand_uniform(&state) * Range + Lower;
+    if (l >= u) return;
+    curandState state;
+    curand_init(Seed, idx, 0, &state);
+    do *l = curand_uniform(&state) * Range + Lower;
+    while (++l < u);
 }
 __global__ void initArrayKernel(bcuda::Span<double> Array, double Lower, double Range, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
-    curandState state;
-    curand_init(Seed, idx, 0, &state);
     double* l = Array.ptr + idx * Count;
     double* u = std::min(l + Count, Array.ptr + Array.size);
-    for (; l < u; ++l)
-        *l = curand_uniform(&state) * Range + Lower;
+    if (l >= u) return;
+    curandState state;
+    curand_init(Seed, idx, 0, &state);
+    do *l = curand_uniform(&state) * Range + Lower;
+    while (++l < u);
 }
 __global__ void initArrayKernel(bcuda::Span<uint32_t> Array, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
-    curandState state;
-    curand_init(Seed, idx, 0, &state);
     uint32_t* l = Array.ptr + idx * Count;
     uint32_t* u = std::min(l + Count, Array.ptr + Array.size);
-    for (; l < u; ++l)
-        *l = curand(&state);
+    if (l >= u) return;
+    curandState state;
+    curand_init(Seed, idx, 0, &state);
+    do *l = curand(&state);
+    while (++l < u);
 }
 __global__ void initArrayKernel(bcuda::Span<uint32_t> Array, uint32_t ProbOf1, uint64_t Seed, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;
-    curandState state;
-    curand_init(Seed, idx, 0, &state);
     uint32_t* l = Array.ptr + idx * Count;
     uint32_t* u = std::min(l + Count, Array.ptr + Array.size);
-    for (; l < u; ++l)
-        *l = bcuda::rand::Get32Bits(ProbOf1, state);
+    if (l >= u) return;
+    curandState state;
+    curand_init(Seed, idx, 0, &state);
+    do *l = bcuda::rand::Get32Bits(ProbOf1, state);
+    while (++l < u);
 }
 __global__ void clearArrayKernel(bcuda::Span<float> Array, uint64_t Count) {
     uint64_t idx = blockIdx.x * (uint64_t)blockDim.x + threadIdx.x;


### PR DESCRIPTION
Previously, some kernels in `rand_randomizer.cu` did bounds checking improperly. The kernels were checking if the index of the kernel was greater than or equal to the length of the array, rather than checking if the element range they were dealing with went outside the array, and minimizing it if it did, which it now will do. Some functions already had such bounds checking implemented, alongside the incorrect version, but not all of them, which is strange. Nonetheless, this will now be corrected.