### PR TITLE
Corrected `template`/`typename` keyword usage in `fields_mfield.h`

### DIFF
--- a/fields_mfield.h
+++ b/fields_mfield.h
@@ -82,19 +82,19 @@ namespace bcuda {
                 return basefb_t::TotalSizeOnGPU();
             }
             template <size_t _Idx>
-            __host__ __device__ fields::FieldProxy<this_t::template element_t<_Idx>, _DimensionCount> F() {
+            __host__ __device__ fields::FieldProxy<element_t<_Idx>, _DimensionCount> F() {
                 return basefb_t::template F<_Idx>();
             }
             template <size_t _Idx>
-            __host__ __device__ fields::FieldProxyConst<this_t::template element_t<_Idx>, _DimensionCount> FConst() const {
+            __host__ __device__ fields::FieldProxyConst<element_t<_Idx>, _DimensionCount> FConst() const {
                 return basefb_t::template FConst<_Idx>();
             }
             template <size_t _Idx>
-            __host__ __device__ this_t::template element_t<_Idx>* FData() {
+            __host__ __device__ element_t<_Idx>* FData() {
                 return basefb_t::template FData<_Idx>();
             }
             template <size_t _Idx>
-            __host__ __device__ const this_t::template element_t<_Idx>* FData() const {
+            __host__ __device__ const element_t<_Idx>* FData() const {
                 return basefb_t::template FData<_Idx>();
             }
             __forceinline size_t SerializedSize() const requires (BSerializer::Serializable<_Ts> && ...) {


### PR DESCRIPTION
Corrected `template`/`typename` keyword usage in `fields_mfield.h`. This completes what is hopefully the remainder of the progress made by #20 that was supposed to fix the entire project.