### PR TITLE
Corrected `template`/`typename` keyword usage for nested types

### DIFF
--- a/ai_mlp_fixedmlp.h
+++ b/ai_mlp_fixedmlp.h
@@ -548,7 +548,7 @@ __host__ __device__ void bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _Inpu
 
 template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
 template <size_t _Index>
-__host__ __device__ bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::layerType_t<_Index>& bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Layer() {
+__host__ __device__ typename bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::template layerType_t<_Index>& bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::Layer() {
     if constexpr (_Index) {
         return nextLayers.Layer<_Index - 1>();
     }
@@ -569,7 +569,7 @@ __host__ __device__ void bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _Inpu
 
 template <std::floating_point _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
 template <size_t _Index>
-__host__ __device__ bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::layerType_t<_Index>& bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Layer() {
+__host__ __device__ typename bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::template layerType_t<_Index>& bcuda::ai::mlp::FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>::Layer() {
     static_assert(!_Index, "_Index is out of bounds.");
     return layer;
 }

--- a/ai_mlpb_fixedmlpb.h
+++ b/ai_mlpb_fixedmlpb.h
@@ -95,7 +95,7 @@ namespace bcuda {
                 using layerType_t = details::mlpbLayerType_t<_Index, _TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>;
 
                 using input_t = _TInput;
-                using output_t = FixedMLPB<_TOutput1, _TOutput2, _TsContinuedOutputs...>::output_t;
+                using output_t = typename FixedMLPB<_TOutput1, _TOutput2, _TsContinuedOutputs...>::output_t;
                 
                 FixedMLPBL<_TInput, _TOutput1> layer;
                 FixedMLPB<_TOutput1, _TOutput2, _TsContinuedOutputs...> nextLayers;

--- a/details_dfieldbase.h
+++ b/details_dfieldbase.h
@@ -9,7 +9,7 @@ namespace bcuda {
             using this_t = DFieldBase<_T, _DimensionCount>;
             using basedb_t = DimensionedBase<_DimensionCount>;
         public:
-            __host__ __device__ __forceinline DFieldBase(const this_t::vector_t& Dimensions)
+            __host__ __device__ __forceinline DFieldBase(const typename this_t::vector_t& Dimensions)
                 : basedb_t(Dimensions) {
                 if (!this->Length(0)) {
                     darrF = 0;
@@ -28,7 +28,7 @@ namespace bcuda {
                 requires (sizeof...(_Ts) == _DimensionCount)
             __host__ __device__ __forceinline DFieldBase(_Ts... Dimensions)
                 : DFieldBase(this_t::vector_t(Dimensions...)) { }
-            __host__ __device__ __forceinline DFieldBase(const this_t::vector_t& Dimensions, _T* ArrF, _T* ArrB)
+            __host__ __device__ __forceinline DFieldBase(const typename this_t::vector_t& Dimensions, _T* ArrF, _T* ArrB)
                 : basedb_t(Dimensions), darrF(ArrF), darrB(ArrB) { }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
@@ -107,7 +107,7 @@ namespace bcuda {
             __host__ __device__ __forceinline void CpyValIn(uint64_t Idx, const _T& Val) const {
                 B().CpyValIn(Idx, Val);
             }
-            __host__ __device__ __forceinline void CpyValIn(const this_t::vector_t& Coords, const _T& Val) const {
+            __host__ __device__ __forceinline void CpyValIn(const typename this_t::vector_t& Coords, const _T& Val) const {
                 B().CpyValIn(Coords, Val);
             }
             template <bool _CopyFromHost>
@@ -120,18 +120,18 @@ namespace bcuda {
             }
 #endif
             template <bool _CopyFromHost>
-            __host__ __forceinline void CpyValIn(const this_t::vector_t& Coords, const _T* Val) const {
+            __host__ __forceinline void CpyValIn(const typename this_t::vector_t& Coords, const _T* Val) const {
                 B().CpyValIn<_CopyFromHost>(Coords, Val);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyValIn(const this_t::vector_t& Coords, const _T* Val) const {
+            __device__ __forceinline void CpyValIn(const typename this_t::vector_t& Coords, const _T* Val) const {
                 B().CpyValIn(Coords, Val);
             }
 #endif
             __host__ __device__ __forceinline void CpyValOut(uint64_t Idx, _T& Val) const {
                 F().CpyValOut(Idx, Val);
             }
-            __host__ __device__ __forceinline void CpyValOut(const this_t::vector_t& Coords, _T& Val) const {
+            __host__ __device__ __forceinline void CpyValOut(const typename this_t::vector_t& Coords, _T& Val) const {
                 F().CpyValOut(Coords, Val);
             }
             template <bool _CopyToHost>
@@ -144,37 +144,37 @@ namespace bcuda {
             }
 #endif
             template <bool _CopyToHost>
-            __host__ __forceinline void CpyValOut(const this_t::vector_t& Coords, _T* Val) const {
+            __host__ __forceinline void CpyValOut(const typename this_t::vector_t& Coords, _T* Val) const {
                 F().CpyValOut<_CopyToHost>(Coords, Val);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyValOut(const this_t::vector_t& Coords, _T* Val) const {
+            __device__ __forceinline void CpyValOut(const typename this_t::vector_t& Coords, _T* Val) const {
                 F().CpyValOut(Coords, Val);
             }
 #endif
             __host__ __device__ __forceinline _T CpyValOut(uint64_t Idx) const {
                 F().CpyValOut(Idx);
             }
-            __host__ __device__ __forceinline _T CpyValOut(const this_t::vector_t& Coords) const {
+            __host__ __device__ __forceinline _T CpyValOut(const typename this_t::vector_t& Coords) const {
                 F().CpyValOut(Coords);
             }
 #pragma endregion
 
             template <bool _InputOnHost>
-            __host__ __forceinline void CopyBlockIn(const _T* Input, const this_t::vector_t& InputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const {
+            __host__ __forceinline void CopyBlockIn(const _T* Input, const typename this_t::vector_t& InputDimensions, const typename this_t::vector_t& RangeDimensions, const typename this_t::vector_t& RangeInInputsCoordinates, const typename this_t::vector_t& RangeInOutputsCoordinates) const {
                 B().CopyBlockIn<_InputOnHost>(Input, InputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CopyBlockIn(const _T* Input, const this_t::vector_t& InputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const {
+            __device__ __forceinline void CopyBlockIn(const _T* Input, const typename this_t::vector_t& InputDimensions, const typename this_t::vector_t& RangeDimensions, const typename this_t::vector_t& RangeInInputsCoordinates, const typename this_t::vector_t& RangeInOutputsCoordinates) const {
                 B().CopyBlockIn(Input, InputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #endif
             template <bool _OutputOnHost>
-            __host__ __forceinline void CopyBlockOut(_T* output, const this_t::vector_t& OutputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const {
+            __host__ __forceinline void CopyBlockOut(_T* output, const typename this_t::vector_t& OutputDimensions, const typename this_t::vector_t& RangeDimensions, const typename this_t::vector_t& RangeInInputsCoordinates, const typename this_t::vector_t& RangeInOutputsCoordinates) const {
                 F().CopyBlockOut<_OutputOnHost>(output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CopyBlockOut(_T* output, const this_t::vector_t& OutputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const {
+            __device__ __forceinline void CopyBlockOut(_T* output, const typename this_t::vector_t& OutputDimensions, const typename this_t::vector_t& RangeDimensions, const typename this_t::vector_t& RangeInInputsCoordinates, const typename this_t::vector_t& RangeInOutputsCoordinates) const {
                 F().CopyBlockOut(output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #endif

--- a/details_dfieldbase.h
+++ b/details_dfieldbase.h
@@ -27,13 +27,13 @@ namespace bcuda {
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
             __host__ __device__ __forceinline DFieldBase(_Ts... Dimensions)
-                : DFieldBase(this_t::vector_t(Dimensions...)) { }
+                : DFieldBase(typename this_t::vector_t(Dimensions...)) { }
             __host__ __device__ __forceinline DFieldBase(const typename this_t::vector_t& Dimensions, _T* ArrF, _T* ArrB)
                 : basedb_t(Dimensions), darrF(ArrF), darrB(ArrB) { }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
             __host__ __device__ __forceinline DFieldBase(_Ts... Dimensions, _T* ArrF, _T* ArrB)
-                : DFieldBase(this_t::vector_t(Dimensions...), ArrF, ArrB) { }
+                : DFieldBase(typename this_t::vector_t(Dimensions...), ArrF, ArrB) { }
 
             __host__ __device__ __forceinline size_t SizeOnGPU() const {
                 return basedb_t::ValueCount() * sizeof(_T);

--- a/details_fieldbase.h
+++ b/details_fieldbase.h
@@ -72,10 +72,10 @@ namespace bcuda {
 #ifdef __CUDACC__
             __device__ __forceinline uint64_t RefToIdx(const _T& Ref) const;
 #endif
-            __host__ __forceinline this_t::vector_t DRefToCoords(thrust::device_reference<_T> Ref) const;
-            __host__ __forceinline this_t::vector_t DRefToCoords(thrust::device_reference<const _T> Ref) const;
+            __host__ __forceinline typename this_t::vector_t DRefToCoords(thrust::device_reference<_T> Ref) const;
+            __host__ __forceinline typename this_t::vector_t DRefToCoords(thrust::device_reference<const _T> Ref) const;
 #ifdef __CUDACC__
-            __device__ __forceinline this_t::vector_t RefToCoords(const _T& Ref) const;
+            __device__ __forceinline typename this_t::vector_t RefToCoords(const _T& Ref) const;
 #endif
             __host__ __forceinline _T* DRefToPtr(thrust::device_reference<_T> Ref) const;
             __host__ __forceinline _T* DRefToPtr(thrust::device_reference<const _T> Ref) const;
@@ -210,7 +210,7 @@ __host__ __device__ __forceinline uint64_t bcuda::details::FieldBase<_T, _Dimens
     return Ptr - darr;
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline auto bcuda::details::FieldBase<_T, _DimensionCount>::PtrToCoords(const _T* Ptr) const -> this_t::vector_t {
+__host__ __device__ __forceinline auto bcuda::details::FieldBase<_T, _DimensionCount>::PtrToCoords(const _T* Ptr) const -> typename this_t::vector_t {
     return this->IdxToCoords(PtrToIdx(Ptr));
 }
 template <typename _T, size_t _DimensionCount>
@@ -236,16 +236,16 @@ __device__ __forceinline uint64_t bcuda::details::FieldBase<_T, _DimensionCount>
 }
 #endif
 template <typename _T, size_t _DimensionCount>
-__host__ __forceinline auto bcuda::details::FieldBase<_T, _DimensionCount>::DRefToCoords(thrust::device_reference<_T> Ref) const -> this_t::vector_t {
+__host__ __forceinline auto bcuda::details::FieldBase<_T, _DimensionCount>::DRefToCoords(thrust::device_reference<_T> Ref) const -> typename this_t::vector_t {
     return PtrToCoords(RefToPtr(Ref));
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __forceinline auto bcuda::details::FieldBase<_T, _DimensionCount>::DRefToCoords(thrust::device_reference<const _T> Ref) const -> this_t::vector_t {
+__host__ __forceinline auto bcuda::details::FieldBase<_T, _DimensionCount>::DRefToCoords(thrust::device_reference<const _T> Ref) const -> typename this_t::vector_t {
     return PtrToCoords(RefToPtr(Ref));
 }
 #ifdef __CUDACC__
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline auto bcuda::details::FieldBase<_T, _DimensionCount>::RefToCoords(const _T& Ref) const -> this_t::vector_t {
+__device__ __forceinline auto bcuda::details::FieldBase<_T, _DimensionCount>::RefToCoords(const _T& Ref) const -> typename this_t::vector_t {
     return PtrToCoords(RefToPtr(Ref));
 }
 #endif

--- a/details_fieldbase.h
+++ b/details_fieldbase.h
@@ -26,13 +26,13 @@ namespace bcuda {
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
             __host__ __device__ __forceinline FieldBase(_Ts... Dimensions)
-                : FieldBase(basedb_t::vector_t(Dimensions...)) { }
+                : FieldBase(typename this_t::vector_t(Dimensions...)) { }
             __host__ __device__ __forceinline FieldBase(const typename this_t::vector_t& Dimensions, _T* Arr)
                 : basedb_t(Dimensions), darr(Arr) { }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
             __host__ __device__ __forceinline FieldBase(_Ts... Dimensions, _T* Arr)
-                : FieldBase(vector_t(Dimensions...), Arr) { }
+                : FieldBase(typename this_t::vector_t(Dimensions...), Arr) { }
 #pragma endregion
 
             __host__ __device__ __forceinline size_t SizeOnGPU() const {
@@ -47,19 +47,19 @@ namespace bcuda {
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
             __host__ __device__ __forceinline _T* CoordsToPtr(_Ts... Coords) const {
-                return CoordsToPtr(vector_t(Coords...));
+                return CoordsToPtr(typename this_t::vector_t(Coords...));
             }
             __host__ __device__ __forceinline _T& CoordsToRef(const typename this_t::vector_t& Coords) const;
             __host__ __device__ __forceinline thrust::device_reference<_T> CoordsToDRef(const typename this_t::vector_t& Coords) const;
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
             __device__ __forceinline _T& CoordsToRef(_Ts... Coords) const {
-                return CoordsToRef(vector_t(Coords...));
+                return CoordsToRef(typename this_t::vector_t(Coords...));
             }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
             __host__ __forceinline thrust::device_reference<_T> CoordsToDRef(_Ts... Coords) const {
-                return CoordsToRef(vector_t(Coords...));
+                return CoordsToRef(typename this_t::vector_t(Coords...));
             }
             __host__ __device__ __forceinline uint64_t PtrToIdx(const _T* Ptr) const;
             __host__ __device__ __forceinline this_t::vector_t PtrToCoords(const _T* Ptr) const;
@@ -90,7 +90,7 @@ namespace bcuda {
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
             __device__ __forceinline _T& operator()(_Ts... Coords) const {
-                return CoordsToRef(vector_t(Coords...));
+                return CoordsToRef(typename this_t::vector_t(Coords...));
             }
 #pragma endregion
 
@@ -450,14 +450,14 @@ __forceinline size_t bcuda::details::FieldBase<_T, _DimensionCount>::SerializedS
 }
 template <typename _T, size_t _DimensionCount>
 __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::Serialize(void*& Data) const requires BSerializer::Serializable<_T> {
-    BSerializer::Serialize<this_t::vector_t>(Data, this->Dimensions());
+    BSerializer::Serialize<typename this_t::vector_t>(Data, this->Dimensions());
     size_t l = this->ValueCount();
     for (size_t i = 0; i < l; ++i)
         BSerializer::Serialize(Data, CpyValOut(i));
 }
 template <typename _T, size_t _DimensionCount>
 __forceinline auto bcuda::details::FieldBase<_T, _DimensionCount>::Deserialize(const void*& Data) -> this_t requires BSerializer::Serializable<_T> {
-    typename basedb_t::vector_t dimensions = BSerializer::Deserialize<typename basedb_t::vector_t>(Data);
+    typename this_t::vector_t dimensions = BSerializer::Deserialize<typename this_t::vector_t>(Data);
     FieldBase<_T, _DimensionCount> field(dimensions);
     size_t l = field.ValueCount();
     for (size_t i = 0; i < l; ++i)

--- a/details_fieldbase.h
+++ b/details_fieldbase.h
@@ -22,12 +22,12 @@ namespace bcuda {
             using basedb_t = DimensionedBase<_DimensionCount>;
         public:
 #pragma region Constructors
-            __host__ __device__ __forceinline FieldBase(const this_t::vector_t& Dimensions);
+            __host__ __device__ __forceinline FieldBase(const typename this_t::vector_t& Dimensions);
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
             __host__ __device__ __forceinline FieldBase(_Ts... Dimensions)
                 : FieldBase(basedb_t::vector_t(Dimensions...)) { }
-            __host__ __device__ __forceinline FieldBase(const this_t::vector_t& Dimensions, _T* Arr)
+            __host__ __device__ __forceinline FieldBase(const typename this_t::vector_t& Dimensions, _T* Arr)
                 : basedb_t(Dimensions), darr(Arr) { }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
@@ -43,14 +43,14 @@ namespace bcuda {
             __host__ __device__ __forceinline _T* IdxToPtr(uint64_t Idx) const;
             __device__ __forceinline _T& IdxToRef(uint64_t Idx) const;
             __host__ __forceinline thrust::device_reference<_T> IdxToDRef(uint64_t Idx) const;
-            __host__ __device__ __forceinline _T* CoordsToPtr(const this_t::vector_t& Coords) const;
+            __host__ __device__ __forceinline _T* CoordsToPtr(const typename this_t::vector_t& Coords) const;
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
             __host__ __device__ __forceinline _T* CoordsToPtr(_Ts... Coords) const {
                 return CoordsToPtr(vector_t(Coords...));
             }
-            __host__ __device__ __forceinline _T& CoordsToRef(const this_t::vector_t& Coords) const;
-            __host__ __device__ __forceinline thrust::device_reference<_T> CoordsToDRef(const this_t::vector_t& Coords) const;
+            __host__ __device__ __forceinline _T& CoordsToRef(const typename this_t::vector_t& Coords) const;
+            __host__ __device__ __forceinline thrust::device_reference<_T> CoordsToDRef(const typename this_t::vector_t& Coords) const;
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
             __device__ __forceinline _T& CoordsToRef(_Ts... Coords) const {
@@ -86,7 +86,7 @@ namespace bcuda {
 
 #pragma region OperatorInvoke
             __device__ __forceinline _T& operator()(uint64_t Idx) const;
-            __device__ __forceinline _T& operator()(const this_t::vector_t& Coords) const;
+            __device__ __forceinline _T& operator()(const typename this_t::vector_t& Coords) const;
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
             __device__ __forceinline _T& operator()(_Ts... Coords) const {
@@ -114,31 +114,31 @@ namespace bcuda {
 
 #pragma region CpyVal
             __host__ __device__ __forceinline void CpyValIn(uint64_t Idx, const _T& Val) const;
-            __host__ __device__ __forceinline void CpyValIn(const this_t::vector_t& Coords, const _T& Val) const;
+            __host__ __device__ __forceinline void CpyValIn(const typename this_t::vector_t& Coords, const _T& Val) const;
             template <bool _CopyFromHost>
             __host__ __forceinline void CpyValIn(uint64_t Idx, const _T* Val) const;
 #ifdef __CUDACC__
             __device__ __forceinline void CpyValIn(uint64_t Idx, const _T* Val) const;
 #endif
             template <bool _CopyFromHost>
-            __host__ __forceinline void CpyValIn(const this_t::vector_t& Coords, const _T* Val) const;
+            __host__ __forceinline void CpyValIn(const typename this_t::vector_t& Coords, const _T* Val) const;
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyValIn(const this_t::vector_t& Coords, const _T* Val) const;
+            __device__ __forceinline void CpyValIn(const typename this_t::vector_t& Coords, const _T* Val) const;
 #endif
             __host__ __device__ __forceinline void CpyValOut(uint64_t Idx, _T& Val) const;
-            __host__ __device__ __forceinline void CpyValOut(const this_t::vector_t& Coords, _T& Val) const;
+            __host__ __device__ __forceinline void CpyValOut(const typename this_t::vector_t& Coords, _T& Val) const;
             template <bool _CopyToHost>
             __host__ __forceinline void CpyValOut(uint64_t Idx, _T* Val) const;
 #ifdef __CUDACC__
             __device__ __forceinline void CpyValOut(uint64_t Idx, _T* Val) const;
 #endif
             template <bool _CopyToHost>
-            __host__ __forceinline void CpyValOut(const this_t::vector_t& Coords, _T* Val) const;
+            __host__ __forceinline void CpyValOut(const typename this_t::vector_t& Coords, _T* Val) const;
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyValOut(const this_t::vector_t& Coords, _T* Val) const;
+            __device__ __forceinline void CpyValOut(const typename this_t::vector_t& Coords, _T* Val) const;
 #endif
             __host__ __device__ __forceinline _T CpyValOut(uint64_t Idx) const;
-            __host__ __device__ __forceinline _T CpyValOut(const this_t::vector_t& Coords) const;
+            __host__ __device__ __forceinline _T CpyValOut(const typename this_t::vector_t& Coords) const;
 #pragma endregion
 
             __host__ __device__ __forceinline void Dispose();
@@ -146,14 +146,14 @@ namespace bcuda {
             __host__ __device__ __forceinline _T* Data() const;
 
             template <bool _InputOnHost>
-            __host__ __forceinline void CopyBlockIn(const _T* Input, const this_t::vector_t& InputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const;
+            __host__ __forceinline void CopyBlockIn(const _T* Input, const typename this_t::vector_t& InputDimensions, const typename this_t::vector_t& RangeDimensions, const typename this_t::vector_t& RangeInInputsCoordinates, const typename this_t::vector_t& RangeInOutputsCoordinates) const;
 #ifdef __CUDACC__
-            __device__ __forceinline void CopyBlockIn(const _T* Input, const this_t::vector_t& InputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const;
+            __device__ __forceinline void CopyBlockIn(const _T* Input, const typename this_t::vector_t& InputDimensions, const typename this_t::vector_t& RangeDimensions, const typename this_t::vector_t& RangeInInputsCoordinates, const typename this_t::vector_t& RangeInOutputsCoordinates) const;
 #endif
             template <bool _OutputOnHost>
-            __host__ __forceinline void CopyBlockOut(_T* output, const this_t::vector_t& OutputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const;
+            __host__ __forceinline void CopyBlockOut(_T* output, const typename this_t::vector_t& OutputDimensions, const typename this_t::vector_t& RangeDimensions, const typename this_t::vector_t& RangeInInputsCoordinates, const typename this_t::vector_t& RangeInOutputsCoordinates) const;
 #ifdef __CUDACC__
-            __device__ __forceinline void CopyBlockOut(_T* output, const this_t::vector_t& OutputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const;
+            __device__ __forceinline void CopyBlockOut(_T* output, const typename this_t::vector_t& OutputDimensions, const typename this_t::vector_t& RangeDimensions, const typename this_t::vector_t& RangeInInputsCoordinates, const typename this_t::vector_t& RangeInOutputsCoordinates) const;
 #endif
             
             __host__ __device__ this_t Clone() const;
@@ -169,7 +169,7 @@ namespace bcuda {
 }
 
 template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline bcuda::details::FieldBase<_T, _DimensionCount>::FieldBase(const this_t::vector_t& Dimensions)
+__host__ __device__ __forceinline bcuda::details::FieldBase<_T, _DimensionCount>::FieldBase(const typename this_t::vector_t& Dimensions)
     : basedb_t(Dimensions) {
     if (!(this->Length(0))) {
         darr = 0;
@@ -194,15 +194,15 @@ __host__ __forceinline thrust::device_reference<_T> bcuda::details::FieldBase<_T
     return *thrust::device_ptr<_T>(darr + Idx);
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline _T* bcuda::details::FieldBase<_T, _DimensionCount>::CoordsToPtr(const this_t::vector_t& Coords) const {
+__host__ __device__ __forceinline _T* bcuda::details::FieldBase<_T, _DimensionCount>::CoordsToPtr(const typename this_t::vector_t& Coords) const {
     return IdxToPtr(this->CoordsToIdx(Coords));
 }
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline _T& bcuda::details::FieldBase<_T, _DimensionCount>::CoordsToRef(const this_t::vector_t& Coords) const {
+__device__ __forceinline _T& bcuda::details::FieldBase<_T, _DimensionCount>::CoordsToRef(const typename this_t::vector_t& Coords) const {
     return IdxToRef(this->CoordsToIdx(Coords));
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __forceinline thrust::device_reference<_T> bcuda::details::FieldBase<_T, _DimensionCount>::CoordsToDRef(const this_t::vector_t& Coords) const {
+__host__ __forceinline thrust::device_reference<_T> bcuda::details::FieldBase<_T, _DimensionCount>::CoordsToDRef(const typename this_t::vector_t& Coords) const {
     return IdxToDRef(this->CoordsToIdx(Coords));
 }
 template <typename _T, size_t _DimensionCount>
@@ -268,7 +268,7 @@ __device__ __forceinline _T& bcuda::details::FieldBase<_T, _DimensionCount>::ope
     return IdxToRef(Idx);
 }
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline _T& bcuda::details::FieldBase<_T, _DimensionCount>::operator()(const this_t::vector_t& Coords) const {
+__device__ __forceinline _T& bcuda::details::FieldBase<_T, _DimensionCount>::operator()(const typename this_t::vector_t& Coords) const {
     return CoordsToRef(Coords);
 }
 template <typename _T, size_t _DimensionCount>
@@ -323,7 +323,7 @@ __host__ __device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionC
 #endif
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValIn(const this_t::vector_t& Coords, const _T& Val) const {
+__host__ __device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValIn(const typename this_t::vector_t& Coords, const _T& Val) const {
 #ifdef __CUDA_ARCH__
     memcpy(CoordsToPtr(Coords), &Val, sizeof(_T));
 #else
@@ -343,12 +343,12 @@ __device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::Cp
 #endif
 template <typename _T, size_t _DimensionCount>
 template <bool _CopyFromHost>
-__host__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValIn(const this_t::vector_t& Coords, const _T* Val) const {
+__host__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValIn(const typename this_t::vector_t& Coords, const _T* Val) const {
     cudaMemcpy(CoordsToPtr(Coords), Val, sizeof(_T), _CopyFromHost ? cudaMemcpyHostToDevice : cudaMemcpyDeviceToDevice);
 }
 #ifdef __CUDACC__
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValIn(const this_t::vector_t& Coords, const _T* Val) const {
+__device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValIn(const typename this_t::vector_t& Coords, const _T* Val) const {
     memcpy(CoordsToPtr(Coords), &Val, sizeof(_T));
 }
 #endif
@@ -361,7 +361,7 @@ __host__ __device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionC
 #endif
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(const this_t::vector_t& Coords, _T& Val) const {
+__host__ __device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(const typename this_t::vector_t& Coords, _T& Val) const {
 #ifdef __CUDA_ARCH__
     memcpy(&Val, CoordsToPtr(Coords), sizeof(_T));
 #else
@@ -381,12 +381,12 @@ __device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::Cp
 #endif
 template <typename _T, size_t _DimensionCount>
 template <bool _CopyToHost>
-__host__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(const this_t::vector_t& Coords, _T* Val) const {
+__host__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(const typename this_t::vector_t& Coords, _T* Val) const {
     cudaMemcpy(Val, CoordsToPtr(Coords), sizeof(_T), _CopyToHost ? cudaMemcpyDeviceToHost : cudaMemcpyDeviceToDevice);
 }
 #ifdef __CUDACC__
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(const this_t::vector_t& Coords, _T* Val) const {
+__device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(const typename this_t::vector_t& Coords, _T* Val) const {
     memcpy(Val, CoordsToPtr(Coords), sizeof(_T));
 }
 #endif
@@ -397,7 +397,7 @@ __host__ __device__ __forceinline _T bcuda::details::FieldBase<_T, _DimensionCou
     return val;
 }
 template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline _T bcuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(const this_t::vector_t& Coords) const {
+__host__ __device__ __forceinline _T bcuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(const typename this_t::vector_t& Coords) const {
     _T val;
     CpyValOut(Coords, val);
     return val;
@@ -416,23 +416,23 @@ __host__ __device__ __forceinline _T* bcuda::details::FieldBase<_T, _DimensionCo
 }
 template <typename _T, size_t _DimensionCount>
 template <bool _InputOnHost>
-__host__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CopyBlockIn(const _T* Input, const this_t::vector_t& InputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const {
+__host__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CopyBlockIn(const _T* Input, const typename this_t::vector_t& InputDimensions, const typename this_t::vector_t& RangeDimensions, const typename this_t::vector_t& RangeInInputsCoordinates, const typename this_t::vector_t& RangeInOutputsCoordinates) const {
     CopyBlock<_T, _DimensionCount, _InputOnHost, false, true>(Input, darr, InputDimensions, this->Dimensions(), RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
 }
 #ifdef __CUDACC__
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CopyBlockIn(const _T* Input, const this_t::vector_t& InputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const {
+__device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CopyBlockIn(const _T* Input, const typename this_t::vector_t& InputDimensions, const typename this_t::vector_t& RangeDimensions, const typename this_t::vector_t& RangeInInputsCoordinates, const typename this_t::vector_t& RangeInOutputsCoordinates) const {
     CopyBlock<_T, _DimensionCount, true>(Input, darr, InputDimensions, this->Dimensions(), RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
 }
 #endif
 template <typename _T, size_t _DimensionCount>
 template <bool _OutputOnHost>
-__host__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CopyBlockOut(_T* output, const this_t::vector_t& OutputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const {
+__host__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CopyBlockOut(_T* output, const typename this_t::vector_t& OutputDimensions, const typename this_t::vector_t& RangeDimensions, const typename this_t::vector_t& RangeInInputsCoordinates, const typename this_t::vector_t& RangeInOutputsCoordinates) const {
     CopyBlock<_T, _DimensionCount, false, _OutputOnHost, true>(darr, output, this->Dimensions(), OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
 }
 #ifdef __CUDACC__
 template <typename _T, size_t _DimensionCount>
-__device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CopyBlockOut(_T* output, const this_t::vector_t& OutputDimensions, const this_t::vector_t& RangeDimensions, const this_t::vector_t& RangeInInputsCoordinates, const this_t::vector_t& RangeInOutputsCoordinates) const {
+__device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CopyBlockOut(_T* output, const typename this_t::vector_t& OutputDimensions, const typename this_t::vector_t& RangeDimensions, const typename this_t::vector_t& RangeInInputsCoordinates, const typename this_t::vector_t& RangeInOutputsCoordinates) const {
     CopyBlock<_T, _DimensionCount, true>(darr, output, this->Dimensions(), OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
 }
 #endif

--- a/details_mfieldbase.h
+++ b/details_mfieldbase.h
@@ -90,7 +90,7 @@ namespace bcuda {
                         darrs[i] = 0;
                     return;
                 }
-                RunFunctionsOverTypeWrapper<MFieldBase_MallocMem, 0, _Ts...>::RunFunctionsOverType((void**)&darrs, basedb_t::ValueCount());
+                RunFunctionsOverTypeWrapper<MFieldBase_MallocMem, 0, _Ts...>::template RunFunctionsOverType((void**)&darrs, basedb_t::ValueCount());
             }
             __host__ __device__ __forceinline MFieldBase(const typename this_t::vector_t& Dimensions, void* const* Arrays)
                 : basedb_t(Dimensions) {
@@ -138,22 +138,22 @@ namespace bcuda {
 
             __host__ __device__ this_t Clone() const {
                 this_t clone(this->Dimensions());
-                RunFunctionsOverTypeWrapper<MFieldBase_Clone, 0, _Ts...>::RunFunctionsOverType(&clone.darrs, (void**)&darrs, basedb_t::ValueCount());
+                RunFunctionsOverTypeWrapper<MFieldBase_Clone, 0, _Ts...>::template RunFunctionsOverType(&clone.darrs, (void**)&darrs, basedb_t::ValueCount());
                 return clone;
             }
 
             __forceinline size_t SerializedSize() const requires (BSerializer::Serializable<_Ts> && ...) {
                 size_t t = sizeof(typename this_t::vector_t);
-                RunFunctionsOverTypeWrapper<MFieldBase_SerializedSize_Wrapper<_DimensionCount>::MFieldBase_SerializedSize, 0, _Ts...>::RunFunctionsOverType((void**)&darrs, basedb_t::ValueCount(), basedb_t::Dimensions(), t);
+                RunFunctionsOverTypeWrapper<MFieldBase_SerializedSize_Wrapper<_DimensionCount>::template MFieldBase_SerializedSize, 0, _Ts...>::template RunFunctionsOverType((void**)&darrs, basedb_t::ValueCount(), basedb_t::Dimensions(), t);
             }
             __forceinline void Serialize(void*& Data) const requires (BSerializer::Serializable<_Ts> && ...) {
                 BSerializer::Serialize(Data, basedb_t::Dimensions());
-                RunFunctionsOverTypeWrapper<MFieldBase_Serialize_Wrapper<_DimensionCount>::MFieldBase_Serialize, 0, _Ts...>::RunFunctionOverType((void**)&darrs, basedb_t::ValueCount(), basedb_t::Dimensions(), Data);
+                RunFunctionsOverTypeWrapper<MFieldBase_Serialize_Wrapper<_DimensionCount>::template MFieldBase_Serialize, 0, _Ts...>::template RunFunctionOverType((void**)&darrs, basedb_t::ValueCount(), basedb_t::Dimensions(), Data);
             }
             static __forceinline this_t Deserialize(const void*& Data) requires (BSerializer::Serializable<_Ts> && ...) {
                 typename this_t::vector_t dims = BSerializer::Deserialize<typename this_t::vector_t>(Data);
                 this_t value(dims);
-                RunFunctionsOverTypeWrapper<MFieldBase_Deserialize_Wrapper<_DimensionCount>::MFieldBase_Deserialize, 0, _Ts...>::RunFunctionOverType((void**)&value.darrs, basedb_t::ValueCount(), basedb_t::Dimensions(), Data);
+                RunFunctionsOverTypeWrapper<MFieldBase_Deserialize_Wrapper<_DimensionCount>::template MFieldBase_Deserialize, 0, _Ts...>::template RunFunctionOverType((void**)&value.darrs, basedb_t::ValueCount(), basedb_t::Dimensions(), Data);
                 return value;
             }
             static __forceinline void Deserialize(const void*& Data, void* Value) requires (BSerializer::Serializable<_Ts> && ...) {

--- a/fields_dfield.h
+++ b/fields_dfield.h
@@ -25,7 +25,7 @@ namespace bcuda {
             using basefb_t = details::DFieldBase<_T, _DimensionCount>;
             using basedb_t = DimensionedBase<_DimensionCount>;
         public:
-            using vector_t = basefb_t::vector_t;
+            using vector_t = typename basefb_t::vector_t;
             using kernelFunc_t = details::dfieldIK_t<_T, _DimensionCount>;
 
 #pragma region Wrapper
@@ -256,7 +256,7 @@ namespace bcuda {
             using basefb_t = details::DFieldBase<_T, _DimensionCount>;
             using basedb_t = DimensionedBase<_DimensionCount>;
         public:
-            using vector_t = basefb_t::vector_t;
+            using vector_t = typename basefb_t::vector_t;
             using kernelFunc_t = details::dfieldIK_t<_T, _DimensionCount>;
 
 #pragma region Wrapper
@@ -439,7 +439,7 @@ namespace bcuda {
             using basefb_t = details::DFieldBase<_T, _DimensionCount>;
             using basedb_t = DimensionedBase<_DimensionCount>;
         public:
-            using vector_t = basefb_t::vector_t;
+            using vector_t = typename basefb_t::vector_t;
 
 #pragma region Wrapper
             __host__ __device__ DFieldProxyConst(const vector_t& Dimensions, const _T* ArrF, const _T* ArrB)

--- a/fields_field.h
+++ b/fields_field.h
@@ -21,7 +21,7 @@ namespace bcuda {
             using basefb_t = details::FieldBase<_T, _DimensionCount>;
             using basedb_t = DimensionedBase<_DimensionCount>;
         public:
-            using vector_t = basedb_t::vector_t;
+            using vector_t = typename basedb_t::vector_t;
 
 #pragma region Wrapper
             __host__ __device__ __forceinline Field(const vector_t& Dimensions)
@@ -382,7 +382,7 @@ namespace bcuda {
             using basefb_t = details::FieldBase<_T, _DimensionCount>;
             using basedb_t = DimensionedBase<_DimensionCount>;
         public:
-            using vector_t = basedb_t::vector_t;
+            using vector_t = typename basedb_t::vector_t;
 
 #pragma region Wrapper
             __host__ __device__ __forceinline FieldProxy(const vector_t& Dimensions, _T* All)
@@ -647,7 +647,7 @@ namespace bcuda {
             using basefb_t = details::FieldBase<_T, _DimensionCount>;
             using basedb_t = DimensionedBase<_DimensionCount>;
         public:
-            using vector_t = basedb_t::vector_t;
+            using vector_t = typename basedb_t::vector_t;
 
 #pragma region Wrapper
             __host__ __device__ __forceinline FieldProxyConst(const vector_t& Dimensions, const _T* All)

--- a/fields_mdfield.h
+++ b/fields_mdfield.h
@@ -32,7 +32,7 @@ namespace bcuda {
                 using type_t = void(*)(const FixedVector<uint32_t, _DimensionCount>& Pos, const idx_fieldType_t<_Idxs>&... Prevs, idx_type_t<_Idxs>&... Next);
             };
 
-            using type_t = Type2<std::make_index_sequence<size>>::type_t;
+            using type_t = typename Type2<std::make_index_sequence<size>>::type_t;
         };
 
         template <size_t _DimensionCount, typename _TTypes, typename _TPublics>
@@ -56,7 +56,7 @@ namespace bcuda {
             using basemf_t = MField<_DimensionCount, _Ts..., _Ts...>;
             basemf_t fields;
         public:
-            using vector_t = basemf_t::vector_t;
+            using vector_t = typename basemf_t::vector_t;
             using tuple_t = std::tuple<_Ts...>;
             template <size_t _Idx>
             using element_t = std::tuple_element_t<_Idx, tuple_t>;
@@ -201,7 +201,7 @@ namespace bcuda {
             using basemf_t = MFieldProxy<_DimensionCount, _Ts..., _Ts...>;
             basemf_t fields;
         public:
-            using vector_t = basemf_t::vector_t;
+            using vector_t = typename basemf_t::vector_t;
             using tuple_t = std::tuple<_Ts...>;
             template <size_t _Idx>
             using element_t = std::tuple_element_t<_Idx, tuple_t>;
@@ -309,7 +309,7 @@ namespace bcuda {
             using basemf_t = MFieldProxyConst<_DimensionCount, _Ts..., _Ts...>;
             basemf_t fields;
         public:
-            using vector_t = basemf_t::vector_t;
+            using vector_t = typename basemf_t::vector_t;
             using tuple_t = std::tuple<_Ts...>;
             template <size_t _Idx>
             using element_t = std::tuple_element_t<_Idx, tuple_t>;

--- a/fields_mfield.h
+++ b/fields_mfield.h
@@ -22,10 +22,10 @@ namespace bcuda {
             using basefb_t = details::MFieldBase<_DimensionCount, _Ts...>;
             using basedb_t = DimensionedBase<_DimensionCount>;
         public:
-            using vector_t = basefb_t::vector_t;
-            using tuple_t = basefb_t::tuple_t;
+            using vector_t = typename basefb_t::vector_t;
+            using tuple_t = typename basefb_t::tuple_t;
             template <size_t _Idx>
-            using element_t = basefb_t::template element_t<_Idx>;
+            using element_t = typename basefb_t::template element_t<_Idx>;
 
 #pragma region Wrapper
             __host__ __device__ __forceinline MField(const vector_t& Dimensions)
@@ -147,10 +147,10 @@ namespace bcuda {
             using basefb_t = details::MFieldBase<_DimensionCount, _Ts...>;
             using basedb_t = DimensionedBase<_DimensionCount>;
         public:
-            using vector_t = basefb_t::vector_t;
-            using tuple_t = basefb_t::tuple_t;
+            using vector_t = typename basefb_t::vector_t;
+            using tuple_t = typename basefb_t::tuple_t;
             template <size_t _Idx>
-            using element_t = basefb_t::template element_t<_Idx>;
+            using element_t = typename basefb_t::template element_t<_Idx>;
 
 #pragma region Wrapper
             __host__ __device__ __forceinline uint32_t LengthX() const requires (_DimensionCount <= 4) {
@@ -233,10 +233,10 @@ namespace bcuda {
             using basefb_t = details::MFieldBase<_DimensionCount, _Ts...>;
             using basedb_t = DimensionedBase<_DimensionCount>;
         public:
-            using vector_t = basefb_t::vector_t;
-            using tuple_t = basefb_t::tuple_t;
+            using vector_t = typename basefb_t::vector_t;
+            using tuple_t = typename basefb_t::tuple_t;
             template <size_t _Idx>
-            using element_t = basefb_t::template element_t<_Idx>;
+            using element_t = typename basefb_t::template element_t<_Idx>;
 
 #pragma region Wrapper
             __host__ __device__ __forceinline uint32_t LengthX() const requires (_DimensionCount <= 4) {

--- a/packs.h
+++ b/packs.h
@@ -42,7 +42,7 @@ namespace bcuda {
         namespace details {
             template <typename _T, uintmax_t _LayerCount>
             struct RecursivePassingParam {
-                using type_t = PassingParam<RecursivePassingParam<_T, _LayerCount - 1>::type_t>;
+                using type_t = PassingParam<typename RecursivePassingParam<_T, _LayerCount - 1>::type_t>;
             };
             template <typename _T>
             struct RecursivePassingParam<_T, 0> {
@@ -51,7 +51,7 @@ namespace bcuda {
         }
 
         template <IsPack _T, uintmax_t _LayerCount>
-        using recursivePassingParams_t = details::RecursivePassingParam<_T, _LayerCount>::type_t;
+        using recursivePassingParams_t = typename details::RecursivePassingParam<_T, _LayerCount>::type_t;
 
         namespace details {
             template <typename _T>
@@ -72,9 +72,9 @@ namespace bcuda {
         }
 
         template <typename _T>
-        using bringOutInside_t = details::bringOut<_T>::type_t;
+        using bringOutInside_t = typename details::bringOut<_T>::type_t;
         template <typename _T>
-        using bringOutInsideBatch_t = details::bringOutBatch<_T>::type_t;
+        using bringOutInsideBatch_t = typename details::bringOutBatch<_T>::type_t;
 
         namespace details {
             template <typename _T>
@@ -127,12 +127,12 @@ namespace bcuda {
 
             template <typename _T1, typename _T2, typename... _Ts>
             struct addPacks<_T1, _T2, _Ts...> {
-                using type_t = addPacks<addPacks<_T1, _T2>::type_t, _Ts...>::type_t;
+                using type_t = typename addPacks<addPacks<_T1, _T2>::type_t, _Ts...>::type_t;
             };
         }
 
         template <typename... _Ts>
-        using combine_t = details::addPacks<_Ts...>::type_t;
+        using combine_t = typename details::addPacks<_Ts...>::type_t;
 
         namespace details {
             template <template <typename...> typename _T, typename _TPack>
@@ -144,6 +144,6 @@ namespace bcuda {
         }
 
         template <template <typename...> typename _T, IsPack _TPack>
-        using appliedPack_t = details::applyPack<_T, _Pack>::type_t;
+        using appliedPack_t = typename details::applyPack<_T, _Pack>::type_t;
     }
 }


### PR DESCRIPTION
Corrected `template`/`typename` keyword usage for nested types. Specifically, in the qualified references to such types. See diffs for details.