### PR TITLE
Fixed `__host__` and `__device__` modifiers for field-related functions

### DIFF
--- a/details_mfieldbase.h
+++ b/details_mfieldbase.h
@@ -159,7 +159,7 @@ namespace bcuda {
             static __forceinline void Deserialize(const void*& Data, void* Value) requires (BSerializer::Serializable<_Ts> && ...) {
                 new (Value) this_t(Deserialize(Data));
             }
-            __forceinline void* const* FieldDataArray() const {
+            __host__ __device__ __forceinline void* const* FieldDataArray() const {
                 return darrs;
             }
         private:

--- a/fields_mdfield.h
+++ b/fields_mdfield.h
@@ -169,10 +169,10 @@ namespace bcuda {
                 details::MFieldBase<_DimensionCount, _Ts..., _Ts...>(Data, Value);
             }
 
-            __host__ __device__ __forceinline MDField(const this_t&) = default;
-            __host__ __device__ __forceinline MDField(this_t&&) = default;
-            __host__ __device__ __forceinline this_t& operator=(const this_t&) = default;
-            __host__ __device__ __forceinline this_t& operator=(this_t&&) = default;
+            __forceinline MDField(const this_t&) = default;
+            __forceinline MDField(this_t&&) = default;
+            __forceinline this_t& operator=(const this_t&) = default;
+            __forceinline this_t& operator=(this_t&&) = default;
 
             __host__ __device__ __forceinline MDFieldProxy<_DimensionCount, _Ts...> MakeProxy() {
                 return MDFieldProxy<_DimensionCount, _Ts...>(*this);


### PR DESCRIPTION
Added `__host__ __device__` modifiers to function `BrendanCUDA::details::MFieldBase::FieldDataArray()`, and removed all CUDA modifiers from all `= default` functions.