### PR TITLE
Fixing `CopyBlock` instantiation errors

### DIFF
--- a/BrendanCUDA.vcxproj
+++ b/BrendanCUDA.vcxproj
@@ -140,13 +140,13 @@
   <ItemGroup>
     <CudaCompile Include="ai.cu" />
     <CudaCompile Include="binary_basic.cu" />
+    <CudaCompile Include="copyblock.cu" />
     <CudaCompile Include="details_fillwith.cu" />
     <CudaCompile Include="nets_makenet.cu" />
     <CudaCompile Include="nets_net.cu" />
     <CudaCompile Include="rand_randomizer.cu" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="copyblock.cpp" />
     <ClCompile Include="ai_evol_evolver.cpp" />
     <ClCompile Include="ai_evol_eval_output_impl_proliferation.cpp" />
     <ClCompile Include="ai_evol_eval_output_impl_uniquevalues.cpp" />

--- a/BrendanCUDA.vcxproj.filters
+++ b/BrendanCUDA.vcxproj.filters
@@ -153,15 +153,15 @@
     <CudaCompile Include="rand_randomizer.cu">
       <Filter>Source Files</Filter>
     </CudaCompile>
+    <CudaCompile Include="copyblock.cu">
+      <Filter>Source Files</Filter>
+    </CudaCompile>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ai_evol_eval_output_impl_proliferation.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="ai_evol_eval_output_impl_uniquevalues.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="copyblock.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="ai_evol_evolver.cpp">

--- a/copyblock.cu
+++ b/copyblock.cu
@@ -38,5 +38,6 @@ __host__ __device__ bcuda::ArrayV<bcuda::details::Landmark> bcuda::details::GetL
     }
     ArrayV<Landmark> landmarkArray(landmarkSize);
     if (landmarks) memcpy(landmarkArray.Data(), landmarks, sizeof(Landmark) * landmarkSize);
+    delete[] landmarks;
     return landmarkArray;
 }

--- a/copyblock.cu
+++ b/copyblock.cu
@@ -1,15 +1,27 @@
 #include "copyblock.h"
-#include <vector>
 
 __host__ __device__ bcuda::ArrayV<bcuda::details::Landmark> bcuda::details::GetLandmarksInDirection(uint32_t InputLength, uint32_t OutputLength, uint32_t RangeLength, uint32_t InputIndex, uint32_t OutputIndex) {
-    std::vector<Landmark> landmarks;
+    Landmark* landmarks = 0;
+    size_t landmarkSize = 0;
+    size_t landmarkCapacity = 0;
+
     while (RangeLength) {
         uint32_t dInput = InputLength - InputIndex;
         uint32_t dOutput = OutputLength - OutputIndex;
         bool oG = dOutput > dInput;
         uint32_t dMin = oG ? dInput : dOutput;
         if (dMin >= RangeLength) break;
-        landmarks.push_back(Landmark(InputIndex, OutputIndex, dMin));
+
+        if (landmarkCapacity <= landmarkSize + 1) {
+            if (landmarkCapacity == 0) landmarkCapacity = 1;
+            else landmarkCapacity <<= 1;
+            Landmark* newArr = new Landmark[landmarkCapacity];
+            memcpy(newArr, landmarks, landmarkSize * sizeof(Landmark));
+            delete[] landmarks;
+            landmarks = newArr;
+        }
+        landmarks[landmarkSize++] = Landmark(InputIndex, OutputIndex, dMin);
+
         if (oG) {
             InputIndex = 0;
             OutputIndex += dMin;
@@ -24,7 +36,7 @@ __host__ __device__ bcuda::ArrayV<bcuda::details::Landmark> bcuda::details::GetL
         }
         RangeLength -= dMin;
     }
-    ArrayV<Landmark> landmarkArray(landmarks.size());
-    std::copy(landmarks.data(), landmarks.data() + landmarks.size(), landmarkArray.Data());
+    ArrayV<Landmark> landmarkArray(landmarkSize);
+    if (landmarks) memcpy(landmarkArray.Data(), landmarks, sizeof(Landmark) * landmarkSize);
     return landmarkArray;
 }

--- a/copyblock.h
+++ b/copyblock.h
@@ -20,46 +20,7 @@ namespace bcuda {
             }
         };
 
-        __host__ __device__ static __forceinline ArrayV<Landmark> GetLandmarksInDirection(uint32_t InputLength, uint32_t OutputLength, uint32_t RangeLength, uint32_t InputIndex, uint32_t OutputIndex) {
-            Landmark* landmarks = 0;
-            size_t landmarkSize = 0;
-            size_t landmarkCapacity = 0;
-
-            while (RangeLength) {
-                uint32_t dInput = InputLength - InputIndex;
-                uint32_t dOutput = OutputLength - OutputIndex;
-                bool oG = dOutput > dInput;
-                uint32_t dMin = oG ? dInput : dOutput;
-                if (dMin >= RangeLength) break;
-
-                if (landmarkCapacity <= landmarkSize + 1) {
-                    if (landmarkCapacity == 0) landmarkCapacity = 1;
-                    else landmarkCapacity <<= 1;
-                    Landmark* newArr = new Landmark[landmarkCapacity];
-                    memcpy(newArr, landmarks, landmarkSize * sizeof(Landmark));
-                    delete[] landmarks;
-                    landmarks = newArr;
-                }
-                landmarks[landmarkSize++] = Landmark(InputIndex, OutputIndex, dMin);
-
-                if (oG) {
-                    InputIndex = 0;
-                    OutputIndex += dMin;
-                }
-                else if (dInput == dOutput) {
-                    InputIndex = 0;
-                    OutputIndex = 0;
-                }
-                else {
-                    InputIndex += dMin;
-                    OutputIndex = 0;
-                }
-                RangeLength -= dMin;
-            }
-            ArrayV<Landmark> landmarkArray(landmarkSize);
-            if (landmarks) memcpy(landmarkArray.Data(), landmarks, sizeof(Landmark) * landmarkSize);
-            return landmarkArray;
-        }
+        __host__ __device__ ArrayV<Landmark> GetLandmarksInDirection(uint32_t InputLength, uint32_t OutputLength, uint32_t RangeLength, uint32_t InputIndex, uint32_t OutputIndex);
     }
     template <typename _T, size_t _VectorLength, bool _InputOnHost, bool _OutputOnHost, bool _Wrap = false>
     __host__ static void CopyBlock(const _T* Input, _T* output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates);


### PR DESCRIPTION
Fixed `CopyBlock` instantiation and linking errors, which included

* renaming file `copyblock.cpp` to `copyblock.cu`, and changing the compiler used accordingly; and
* replacing use of `std::vector` with a custom-built system, and removing `#include <vector>`.