### PR TITLE
Fixing bugs in `bcuda::CopyBlock` functions

### DIFF
--- a/copyblock.cu
+++ b/copyblock.cu
@@ -10,7 +10,7 @@ __host__ __device__ bcuda::ArrayV<bcuda::details::Landmark> bcuda::details::GetL
         uint32_t dOutput = OutputLength - OutputIndex;
         bool oG = dOutput > dInput;
         uint32_t dMin = oG ? dInput : dOutput;
-        if (dMin >= RangeLength) break;
+        if (dMin > RangeLength) dMin = RangeLength;
 
         if (landmarkCapacity <= landmarkSize + 1) {
             if (landmarkCapacity == 0) landmarkCapacity = 1;

--- a/copyblock.h
+++ b/copyblock.h
@@ -151,7 +151,7 @@ __device__ void bcuda::CopyBlock(const _T* Input, _T* Output, const FixedVector<
             memcpy(Output + RangeInOutputsCoordinates.x, Input + RangeInInputsCoordinates.x, sizeof(_T) * RangeDimensions.x);
             return;
         }
-        size_t elementNum = RangeDimensions[_VectorLength - 1];
+        size_t elementNum = RangeDimensions[0];
         size_t memcpySize = sizeof(_T) * elementNum;
         vector_t i;
         while (true) {
@@ -219,7 +219,7 @@ __host__ __device__ void bcuda::CopyBlock(const _T* Input, _T* Output, const Fix
                 _CopyValFunc(Output + RangeInOutputsCoordinates.x, Input + RangeInInputsCoordinates.x);
             return;
         }
-        size_t elementNum = RangeDimensions[_VectorLength - 1];
+        size_t elementNum = RangeDimensions[0];
         vector_t i;
         while (true) {
             size_t iptIdx = CoordinatesToIndex<size_t, uint32_t, _VectorLength, true>(InputDimensions, RangeInInputsCoordinates + i);
@@ -285,7 +285,7 @@ __host__ __device__ void bcuda::CopyBlock(const _T* Input, _T* Output, const Fix
             _CopyArrFunc(Output + RangeInOutputsCoordinates.x, Input + RangeInInputsCoordinates.x, RangeDimensions.x);
             return;
         }
-        size_t elementNum = RangeDimensions[_VectorLength - 1];
+        size_t elementNum = RangeDimensions[0];
         vector_t i;
         while (true) {
             size_t iptIdx = CoordinatesToIndex<size_t, uint32_t, _VectorLength, true>(InputDimensions, RangeInInputsCoordinates + i);

--- a/copyblock.h
+++ b/copyblock.h
@@ -118,7 +118,7 @@ __device__ void bcuda::CopyBlock(const _T* Input, _T* Output, const FixedVector<
     if constexpr (_Wrap) {
         ArrayV<details::Landmark> landmarksArray[_VectorLength];
         for (size_t i = 0; i < _VectorLength; ++i)
-            landmarksArray[i] = details::GetLandmarksInDirection(InputDimensions[i], OutputDimensions[i], RangeDimensions[i], RangeInInputsCoordinates[i], RangeInOutputsCoordinates[i]);
+            new (landmarksArray + i) ArrayV<details::Landmark>(details::GetLandmarksInDirection(InputDimensions[i], OutputDimensions[i], RangeDimensions[i], RangeInInputsCoordinates[i], RangeInOutputsCoordinates[i]));
         
         vector_t i;
         while (true) {
@@ -185,7 +185,7 @@ __host__ __device__ void bcuda::CopyBlock(const _T* Input, _T* Output, const Fix
     if constexpr (_Wrap) {
         ArrayV<details::Landmark> landmarksArray[_VectorLength];
         for (size_t i = 0; i < _VectorLength; ++i)
-            landmarksArray[i] = details::GetLandmarksInDirection(InputDimensions[i], OutputDimensions[i], RangeDimensions[i], RangeInInputsCoordinates[i], RangeInOutputsCoordinates[i]);
+            new (landmarksArray + i) ArrayV<details::Landmark>(details::GetLandmarksInDirection(InputDimensions[i], OutputDimensions[i], RangeDimensions[i], RangeInInputsCoordinates[i], RangeInOutputsCoordinates[i]));
 
         vector_t i;
         while (true) {
@@ -252,7 +252,7 @@ __host__ __device__ void bcuda::CopyBlock(const _T* Input, _T* Output, const Fix
     if constexpr (_Wrap) {
         ArrayV<details::Landmark> landmarksArray[_VectorLength];
         for (size_t i = 0; i < _VectorLength; ++i)
-            landmarksArray[i] = details::GetLandmarksInDirection(InputDimensions[i], OutputDimensions[i], RangeDimensions[i], RangeInInputsCoordinates[i], RangeInOutputsCoordinates[i]);
+            new (landmarksArray + i) ArrayV<details::Landmark>(details::GetLandmarksInDirection(InputDimensions[i], OutputDimensions[i], RangeDimensions[i], RangeInInputsCoordinates[i], RangeInOutputsCoordinates[i]));
 
         vector_t i;
         while (true) {

--- a/copyblock.h
+++ b/copyblock.h
@@ -80,7 +80,7 @@ __host__ void bcuda::CopyBlock(const _T* Input, _T* Output, const FixedVector<ui
                 else cudaMemcpy(Output + RangeInOutputsCoordinates.x, Input + RangeInInputsCoordinates.x, sizeof(_T) * RangeDimensions.x, cudaMemcpyDeviceToDevice);
             return;
         }
-        size_t elementNum = RangeDimensions[_VectorLength - 1];
+        size_t elementNum = RangeDimensions[0];
         size_t memcpySize = sizeof(_T) * elementNum;
         vector_t i;
         while (true) {

--- a/copyblock.h
+++ b/copyblock.h
@@ -42,7 +42,7 @@ __host__ void bcuda::CopyBlock(const _T* Input, _T* Output, const FixedVector<ui
     if constexpr (_Wrap) {
         ArrayV<details::Landmark> landmarksArray[_VectorLength];
         for (size_t i = 0; i < _VectorLength; ++i)
-            landmarksArray[i] = details::GetLandmarksInDirection(InputDimensions[i], OutputDimensions[i], RangeDimensions[i], RangeInInputsCoordinates[i], RangeInOutputsCoordinates[i]);
+            new (landmarksArray + i) ArrayV<details::Landmark>(details::GetLandmarksInDirection(InputDimensions[i], OutputDimensions[i], RangeDimensions[i], RangeInInputsCoordinates[i], RangeInOutputsCoordinates[i]));
         
         vector_t i;
         while (true) {


### PR DESCRIPTION
Fixed bugs in `bcuda::CopyBlock` functions. This includes bugs such as

* simply straight up forgetting to copy wrapped-around partitions,
* (caused by but a subset of) premature exits of the while loop,
* deletion of garbage pointers, and
* using the wrong dimension as the one whose elements are expected to be consecutive.