### PR TITLE
Adding file `uniqueid.h` for the creation of unique IDs

### DIFF
--- a/BrendanCUDA.vcxproj
+++ b/BrendanCUDA.vcxproj
@@ -136,6 +136,7 @@
     <ClInclude Include="rand_randomizer.h" />
     <ClInclude Include="threadid.h" />
     <ClInclude Include="rand_bits.h" />
+    <ClInclude Include="uniqueid.h" />
   </ItemGroup>
   <ItemGroup>
     <CudaCompile Include="ai.cu" />
@@ -150,6 +151,7 @@
     <ClCompile Include="ai_evol_evolver.cpp" />
     <ClCompile Include="ai_evol_eval_output_impl_proliferation.cpp" />
     <ClCompile Include="ai_evol_eval_output_impl_uniquevalues.cpp" />
+    <ClCompile Include="uniqueid.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/BrendanCUDA.vcxproj.filters
+++ b/BrendanCUDA.vcxproj.filters
@@ -133,6 +133,9 @@
     <ClInclude Include="allheaders.cuh">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="uniqueid.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <CudaCompile Include="ai.cu">
@@ -165,6 +168,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="ai_evol_evolver.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="uniqueid.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/uniqueid.cpp
+++ b/uniqueid.cpp
@@ -1,0 +1,10 @@
+#include "uniqueid.h"
+
+#include <atomic>
+
+namespace bcuda {
+    std::uint64_t GetUniqueIdForThisAppInstance() {
+        static std::atomic_uint64_t idCounter(0);
+        return idCounter.fetch_add(1);
+    }
+}

--- a/uniqueid.h
+++ b/uniqueid.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <cstdint>
+
+namespace bcuda {
+    std::uint64_t GetUniqueIdForThisAppInstance();
+}


### PR DESCRIPTION
Added file `uniqueid.h` for the creation of unique IDs. File `uniqueid.h` features function `bcuda::GetUniqueIdForThisAppInstance()`, which creates a unique ID which will be unique inside the running application for the life of the running application.