### PR TITLE
Adding missing includes to file `errorhelp.h`

### DIFF
--- a/errorhelp.h
+++ b/errorhelp.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <concepts>
+#include <type_traits>
+
 namespace bcuda {
     template <typename _T>
         requires (std::is_enum_v<_T> || std::integral<_T>)


### PR DESCRIPTION
Adding missing includes to file `errorhelp.h`. Specifically, added

* `#include <concepts>` for `std::integral<_T>` on line 8 and added
* `#include <type_traits>` for `std::is_enum_v<_T>` on line 8,

where previously there were no includes.