### PR TITLE
Adding project build dependency BSerializer to BrendanCUDA

### DIFF
--- a/BrendanCUDA.sln
+++ b/BrendanCUDA.sln
@@ -4,6 +4,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 17.9.34607.119
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "BrendanCUDA", "BrendanCUDA.vcxproj", "{AA54D43E-9928-45D9-B2DE-1F878F8B000B}"
+	ProjectSection(ProjectDependencies) = postProject
+		{E44BCDF6-B619-48D3-87EA-4EC12179219A} = {E44BCDF6-B619-48D3-87EA-4EC12179219A}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "BSerializer", "BSerializer\BSerializer.vcxproj", "{E44BCDF6-B619-48D3-87EA-4EC12179219A}"
 EndProject


### PR DESCRIPTION
Despite BSerializer and BrendanCUDA coexisting in the same solution for some time, with BrendanCUDA dependent on BSerializer, a project dependency was never created. This was likely overlooked since BSerializer is exclusively templates and headers -- no compilation necessary. Now, this oversight is resolved.