### PR TITLE
Mass refactoring of conventions

### DIFF
--- a/ai.cu
+++ b/ai.cu
@@ -179,19 +179,19 @@ __global__ void convertInt32sToFloatsKernel(uint32_t* Int32s, double* Doubles, s
 }
 
 template <std::floating_point _TFloat>
-__host__ __forceinline void convertFloatsToBools(_TFloat* Floats, bool* Bools, size_t Length, _TFloat Split) {
+__host__ inline void convertFloatsToBools(_TFloat* Floats, bool* Bools, size_t Length, _TFloat Split) {
     convertFloatsToBoolsKernel<<<Length, 1>>>(Floats, Bools, Split);
 }
 template <std::floating_point _TFloat>
-__host__ __forceinline void convertBoolsToFloats(bool* Bools, _TFloat* Floats, size_t Length, _TFloat ValTrue, _TFloat ValFalse) {
+__host__ inline void convertBoolsToFloats(bool* Bools, _TFloat* Floats, size_t Length, _TFloat ValTrue, _TFloat ValFalse) {
     convertBoolsToFloatsKernel<<<Length, 1>>>(Bools, Floats, ValTrue, ValFalse);
 }
 template <std::floating_point _TFloat>
-__host__ __forceinline void convertFloatsToInt32s(_TFloat* Floats, uint32_t* Int32s, size_t Length, _TFloat Split) {
+__host__ inline void convertFloatsToInt32s(_TFloat* Floats, uint32_t* Int32s, size_t Length, _TFloat Split) {
     convertFloatsToInt32sKernel<<<((Length + 31) >> 5), 1>>>(Floats, Int32s, Length, Split);
 }
 template <std::floating_point _TFloat>
-__host__ __forceinline void convertInt32sToFloats(uint32_t* Int32s, _TFloat* Floats, size_t Length, _TFloat ValTrue, _TFloat ValFalse) {
+__host__ inline void convertInt32sToFloats(uint32_t* Int32s, _TFloat* Floats, size_t Length, _TFloat ValTrue, _TFloat ValFalse) {
     convertInt32sToFloatsKernel<<<((Length + 31) >> 5), 1>>>(Floats, Int32s, Length, ValTrue, ValFalse);
 }
 

--- a/ai.cu
+++ b/ai.cu
@@ -195,137 +195,141 @@ __host__ __forceinline void convertInt32sToFloats(uint32_t* Int32s, _TFloat* Flo
     convertInt32sToFloatsKernel<<<((Length + 31) >> 5), 1>>>(Floats, Int32s, Length, ValTrue, ValFalse);
 }
 
-template <bool _FloatsOnHost, std::floating_point _TFloat, bool _BoolsOnHost>
-__host__ void bcuda::ai::ConvertFloatsToBools(_TFloat* Floats, bool* Bools, size_t Length, _TFloat Split) {
-    if constexpr (_FloatsOnHost) {
-        if constexpr (_BoolsOnHost) {
+namespace bcuda {
+    namespace ai {
+        template <bool _FloatsOnHost, std::floating_point _TFloat, bool _BoolsOnHost>
+        __host__ void ConvertFloatsToBools(_TFloat* Floats, bool* Bools, size_t Length, _TFloat Split) {
+            if constexpr (_FloatsOnHost) {
+                if constexpr (_BoolsOnHost) {
+                    for (bool* boolsU = Bools + Length; Bools < boolsU; ++Floats, ++Bools)
+                        *Bools = *Floats > Split;
+                }
+                else {
+                    _TFloat* dFloats;
+                    cudaMalloc(&dFloats, sizeof(_TFloat) * Length);
+                    cudaMemcpy(dFloats, Floats, sizeof(_TFloat) * Length, cudaMemcpyHostToDevice);
+                    convertFloatsToBools(dFloats, Bools, Length, Split);
+                    cudaFree(dFloats);
+                }
+            }
+            else {
+                if constexpr (_BoolsOnHost) {
+                    bool* dBools;
+                    cudaMalloc(&dBools, sizeof(bool) * Length);
+                    convertFloatsToBools(Floats, Bools, Length, Split);
+                    cudaMemcpy(Bools, dBools, sizeof(bool) * Length, cudaMemcpyDeviceToHost);
+                }
+                else {
+                    convertFloatsToBools(Floats, Bools, Length, Split);
+                }
+            }
+        }
+        template <std::floating_point _TFloat>
+        __device__ void ConvertFloatsToBools(_TFloat* Floats, bool* Bools, size_t Length, _TFloat Split) {
             for (bool* boolsU = Bools + Length; Bools < boolsU; ++Floats, ++Bools)
                 *Bools = *Floats > Split;
         }
-        else {
-            _TFloat* dFloats;
-            cudaMalloc(&dFloats, sizeof(_TFloat) * Length);
-            cudaMemcpy(dFloats, Floats, sizeof(_TFloat) * Length, cudaMemcpyHostToDevice);
-            convertFloatsToBools(dFloats, Bools, Length, Split);
-            cudaFree(dFloats);
+        template <bool _FloatsOnHost, std::floating_point _TFloat, bool _IntsOnHost, std::integral _TInt>
+        __host__ void ConvertFloatsToInts(_TFloat* Floats, _TInt* Ints, size_t FloatsLength, _TFloat Split) {
+            if constexpr (_FloatsOnHost) {
+                if constexpr (_IntsOnHost) {
+                    size_t intLength = (FloatsLength + 31) >> 5;
+                    for (_TInt* intsU = Ints + intLength; Ints < intsU; Floats += 32, ++Ints, FloatsLength -= 32)
+                        *Ints = convertFloatsToInt32(Floats, FloatsLength, Split);
+                }
+                else {
+                    _TFloat* dFloats;
+                    cudaMalloc(&dFloats, sizeof(_TFloat) * FloatsLength);
+                    cudaMemcpy(dFloats, Floats, sizeof(_TFloat) * FloatsLength, cudaMemcpyHostToDevice);
+                    convertFloatsToInt32s(dFloats, Ints, FloatsLength, Split);
+                    cudaFree(dFloats);
+                }
+            }
+            else {
+                if constexpr (_IntsOnHost) {
+                    size_t intLength = (FloatsLength + 31) >> 5;
+                    _TInt* dInts;
+                    cudaMalloc(&dInts, sizeof(_TInt) * intLength);
+                    convertFloatsToInt32s(Floats, dInts, FloatsLength, Split);
+                    cudaMemcpy(Ints, dInts, sizeof(_TInt) * intLength, cudaMemcpyDeviceToHost);
+                }
+                else {
+                    convertFloatsToInt32s(Floats, Ints, FloatsLength, Split);
+                }
+            }
         }
-    }
-    else {
-        if constexpr (_BoolsOnHost) {
-            bool* dBools;
-            cudaMalloc(&dBools, sizeof(bool) * Length);
-            convertFloatsToBools(Floats, Bools, Length, Split);
-            cudaMemcpy(Bools, dBools, sizeof(bool) * Length, cudaMemcpyDeviceToHost);
-        }
-        else {
-            convertFloatsToBools(Floats, Bools, Length, Split);
-        }
-    }
-}
-template <std::floating_point _TFloat>
-__device__ void bcuda::ai::ConvertFloatsToBools(_TFloat* Floats, bool* Bools, size_t Length, _TFloat Split) {
-    for (bool* boolsU = Bools + Length; Bools < boolsU; ++Floats, ++Bools)
-        *Bools = *Floats > Split;
-}
-template <bool _FloatsOnHost, std::floating_point _TFloat, bool _IntsOnHost, std::integral _TInt>
-__host__ void bcuda::ai::ConvertFloatsToInts(_TFloat* Floats, _TInt* Ints, size_t FloatsLength, _TFloat Split) {
-    if constexpr (_FloatsOnHost) {
-        if constexpr (_IntsOnHost) {
+        template <std::floating_point _TFloat, std::integral _TInt>
+        __device__ void ConvertFloatsToInts(_TFloat* Floats, _TInt* Ints, size_t FloatsLength, _TFloat Split) {
             size_t intLength = (FloatsLength + 31) >> 5;
             for (_TInt* intsU = Ints + intLength; Ints < intsU; Floats += 32, ++Ints, FloatsLength -= 32)
                 *Ints = convertFloatsToInt32(Floats, FloatsLength, Split);
         }
-        else {
-            _TFloat* dFloats;
-            cudaMalloc(&dFloats, sizeof(_TFloat) * FloatsLength);
-            cudaMemcpy(dFloats, Floats, sizeof(_TFloat) * FloatsLength, cudaMemcpyHostToDevice);
-            convertFloatsToInt32s(dFloats, Ints, FloatsLength, Split);
-            cudaFree(dFloats);
+        template <bool _FloatsOnHost, bool _BoolsOnHost, std::floating_point _TFloat>
+        __host__ void ConvertBoolsToFloats(bool* Bools, _TFloat* Floats, size_t Length, _TFloat ValFalse, _TFloat ValTrue) {
+            if constexpr (_BoolsOnHost) {
+                if constexpr (_FloatsOnHost) {
+                    for (bool* boolsU = Bools + Length; Bools < boolsU; ++Floats, ++Bools)
+                        *Floats = *Bools ? ValTrue : ValFalse;
+                }
+                else {
+                    bool* dBools;
+                    cudaMalloc(&dBools, sizeof(_TFloat) * Length);
+                    cudaMemcpy(dBools, Bools, sizeof(_TFloat) * Length, cudaMemcpyHostToDevice);
+                    convertBoolsToFloats(dBools, Floats, Length, ValTrue, ValFalse);
+                    cudaFree(dBools);
+                }
+            }
+            else {
+                if constexpr (_FloatsOnHost) {
+                    _TFloat* dFloats;
+                    cudaMalloc(&dFloats, sizeof(_TFloat) * Length);
+                    convertBoolsToFloats(Bools, dFloats, Length, ValTrue, ValFalse);
+                    cudaMemcpy(Floats, dFloats, sizeof(_TFloat) * Length, cudaMemcpyDeviceToHost);
+                }
+                else {
+                    convertBoolsToFloats(Bools, Floats, Length, ValTrue, ValFalse);
+                }
+            }
         }
-    }
-    else {
-        if constexpr (_IntsOnHost) {
-            size_t intLength = (FloatsLength + 31) >> 5;
-            _TInt* dInts;
-            cudaMalloc(&dInts, sizeof(_TInt) * intLength);
-            convertFloatsToInt32s(Floats, dInts, FloatsLength, Split);
-            cudaMemcpy(Ints, dInts, sizeof(_TInt) * intLength, cudaMemcpyDeviceToHost);
-        }
-        else {
-            convertFloatsToInt32s(Floats, Ints, FloatsLength, Split);
-        }
-    }
-}
-template <std::floating_point _TFloat, std::integral _TInt>
-__device__ void bcuda::ai::ConvertFloatsToInts(_TFloat* Floats, _TInt* Ints, size_t FloatsLength, _TFloat Split) {
-    size_t intLength = (FloatsLength + 31) >> 5;
-    for (_TInt* intsU = Ints + intLength; Ints < intsU; Floats += 32, ++Ints, FloatsLength -= 32)
-        *Ints = convertFloatsToInt32(Floats, FloatsLength, Split);
-}
-template <bool _FloatsOnHost, bool _BoolsOnHost, std::floating_point _TFloat>
-__host__ void bcuda::ai::ConvertBoolsToFloats(bool* Bools, _TFloat* Floats, size_t Length, _TFloat ValFalse, _TFloat ValTrue) {
-    if constexpr (_BoolsOnHost) {
-        if constexpr (_FloatsOnHost) {
+        template <std::floating_point _TFloat>
+        __device__ void ConvertBoolsToFloats(bool* Bools, _TFloat* Floats, size_t Length, _TFloat ValFalse, _TFloat ValTrue) {
             for (bool* boolsU = Bools + Length; Bools < boolsU; ++Floats, ++Bools)
                 *Floats = *Bools ? ValTrue : ValFalse;
         }
-        else {
-            bool* dBools;
-            cudaMalloc(&dBools, sizeof(_TFloat) * Length);
-            cudaMemcpy(dBools, Bools, sizeof(_TFloat) * Length, cudaMemcpyHostToDevice);
-            convertBoolsToFloats(dBools, Floats, Length, ValTrue, ValFalse);
-            cudaFree(dBools);
+        template <bool _IntsOnHost, std::integral _TInt, bool _FloatsOnHost, std::floating_point _TFloat>
+        __host__ void ConvertIntsToFloats(_TInt* Ints, _TFloat* Floats, size_t FloatsLength, _TFloat ValFalse, _TFloat ValTrue) {
+            if constexpr (_IntsOnHost) {
+                if constexpr (_FloatsOnHost) {
+                    size_t intLength = (FloatsLength + 31) >> 5;
+                    for (_TInt* intsU = Ints + intLength; Ints < intsU; Floats += 32, ++Ints, FloatsLength -= 32)
+                        convertInt32ToFloats(Ints, Floats, FloatsLength, ValTrue, ValFalse);
+                }
+                else {
+                    size_t intLength = (FloatsLength + 31) >> 5;
+                    _TInt* dInts;
+                    cudaMalloc(&dInts, sizeof(_TInt) * intLength);
+                    cudaMemcpy(dInts, Ints, sizeof(_TInt) * intLength, cudaMemcpyHostToDevice);
+                    convertInt32sToFloats(dInts, Floats, FloatsLength, ValTrue, ValFalse);
+                    cudaFree(dInts);
+                }
+            }
+            else {
+                if constexpr (_FloatsOnHost) {
+                    _TFloat* dFloats;
+                    cudaMalloc(&dFloats, sizeof(_TFloat) * FloatsLength);
+                    convertInt32sToFloats(Ints, dFloats, FloatsLength, ValTrue, ValFalse);
+                    cudaMemcpy(Floats, dFloats, sizeof(_TFloat) * FloatsLength, cudaMemcpyDeviceToHost);
+                }
+                else {
+                    convertInt32sToFloats(Ints, Floats, FloatsLength, ValTrue, ValFalse);
+                }
+            }
         }
-    }
-    else {
-        if constexpr (_FloatsOnHost) {
-            _TFloat* dFloats;
-            cudaMalloc(&dFloats, sizeof(_TFloat) * Length);
-            convertBoolsToFloats(Bools, dFloats, Length, ValTrue, ValFalse);
-            cudaMemcpy(Floats, dFloats, sizeof(_TFloat) * Length, cudaMemcpyDeviceToHost);
-        }
-        else {
-            convertBoolsToFloats(Bools, Floats, Length, ValTrue, ValFalse);
-        }
-    }
-}
-template <std::floating_point _TFloat>
-__device__ void bcuda::ai::ConvertBoolsToFloats(bool* Bools, _TFloat* Floats, size_t Length, _TFloat ValFalse, _TFloat ValTrue) {
-    for (bool* boolsU = Bools + Length; Bools < boolsU; ++Floats, ++Bools)
-        *Floats = *Bools ? ValTrue : ValFalse;
-}
-template <bool _IntsOnHost, std::integral _TInt, bool _FloatsOnHost, std::floating_point _TFloat>
-__host__ void bcuda::ai::ConvertIntsToFloats(_TInt* Ints, _TFloat* Floats, size_t FloatsLength, _TFloat ValFalse, _TFloat ValTrue) {
-    if constexpr (_IntsOnHost) {
-        if constexpr (_FloatsOnHost) {
+        template <std::integral _TInt, std::floating_point _TFloat>
+        __device__ void ConvertIntsToFloats(_TInt* Ints, _TFloat* Floats, size_t FloatsLength, _TFloat ValFalse, _TFloat ValTrue) {
             size_t intLength = (FloatsLength + 31) >> 5;
             for (_TInt* intsU = Ints + intLength; Ints < intsU; Floats += 32, ++Ints, FloatsLength -= 32)
                 convertInt32ToFloats(Ints, Floats, FloatsLength, ValTrue, ValFalse);
         }
-        else {
-            size_t intLength = (FloatsLength + 31) >> 5;
-            _TInt* dInts;
-            cudaMalloc(&dInts, sizeof(_TInt) * intLength);
-            cudaMemcpy(dInts, Ints, sizeof(_TInt) * intLength, cudaMemcpyHostToDevice);
-            convertInt32sToFloats(dInts, Floats, FloatsLength, ValTrue, ValFalse);
-            cudaFree(dInts);
-        }
     }
-    else {
-        if constexpr (_FloatsOnHost) {
-            _TFloat* dFloats;
-            cudaMalloc(&dFloats, sizeof(_TFloat) * FloatsLength);
-            convertInt32sToFloats(Ints, dFloats, FloatsLength, ValTrue, ValFalse);
-            cudaMemcpy(Floats, dFloats, sizeof(_TFloat) * FloatsLength, cudaMemcpyDeviceToHost);
-        }
-        else {
-            convertInt32sToFloats(Ints, Floats, FloatsLength, ValTrue, ValFalse);
-        }
-    }
-}
-template <std::integral _TInt, std::floating_point _TFloat>
-__device__ void bcuda::ai::ConvertIntsToFloats(_TInt* Ints, _TFloat* Floats, size_t FloatsLength, _TFloat ValFalse, _TFloat ValTrue) {
-    size_t intLength = (FloatsLength + 31) >> 5;
-    for (_TInt* intsU = Ints + intLength; Ints < intsU; Floats += 32, ++Ints, FloatsLength -= 32)
-        convertInt32ToFloats(Ints, Floats, FloatsLength, ValTrue, ValFalse);
 }

--- a/ai.h
+++ b/ai.h
@@ -12,17 +12,34 @@ namespace bcuda {
         using activationFunction_t = _T(*)(_T Value);
 
         template <typename _T>
-        __host__ __device__ constexpr _T ReLU(_T Value);
+        __host__ __device__ constexpr _T ReLU(_T Value) {
+            return (Value < (_T)0.) ? (_T)0. : Value;
+        }
         template <typename _T, _T _Slope>
-        __host__ __device__ constexpr _T LeakyReLU(_T Value);
+        __host__ __device__ constexpr _T LeakyReLU(_T Value) {
+            return (Value < (_T)0.) ? Value * _Slope : Value;
+        }
         template <typename _T, _T _Lower, _T _Upper>
-        __host__ __device__ constexpr _T BoundReLU(_T Value);
+        __host__ __device__ constexpr _T BoundReLU(_T Value) {
+            if (Value < _Lower) return (_T)0.;
+            if (Value > _Upper) return (_T)1.;
+            return Value;
+        }
         template <typename _T, _T _Slope, _T _Lower, _T _Upper>
-        __host__ __device__ constexpr _T LeakyBoundReLU(_T Value);
+        __host__ __device__ constexpr _T LeakyBoundReLU(_T Value) {
+            if (Value < _Lower) return Value * _Slope;
+            if (Value > _Upper) return (_T)1. + (Value - _Upper) * _Slope;
+            return Value;
+        }
         template <typename _T>
-        __host__ __device__ _T TanH(_T Value);
+        __host__ __device__ _T TanH(_T Value) {
+            return std::tanh(Value);
+        }
         template <typename _T>
-        __host__ __device__ _T Sigmoid(_T Value);
+        __host__ __device__ _T Sigmoid(_T Value) {
+            Value = std::exp(Value);
+            return Value / ((_T)1. + Value);
+        }
 
         template <bool _FloatsOnHost, std::floating_point _TFloat, bool _BoolsOnHost>
         __host__ void ConvertFloatsToBools(_TFloat* Floats, bool* Bools, size_t Length, _TFloat Split);
@@ -50,34 +67,4 @@ namespace bcuda {
         __device__ void ConvertIntsToFloats(_TInt* Ints, _TFloat* Floats, size_t FloatsLength, _TFloat ValFalse, _TFloat ValTrue);
 #endif
     }
-}
-
-template <typename _T>
-__host__ __device__ constexpr _T bcuda::ai::ReLU(_T Value) {
-    return (Value < (_T)0.) ? (_T)0. : Value;
-}
-template <typename _T, _T _Slope>
-__host__ __device__ constexpr _T bcuda::ai::LeakyReLU(_T Value) {
-    return (Value < (_T)0.) ? Value * _Slope : Value;
-}
-template <typename _T, _T _Lower, _T _Upper>
-__host__ __device__ constexpr _T bcuda::ai::BoundReLU(_T Value) {
-    if (Value < _Lower) return (_T)0.;
-    if (Value > _Upper) return (_T)1.;
-    return Value;
-}
-template <typename _T, _T _Slope, _T _Lower, _T _Upper>
-__host__ __device__ constexpr _T bcuda::ai::LeakyBoundReLU(_T Value) {
-    if (Value < _Lower) return Value * _Slope;
-    if (Value > _Upper) return (_T)1. + (Value - _Upper) * _Slope;
-    return Value;
-}
-template <typename _T>
-__host__ __device__ _T bcuda::ai::TanH(_T Value) {
-    return std::tanh(Value);
-}
-template <typename _T>
-__host__ __device__ _T bcuda::ai::Sigmoid(_T Value) {
-    Value = std::exp(Value);
-    return Value / ((_T)1. + Value);
 }

--- a/ai.h
+++ b/ai.h
@@ -12,31 +12,31 @@ namespace bcuda {
         using activationFunction_t = _T(*)(_T Value);
 
         template <typename _T>
-        __host__ __device__ constexpr _T ReLU(_T Value) {
+        __host__ __device__ inline static constexpr _T ReLU(_T Value) {
             return (Value < (_T)0.) ? (_T)0. : Value;
         }
         template <typename _T, _T _Slope>
-        __host__ __device__ constexpr _T LeakyReLU(_T Value) {
+        __host__ __device__ inline static constexpr _T LeakyReLU(_T Value) {
             return (Value < (_T)0.) ? Value * _Slope : Value;
         }
         template <typename _T, _T _Lower, _T _Upper>
-        __host__ __device__ constexpr _T BoundReLU(_T Value) {
+        __host__ __device__ inline static constexpr _T BoundReLU(_T Value) {
             if (Value < _Lower) return (_T)0.;
             if (Value > _Upper) return (_T)1.;
             return Value;
         }
         template <typename _T, _T _Slope, _T _Lower, _T _Upper>
-        __host__ __device__ constexpr _T LeakyBoundReLU(_T Value) {
+        __host__ __device__ inline static constexpr _T LeakyBoundReLU(_T Value) {
             if (Value < _Lower) return Value * _Slope;
             if (Value > _Upper) return (_T)1. + (Value - _Upper) * _Slope;
             return Value;
         }
         template <typename _T>
-        __host__ __device__ _T TanH(_T Value) {
+        __host__ __device__ inline static _T TanH(_T Value) {
             return std::tanh(Value);
         }
         template <typename _T>
-        __host__ __device__ _T Sigmoid(_T Value) {
+        __host__ __device__ inline static _T Sigmoid(_T Value) {
             Value = std::exp(Value);
             return Value / ((_T)1. + Value);
         }

--- a/ai_evol_eval_multieval.h
+++ b/ai_evol_eval_multieval.h
@@ -13,142 +13,118 @@ namespace bcuda {
                     void* internalEvaluationSharedData;
                 };
                 template <evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-                float Evaluate_MultipleTimes_AM_C(void* Object, void* EvaluationSharedData);
+                float Evaluate_MultipleTimes_AM_C(void* Object, void* EvaluationSharedData) {
+                    constexpr float s = 1.f / _IterationCount;
+
+                    float t = 0.f;
+                    for (size_t i = 0; i < _IterationCount; ++i) {
+                        t += _SingleEvaluationFunc(Object, EvaluationSharedData);
+                    }
+
+                    return t * s;
+                }
                 template <evaluationFunction_t _SingleEvaluationFunc>
-                float Evaluate_MultipleTimes_AM_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings);
+                float Evaluate_MultipleTimes_AM_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+                    float t = 0.f;
+                    for (size_t i = 0; i < Settings.iterationCount; ++i) {
+                        t += _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);
+                    }
+
+                    return t / Settings.iterationCount;
+                }
                 template <evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-                float Evaluate_MultipleTimes_Min_C(void* Object, void* EvaluationSharedData);
+                float Evaluate_MultipleTimes_Min_C(void* Object, void* EvaluationSharedData) {
+                    float min = std::numeric_limits<float>::infinity();
+                    for (size_t i = 0; i < _IterationCount; ++i) {
+                        float v = _SingleEvaluationFunc(Object, EvaluationSharedData);
+                        if (v < min) {
+                            min = v;
+                        }
+                    }
+
+                    return min;
+                }
                 template <evaluationFunction_t _SingleEvaluationFunc>
-                float Evaluate_MultipleTimes_Min_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings);
+                float Evaluate_MultipleTimes_Min_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+                    float min = std::numeric_limits<float>::infinity();
+                    for (size_t i = 0; i < Settings.iterationCount; ++i) {
+                        float v = _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);
+                        if (v < min) {
+                            min = v;
+                        }
+                    }
+
+                    return min;
+                }
                 template <evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-                float Evaluate_MultipleTimes_Max_C(void* Object, void* EvaluationSharedData);
+                float Evaluate_MultipleTimes_Max_C(void* Object, void* EvaluationSharedData) {
+                    float max = -std::numeric_limits<float>::infinity();
+                    for (size_t i = 0; i < _IterationCount; ++i) {
+                        float v = _SingleEvaluationFunc(Object, EvaluationSharedData);
+                        if (v > max) {
+                            max = v;
+                        }
+                    }
+
+                    return max;
+                }
                 template <evaluationFunction_t _SingleEvaluationFunc>
-                float Evaluate_MultipleTimes_Max_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings);
+                float Evaluate_MultipleTimes_Max_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+                    float max = -std::numeric_limits<float>::infinity();
+                    for (size_t i = 0; i < Settings.iterationCount; ++i) {
+                        float v = _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);
+                        if (v > max) {
+                            max = v;
+                        }
+                    }
+
+                    return max;
+                }
                 template <evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-                float Evaluate_MultipleTimes_Med_C(void* Object, void* EvaluationSharedData);
+                float Evaluate_MultipleTimes_Med_C(void* Object, void* EvaluationSharedData) {
+                    float* arr = new float[_IterationCount];
+                    for (size_t i = 0; i < _IterationCount; ++i) {
+                        arr[i] = _SingleEvaluationFunc(Object, EvaluationSharedData);
+                    }
+
+                    std::sort(arr, arr + _IterationCount);
+
+                    float r;
+                    size_t h = _IterationCount >> 1;
+                    if (_IterationCount & 1) {
+                        r = arr[h];
+                    }
+                    else {
+                        r = (arr[h - 1] + arr[h]) * .5f;
+                    }
+
+                    delete[] arr;
+
+                    return r;
+                }
                 template <evaluationFunction_t _SingleEvaluationFunc>
-                float Evaluate_MultipleTimes_Med_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings);
+                float Evaluate_MultipleTimes_Med_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+                    float* arr = new float[Settings.iterationCount];
+                    for (size_t i = 0; i < Settings.iterationCount; ++i) {
+                        arr[i] = _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);
+                    }
+
+                    std::sort(arr, arr + Settings.iterationCount);
+
+                    float r;
+                    size_t h = Settings.iterationCount >> 1;
+                    if (Settings.iterationCount & 1) {
+                        r = arr[h];
+                    }
+                    else {
+                        r = (arr[h - 1] + arr[h]) * .5f;
+                    }
+
+                    delete[] arr;
+
+                    return r;
+                }
             }
         }
     }
-}
-
-template <bcuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-float bcuda::ai::evol::eval::Evaluate_MultipleTimes_AM_C(void* Object, void* EvaluationSharedData) {
-    constexpr float s = 1.f / _IterationCount;
-
-    float t = 0.f;
-    for (size_t i = 0; i < _IterationCount; ++i) {
-        t += _SingleEvaluationFunc(Object, EvaluationSharedData);
-    }
-
-    return t * s;
-}
-
-template <bcuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc>
-float bcuda::ai::evol::eval::Evaluate_MultipleTimes_AM_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
-    float t = 0.f;
-    for (size_t i = 0; i < Settings.iterationCount; ++i) {
-        t += _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);
-    }
-
-    return t / Settings.iterationCount;
-}
-
-template <bcuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-float bcuda::ai::evol::eval::Evaluate_MultipleTimes_Min_C(void* Object, void* EvaluationSharedData) {
-    float min = std::numeric_limits<float>::infinity();
-    for (size_t i = 0; i < _IterationCount; ++i) {
-        float v = _SingleEvaluationFunc(Object, EvaluationSharedData);
-        if (v < min) {
-            min = v;
-        }
-    }
-
-    return min;
-}
-
-template <bcuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc>
-float bcuda::ai::evol::eval::Evaluate_MultipleTimes_Min_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
-    float min = std::numeric_limits<float>::infinity();
-    for (size_t i = 0; i < Settings.iterationCount; ++i) {
-        float v = _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);
-        if (v < min) {
-            min = v;
-        }
-    }
-
-    return min;
-}
-
-template <bcuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-float bcuda::ai::evol::eval::Evaluate_MultipleTimes_Max_C(void* Object, void* EvaluationSharedData) {
-    float max = -std::numeric_limits<float>::infinity();
-    for (size_t i = 0; i < _IterationCount; ++i) {
-        float v = _SingleEvaluationFunc(Object, EvaluationSharedData);
-        if (v > max) {
-            max = v;
-        }
-    }
-
-    return max;
-}
-
-template <bcuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc>
-float bcuda::ai::evol::eval::Evaluate_MultipleTimes_Max_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
-    float max = -std::numeric_limits<float>::infinity();
-    for (size_t i = 0; i < Settings.iterationCount; ++i) {
-        float v = _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);
-        if (v > max) {
-            max = v;
-        }
-    }
-
-    return max;
-}
-
-template <bcuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-float bcuda::ai::evol::eval::Evaluate_MultipleTimes_Med_C(void* Object, void* EvaluationSharedData) {
-    float* arr = new float[_IterationCount];
-    for (size_t i = 0; i < _IterationCount; ++i) {
-        arr[i] = _SingleEvaluationFunc(Object, EvaluationSharedData);
-    }
-
-    std::sort(arr, arr + _IterationCount);
-
-    float r;
-    size_t h = _IterationCount >> 1;
-    if (_IterationCount & 1) {
-        r = arr[h];
-    }
-    else {
-        r = (arr[h - 1] + arr[h]) * .5f;
-    }
-
-    delete[] arr;
-
-    return r;
-}
-
-template <bcuda::ai::evol::evaluationFunction_t _SingleEvaluationFunc>
-float bcuda::ai::evol::eval::Evaluate_MultipleTimes_Med_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
-    float* arr = new float[Settings.iterationCount];
-    for (size_t i = 0; i < Settings.iterationCount; ++i) {
-        arr[i] = _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);
-    }
-
-    std::sort(arr, arr + Settings.iterationCount);
-
-    float r;
-    size_t h = Settings.iterationCount >> 1;
-    if (Settings.iterationCount & 1) {
-        r = arr[h];
-    }
-    else {
-        r = (arr[h - 1] + arr[h]) * .5f;
-    }
-
-    delete[] arr;
-
-    return r;
 }

--- a/ai_evol_eval_multieval.h
+++ b/ai_evol_eval_multieval.h
@@ -11,9 +11,12 @@ namespace bcuda {
                 struct Evaluate_MultipleTimes_V_SD final {
                     size_t iterationCount;
                     void* internalEvaluationSharedData;
+
+                    inline constexpr Evaluate_MultipleTimes_V_SD()
+                        : iterationCount(0), internalEvaluationSharedData(0) { }
                 };
                 template <evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-                float Evaluate_MultipleTimes_AM_C(void* Object, void* EvaluationSharedData) {
+                static inline float Evaluate_MultipleTimes_AM_C(void* Object, void* EvaluationSharedData) {
                     constexpr float s = 1.f / _IterationCount;
 
                     float t = 0.f;
@@ -24,7 +27,7 @@ namespace bcuda {
                     return t * s;
                 }
                 template <evaluationFunction_t _SingleEvaluationFunc>
-                float Evaluate_MultipleTimes_AM_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+                static inline float Evaluate_MultipleTimes_AM_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
                     float t = 0.f;
                     for (size_t i = 0; i < Settings.iterationCount; ++i) {
                         t += _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);
@@ -33,7 +36,7 @@ namespace bcuda {
                     return t / Settings.iterationCount;
                 }
                 template <evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-                float Evaluate_MultipleTimes_Min_C(void* Object, void* EvaluationSharedData) {
+                static inline float Evaluate_MultipleTimes_Min_C(void* Object, void* EvaluationSharedData) {
                     float min = std::numeric_limits<float>::infinity();
                     for (size_t i = 0; i < _IterationCount; ++i) {
                         float v = _SingleEvaluationFunc(Object, EvaluationSharedData);
@@ -45,7 +48,7 @@ namespace bcuda {
                     return min;
                 }
                 template <evaluationFunction_t _SingleEvaluationFunc>
-                float Evaluate_MultipleTimes_Min_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+                static inline float Evaluate_MultipleTimes_Min_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
                     float min = std::numeric_limits<float>::infinity();
                     for (size_t i = 0; i < Settings.iterationCount; ++i) {
                         float v = _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);
@@ -57,7 +60,7 @@ namespace bcuda {
                     return min;
                 }
                 template <evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-                float Evaluate_MultipleTimes_Max_C(void* Object, void* EvaluationSharedData) {
+                static inline float Evaluate_MultipleTimes_Max_C(void* Object, void* EvaluationSharedData) {
                     float max = -std::numeric_limits<float>::infinity();
                     for (size_t i = 0; i < _IterationCount; ++i) {
                         float v = _SingleEvaluationFunc(Object, EvaluationSharedData);
@@ -69,7 +72,7 @@ namespace bcuda {
                     return max;
                 }
                 template <evaluationFunction_t _SingleEvaluationFunc>
-                float Evaluate_MultipleTimes_Max_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+                static inline float Evaluate_MultipleTimes_Max_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
                     float max = -std::numeric_limits<float>::infinity();
                     for (size_t i = 0; i < Settings.iterationCount; ++i) {
                         float v = _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);
@@ -81,7 +84,7 @@ namespace bcuda {
                     return max;
                 }
                 template <evaluationFunction_t _SingleEvaluationFunc, size_t _IterationCount>
-                float Evaluate_MultipleTimes_Med_C(void* Object, void* EvaluationSharedData) {
+                static inline float Evaluate_MultipleTimes_Med_C(void* Object, void* EvaluationSharedData) {
                     float* arr = new float[_IterationCount];
                     for (size_t i = 0; i < _IterationCount; ++i) {
                         arr[i] = _SingleEvaluationFunc(Object, EvaluationSharedData);
@@ -103,7 +106,7 @@ namespace bcuda {
                     return r;
                 }
                 template <evaluationFunction_t _SingleEvaluationFunc>
-                float Evaluate_MultipleTimes_Med_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
+                static inline float Evaluate_MultipleTimes_Med_V(void* Object, Evaluate_MultipleTimes_V_SD& Settings) {
                     float* arr = new float[Settings.iterationCount];
                     for (size_t i = 0; i < Settings.iterationCount; ++i) {
                         arr[i] = _SingleEvaluationFunc(Object, Settings.internalEvaluationSharedData);

--- a/ai_evol_eval_output.h
+++ b/ai_evol_eval_output.h
@@ -27,13 +27,12 @@ namespace bcuda {
                     template <typename _TInput, typename _TOutput, constructInstance_t _CI, iterateInstance_t<_TInput, _TOutput> _II, destructInstance_t _DI>
                     class Instance_C final {
                     public:
-                        Instance_C(void* Object, void* ConstructInstanceSharedData) {
-                            is = _CI(Object, ConstructInstanceSharedData);
-                        }
-                        _TOutput IterateInstance(_TInput Input) {
+                        inline Instance_C(void* Object, void* ConstructInstanceSharedData)
+                            : is(_CI(Object, ConstructInstanceSharedData)) { }
+                        inline _TOutput IterateInstance(_TInput Input) {
                             return _II(is, Input);
                         }
-                        void DestroyInstance() {
+                        inline void DestroyInstance() {
                             _DI(is);
                         }
                     private:
@@ -43,24 +42,14 @@ namespace bcuda {
                     template <typename _TInput, typename _TOutput>
                     class Instance_V final {
                     public:
-                        Instance_V(constructInstance_t CI, iterateInstance_t<_TInput, _TOutput> II, destructInstance_t DI, void* Object, void* ConstructInstanceSharedData) {
-                            this->ci = CI;
-                            this->ii = II;
-                            this->di = DI;
-                            
-                            is = CI(Object, ConstructInstanceSharedData);
-                        }
-                        Instance_V(InstanceFunctions<_TInput, _TOutput> InstanceFunctions, void* Object, void* ConstructInstanceSharedData) {
-                            this->ci = InstanceFunctions.constructInstance;
-                            this->ii = InstanceFunctions.iterateInstance;
-                            this->di = InstanceFunctions.destructInstance;
-
-                            is = ci(Object, ConstructInstanceSharedData);
-                        }
-                        _TOutput IterateInstance(_TInput Input) {
+                        inline Instance_V(constructInstance_t CI, iterateInstance_t<_TInput, _TOutput> II, destructInstance_t DI, void* Object, void* ConstructInstanceSharedData)
+                            : ci(CI), ii(II), di(DI), is(CI(Object, ConstructInstanceSharedData)) { }
+                        inline Instance_V(InstanceFunctions<_TInput, _TOutput> InstanceFunctions, void* Object, void* ConstructInstanceSharedData)
+                            : ci(InstanceFunctions.constructInstance), ii(InstanceFunctions.iterateInstance), di(InstanceFunctions.destructInstance), is(InstanceFunctions.constructInstance(Object, ConstructInstanceSharedData)) { }
+                        inline _TOutput IterateInstance(_TInput Input) {
                             return ii(is, Input);
                         }
-                        void DestroyInstance() {
+                        inline void DestroyInstance() {
                             di(is);
                         }
                     private:

--- a/ai_evol_eval_output.h
+++ b/ai_evol_eval_output.h
@@ -20,7 +20,8 @@ namespace bcuda {
                         constructInstance_t constructInstance;
                         iterateInstance_t<_TInput, _TOutput> iterateInstance;
                         destructInstance_t destructInstance;
-                        constexpr InstanceFunctions() = default;
+                        inline constexpr InstanceFunctions()
+                            : constructInstance(0), iterateInstance(0), destructInstance(0) { }
                     };
 
                     template <typename _TInput, typename _TOutput, constructInstance_t _CI, iterateInstance_t<_TInput, _TOutput> _II, destructInstance_t _DI>

--- a/ai_evol_eval_output_impl_proliferation.cpp
+++ b/ai_evol_eval_output_impl_proliferation.cpp
@@ -6,144 +6,154 @@
 #include <stdexcept>
 #include <type_traits>
 
-template <>
-float bcuda::ai::evol::eval::output::Evaluate_Proliferation<float>(void* Object, Evaluate_Proliferation_SD<float>& Settings) {
-    constexpr float rndSclr = 2.f / (float)std::numeric_limits<uint64_t>::max();
-    if (!Settings.inputCount) {
-        throw std::runtime_error("'Settings.inputCount' cannot be zero.");
-    }
-    Instance_V<float*, float*> oi(Settings.instanceFunctions, Object, Settings.sd_ci);
-    float t = 0.f;
-    for (size_t i = 0; i < Settings.roundCount; ++i) {
-        float* vs = new float[Settings.inputCount];
-        float rndVal = Settings.rng() * rndSclr - 1.f;
-        for (size_t j = 0; j < Settings.inputCount; ++j) {
-            vs[j] = rndVal;
-        }
-        for (size_t j = 0; j < Settings.iterationsPerRound; ++j) {
-            float* r = oi.IterateInstance(vs);
-            float dev_t = 0.f;
-            for (size_t k = 0; k < Settings.outputCount; ++k) {
-                float iv = r[k] - rndVal;
-                dev_t += iv * iv;
+namespace bcuda {
+    namespace ai {
+        namespace evol {
+            namespace eval {
+                namespace output {
+                    template <>
+                    float Evaluate_Proliferation<float>(void* Object, Evaluate_Proliferation_SD<float>& Settings) {
+                        constexpr float rndSclr = 2.f / (float)std::numeric_limits<uint64_t>::max();
+                        if (!Settings.inputCount) {
+                            throw std::runtime_error("'Settings.inputCount' cannot be zero.");
+                        }
+                        Instance_V<float*, float*> oi(Settings.instanceFunctions, Object, Settings.sd_ci);
+                        float t = 0.f;
+                        for (size_t i = 0; i < Settings.roundCount; ++i) {
+                            float* vs = new float[Settings.inputCount];
+                            float rndVal = Settings.rng() * rndSclr - 1.f;
+                            for (size_t j = 0; j < Settings.inputCount; ++j) {
+                                vs[j] = rndVal;
+                            }
+                            for (size_t j = 0; j < Settings.iterationsPerRound; ++j) {
+                                float* r = oi.IterateInstance(vs);
+                                float dev_t = 0.f;
+                                for (size_t k = 0; k < Settings.outputCount; ++k) {
+                                    float iv = r[k] - rndVal;
+                                    dev_t += iv * iv;
+                                }
+                                delete[] r;
+                                t += std::sqrt(dev_t);
+                            }
+                            delete[] vs;
+                        }
+                        return t;
+                    }
+
+                    template<>
+                    float Evaluate_Proliferation<double>(void* Object, Evaluate_Proliferation_SD<double>& Settings) {
+                        constexpr double rndSclr = 2. / (double)std::numeric_limits<uint64_t>::max();
+
+                        if (!Settings.inputCount) {
+                            throw std::runtime_error("'Settings.inputCount' cannot be zero.");
+                        }
+                        Instance_V<double*, double*> oi(Settings.instanceFunctions, Object, Settings.sd_ci);
+                        double t = 0.;
+                        for (size_t i = 0; i < Settings.roundCount; ++i) {
+                            double* vs = new double[Settings.inputCount];
+                            double rndVal = Settings.rng() * rndSclr - 1.;
+                            for (size_t j = 0; j < Settings.inputCount; ++j) {
+                                vs[j] = rndVal;
+                            }
+                            for (size_t j = 0; j < Settings.iterationsPerRound; ++j) {
+                                double* r = oi.IterateInstance(vs);
+                                double dev_t = 0.;
+                                for (size_t k = 0; k < Settings.outputCount; ++k) {
+                                    double iv = r[k] - rndVal;
+                                    dev_t += iv * iv;
+                                }
+                                delete[] r;
+                                t += std::sqrt(dev_t);
+                            }
+                            delete[] vs;
+                        }
+                        return (float)t;
+                    }
+
+                    template <typename _T>
+                    float Evaluate_Proliferation(void* Object, Evaluate_Proliferation_SD<_T>& Settings) {
+                        if (!Settings.inputCount) {
+                            throw std::runtime_error("'Settings.inputCount' cannot be zero.");
+                        }
+                        Instance_V<_T*, _T*> oi(Settings.instanceFunctions, Object, Settings.sd_ci);
+                        uint64_t t = 0ui64;
+                        for (size_t i = 0; i < Settings.roundCount; ++i) {
+                            _T* vs = new _T[Settings.inputCount];
+                            _T rndVal = (_T)Settings.rng();
+                            for (size_t j = 0; j < Settings.inputCount; ++j) {
+                                vs[j] = rndVal;
+                            }
+                            for (size_t j = 0; j < Settings.iterationsPerRound; ++j) {
+                                _T* r = oi.IterateInstance(vs);
+                                for (size_t k = 0; k < Settings.outputCount; ++k) {
+                                    _T iv = Settings.mask & ~(r[k] ^ rndVal);
+                                    if constexpr (std::is_same<int8_t, _T>::value || std::is_same<uint8_t, _T>::value) {
+                                        t += std::popcount((uint8_t)iv);
+                                    }
+                                    else if constexpr (std::is_same<int16_t, _T>::value || std::is_same<uint16_t, _T>::value) {
+                                        t += std::popcount((uint16_t)iv);
+                                    }
+                                    else if constexpr (std::is_same<int32_t, _T>::value || std::is_same<uint32_t, _T>::value) {
+                                        t += std::popcount((uint32_t)iv);
+                                    }
+                                    else if constexpr (std::is_same<int64_t, _T>::value || std::is_same<uint64_t, _T>::value) {
+                                        t += std::popcount((uint64_t)iv);
+                                    }
+                                    else {
+                                        throw std::exception();
+                                    }
+                                }
+                                delete[] r;
+                            }
+                            delete[] vs;
+                        }
+                        _T mc;
+                        if constexpr (std::is_same<int8_t, _T>::value || std::is_same<uint8_t, _T>::value) {
+                            mc = std::popcount((uint8_t)Settings.mask);
+                        }
+                        else if constexpr (std::is_same<int16_t, _T>::value || std::is_same<uint16_t, _T>::value) {
+                            mc = std::popcount((uint16_t)Settings.mask);
+                        }
+                        else if constexpr (std::is_same<int32_t, _T>::value || std::is_same<uint32_t, _T>::value) {
+                            mc = std::popcount((uint32_t)Settings.mask);
+                        }
+                        else if constexpr (std::is_same<int64_t, _T>::value || std::is_same<uint64_t, _T>::value) {
+                            mc = std::popcount((uint64_t)Settings.mask);
+                        }
+                        else {
+                            throw std::exception();
+                        }
+                        return (float)t / (float)((uint64_t)mc * Settings.iterationsPerRound * Settings.roundCount * Settings.outputCount);
+                    }
+
+                    template <typename _T>
+                    float Evaluate_Proliferation(void* Object, void* Settings) {
+                        return Evaluate_Proliferation<_T>(Object, *(Evaluate_Proliferation_SD<_T>*)Settings);
+                    }
+
+                    template float Evaluate_Proliferation<uint8_t>(void*, Evaluate_Proliferation_SD<uint8_t>&);
+                    template float Evaluate_Proliferation<int8_t>(void*, Evaluate_Proliferation_SD<int8_t>&);
+                    template float Evaluate_Proliferation<uint16_t>(void*, Evaluate_Proliferation_SD<uint16_t>&);
+                    template float Evaluate_Proliferation<int16_t>(void*, Evaluate_Proliferation_SD<int16_t>&);
+                    template float Evaluate_Proliferation<uint32_t>(void*, Evaluate_Proliferation_SD<uint32_t>&);
+                    template float Evaluate_Proliferation<int32_t>(void*, Evaluate_Proliferation_SD<int32_t>&);
+                    template float Evaluate_Proliferation<uint64_t>(void*, Evaluate_Proliferation_SD<uint64_t>&);
+                    template float Evaluate_Proliferation<int64_t>(void*, Evaluate_Proliferation_SD<int64_t>&);
+                    template float Evaluate_Proliferation<float>(void*, Evaluate_Proliferation_SD<float>&);
+                    template float Evaluate_Proliferation<double>(void*, Evaluate_Proliferation_SD<double>&);
+
+                    template float Evaluate_Proliferation<uint8_t>(void*, void*);
+                    template float Evaluate_Proliferation<int8_t>(void*, void*);
+                    template float Evaluate_Proliferation<uint16_t>(void*, void*);
+                    template float Evaluate_Proliferation<int16_t>(void*, void*);
+                    template float Evaluate_Proliferation<uint32_t>(void*, void*);
+                    template float Evaluate_Proliferation<int32_t>(void*, void*);
+                    template float Evaluate_Proliferation<uint64_t>(void*, void*);
+                    template float Evaluate_Proliferation<int64_t>(void*, void*);
+                    template float Evaluate_Proliferation<float>(void*, void*);
+                    template float Evaluate_Proliferation<double>(void*, void*);
+                }
             }
-            delete[] r;
-            t += std::sqrt(dev_t);
         }
-        delete[] vs;
     }
-    return t;
 }
-
-template<>
-float bcuda::ai::evol::eval::output::Evaluate_Proliferation<double>(void* Object, Evaluate_Proliferation_SD<double>& Settings) {
-    constexpr double rndSclr = 2. / (double)std::numeric_limits<uint64_t>::max();
-
-    if (!Settings.inputCount) {
-        throw std::runtime_error("'Settings.inputCount' cannot be zero.");
-    }
-    Instance_V<double*, double*> oi(Settings.instanceFunctions, Object, Settings.sd_ci);
-    double t = 0.;
-    for (size_t i = 0; i < Settings.roundCount; ++i) {
-        double* vs = new double[Settings.inputCount];
-        double rndVal = Settings.rng() * rndSclr - 1.;
-        for (size_t j = 0; j < Settings.inputCount; ++j) {
-            vs[j] = rndVal;
-        }
-        for (size_t j = 0; j < Settings.iterationsPerRound; ++j) {
-            double* r = oi.IterateInstance(vs);
-            double dev_t = 0.;
-            for (size_t k = 0; k < Settings.outputCount; ++k) {
-                double iv = r[k] - rndVal;
-                dev_t += iv * iv;
-            }
-            delete[] r;
-            t += std::sqrt(dev_t);
-        }
-        delete[] vs;
-    }
-    return (float)t;
-}
-
-template <typename _T>
-float bcuda::ai::evol::eval::output::Evaluate_Proliferation(void* Object, Evaluate_Proliferation_SD<_T>& Settings) {
-    if (!Settings.inputCount) {
-        throw std::runtime_error("'Settings.inputCount' cannot be zero.");
-    }
-    Instance_V<_T*, _T*> oi(Settings.instanceFunctions, Object, Settings.sd_ci);
-    uint64_t t = 0ui64;
-    for (size_t i = 0; i < Settings.roundCount; ++i) {
-        _T* vs = new _T[Settings.inputCount];
-        _T rndVal = (_T)Settings.rng();
-        for (size_t j = 0; j < Settings.inputCount; ++j) {
-            vs[j] = rndVal;
-        }
-        for (size_t j = 0; j < Settings.iterationsPerRound; ++j) {
-            _T* r = oi.IterateInstance(vs);
-            for (size_t k = 0; k < Settings.outputCount; ++k) {
-                _T iv = Settings.mask & ~(r[k] ^ rndVal);
-                if constexpr (std::is_same<int8_t, _T>::value || std::is_same<uint8_t, _T>::value) {
-                    t += std::popcount((uint8_t)iv);
-                }
-                else if constexpr (std::is_same<int16_t, _T>::value || std::is_same<uint16_t, _T>::value) {
-                    t += std::popcount((uint16_t)iv);
-                }
-                else if constexpr (std::is_same<int32_t, _T>::value || std::is_same<uint32_t, _T>::value) {
-                    t += std::popcount((uint32_t)iv);
-                }
-                else if constexpr (std::is_same<int64_t, _T>::value || std::is_same<uint64_t, _T>::value) {
-                    t += std::popcount((uint64_t)iv);
-                }
-                else {
-                    throw std::exception();
-                }
-            }
-            delete[] r;
-        }
-        delete[] vs;
-    }
-    _T mc;
-    if constexpr (std::is_same<int8_t, _T>::value || std::is_same<uint8_t, _T>::value) {
-        mc = std::popcount((uint8_t)Settings.mask);
-    }
-    else if constexpr (std::is_same<int16_t, _T>::value || std::is_same<uint16_t, _T>::value) {
-        mc = std::popcount((uint16_t)Settings.mask);
-    }
-    else if constexpr (std::is_same<int32_t, _T>::value || std::is_same<uint32_t, _T>::value) {
-        mc = std::popcount((uint32_t)Settings.mask);
-    }
-    else if constexpr (std::is_same<int64_t, _T>::value || std::is_same<uint64_t, _T>::value) {
-        mc = std::popcount((uint64_t)Settings.mask);
-    }
-    else {
-        throw std::exception();
-    }
-    return (float)t / (float)((uint64_t)mc * Settings.iterationsPerRound * Settings.roundCount * Settings.outputCount);
-}
-
-template <typename _T>
-float bcuda::ai::evol::eval::output::Evaluate_Proliferation(void* Object, void* Settings) {
-    return Evaluate_Proliferation<_T>(Object, *(Evaluate_Proliferation_SD<_T>*)Settings);
-}
-
-template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<uint8_t>(void*, Evaluate_Proliferation_SD<uint8_t>&);
-template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<int8_t>(void*, Evaluate_Proliferation_SD<int8_t>&);
-template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<uint16_t>(void*, Evaluate_Proliferation_SD<uint16_t>&);
-template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<int16_t>(void*, Evaluate_Proliferation_SD<int16_t>&);
-template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<uint32_t>(void*, Evaluate_Proliferation_SD<uint32_t>&);
-template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<int32_t>(void*, Evaluate_Proliferation_SD<int32_t>&);
-template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<uint64_t>(void*, Evaluate_Proliferation_SD<uint64_t>&);
-template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<int64_t>(void*, Evaluate_Proliferation_SD<int64_t>&);
-template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<float>(void*, Evaluate_Proliferation_SD<float>&);
-template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<double>(void*, Evaluate_Proliferation_SD<double>&);
-
-template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<uint8_t>(void*, void*);
-template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<int8_t>(void*, void*);
-template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<uint16_t>(void*, void*);
-template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<int16_t>(void*, void*);
-template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<uint32_t>(void*, void*);
-template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<int32_t>(void*, void*);
-template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<uint64_t>(void*, void*);
-template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<int64_t>(void*, void*);
-template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<float>(void*, void*);
-template float bcuda::ai::evol::eval::output::Evaluate_Proliferation<double>(void*, void*);

--- a/ai_evol_eval_output_impl_proliferation.h
+++ b/ai_evol_eval_output_impl_proliferation.h
@@ -18,7 +18,7 @@ namespace bcuda {
                         _T mask;
                         void* sd_ci;
                         bcuda::rand::AnyRNG<uint64_t> rng;
-                        __forceinline Evaluate_Proliferation_SD(bcuda::rand::AnyRNG<uint64_t> RNG)
+                        inline Evaluate_Proliferation_SD(bcuda::rand::AnyRNG<uint64_t> RNG)
                             : rng(RNG), instanceFunctions(), iterationsPerRound(0), roundCount(0), inputCount(0), outputCount(0), mask(0), sd_ci(0) { }
                     };
                     template <>
@@ -30,7 +30,7 @@ namespace bcuda {
                         size_t outputCount;
                         void* sd_ci;
                         bcuda::rand::AnyRNG<uint64_t> rng;
-                        __forceinline Evaluate_Proliferation_SD(bcuda::rand::AnyRNG<uint64_t> RNG)
+                        inline Evaluate_Proliferation_SD(bcuda::rand::AnyRNG<uint64_t> RNG)
                             : rng(RNG), instanceFunctions(), iterationsPerRound(0), roundCount(0), inputCount(0), outputCount(0), mask(0), sd_ci(0) { }
                     };
                     template <>
@@ -42,7 +42,7 @@ namespace bcuda {
                         size_t outputCount;
                         void* sd_ci;
                         bcuda::rand::AnyRNG<uint64_t> rng;
-                        __forceinline Evaluate_Proliferation_SD(bcuda::rand::AnyRNG<uint64_t> RNG)
+                        inline Evaluate_Proliferation_SD(bcuda::rand::AnyRNG<uint64_t> RNG)
                             : rng(RNG), instanceFunctions(), iterationsPerRound(0), roundCount(0), inputCount(0), outputCount(0), mask(0), sd_ci(0) { }
                     };
 

--- a/ai_evol_eval_output_impl_proliferation.h
+++ b/ai_evol_eval_output_impl_proliferation.h
@@ -31,7 +31,7 @@ namespace bcuda {
                         void* sd_ci;
                         bcuda::rand::AnyRNG<uint64_t> rng;
                         inline Evaluate_Proliferation_SD(bcuda::rand::AnyRNG<uint64_t> RNG)
-                            : rng(RNG), instanceFunctions(), iterationsPerRound(0), roundCount(0), inputCount(0), outputCount(0), mask(0), sd_ci(0) { }
+                            : rng(RNG), instanceFunctions(), iterationsPerRound(0), roundCount(0), inputCount(0), outputCount(0), sd_ci(0) { }
                     };
                     template <>
                     struct Evaluate_Proliferation_SD<double> final {
@@ -43,7 +43,7 @@ namespace bcuda {
                         void* sd_ci;
                         bcuda::rand::AnyRNG<uint64_t> rng;
                         inline Evaluate_Proliferation_SD(bcuda::rand::AnyRNG<uint64_t> RNG)
-                            : rng(RNG), instanceFunctions(), iterationsPerRound(0), roundCount(0), inputCount(0), outputCount(0), mask(0), sd_ci(0) { }
+                            : rng(RNG), instanceFunctions(), iterationsPerRound(0), roundCount(0), inputCount(0), outputCount(0), sd_ci(0) { }
                     };
 
                     template <typename _T>

--- a/ai_evol_eval_output_impl_proliferation.h
+++ b/ai_evol_eval_output_impl_proliferation.h
@@ -18,7 +18,8 @@ namespace bcuda {
                         _T mask;
                         void* sd_ci;
                         bcuda::rand::AnyRNG<uint64_t> rng;
-                        __forceinline Evaluate_Proliferation_SD(bcuda::rand::AnyRNG<uint64_t> RNG);
+                        __forceinline Evaluate_Proliferation_SD(bcuda::rand::AnyRNG<uint64_t> RNG)
+                            : rng(RNG), instanceFunctions(), iterationsPerRound(0), roundCount(0), inputCount(0), outputCount(0), mask(0), sd_ci(0) { }
                     };
                     template <>
                     struct Evaluate_Proliferation_SD<float> final {
@@ -29,7 +30,8 @@ namespace bcuda {
                         size_t outputCount;
                         void* sd_ci;
                         bcuda::rand::AnyRNG<uint64_t> rng;
-                        __forceinline Evaluate_Proliferation_SD(bcuda::rand::AnyRNG<uint64_t> RNG);
+                        __forceinline Evaluate_Proliferation_SD(bcuda::rand::AnyRNG<uint64_t> RNG)
+                            : rng(RNG), instanceFunctions(), iterationsPerRound(0), roundCount(0), inputCount(0), outputCount(0), mask(0), sd_ci(0) { }
                     };
                     template <>
                     struct Evaluate_Proliferation_SD<double> final {
@@ -40,7 +42,8 @@ namespace bcuda {
                         size_t outputCount;
                         void* sd_ci;
                         bcuda::rand::AnyRNG<uint64_t> rng;
-                        __forceinline Evaluate_Proliferation_SD(bcuda::rand::AnyRNG<uint64_t> RNG);
+                        __forceinline Evaluate_Proliferation_SD(bcuda::rand::AnyRNG<uint64_t> RNG)
+                            : rng(RNG), instanceFunctions(), iterationsPerRound(0), roundCount(0), inputCount(0), outputCount(0), mask(0), sd_ci(0) { }
                     };
 
                     template <typename _T>
@@ -51,34 +54,4 @@ namespace bcuda {
             }
         }
     }
-}
-
-template <typename _T>
-__forceinline bcuda::ai::evol::eval::output::Evaluate_Proliferation_SD<_T>::Evaluate_Proliferation_SD(bcuda::rand::AnyRNG<uint64_t> RNG)
-    : rng(RNG),
-    instanceFunctions() {
-    iterationsPerRound = 0;
-    roundCount = 0;
-    inputCount = 0;
-    outputCount = 0;
-    mask = 0;
-    sd_ci = 0;
-}
-__forceinline bcuda::ai::evol::eval::output::Evaluate_Proliferation_SD<float>::Evaluate_Proliferation_SD(bcuda::rand::AnyRNG<uint64_t> RNG)
-    : rng(RNG),
-    instanceFunctions() {
-    iterationsPerRound = 0;
-    roundCount = 0;
-    inputCount = 0;
-    outputCount = 0;
-    sd_ci = 0;
-}
-__forceinline bcuda::ai::evol::eval::output::Evaluate_Proliferation_SD<double>::Evaluate_Proliferation_SD(bcuda::rand::AnyRNG<uint64_t> RNG)
-    : rng(RNG),
-    instanceFunctions() {
-    iterationsPerRound = 0;
-    roundCount = 0;
-    inputCount = 0;
-    outputCount = 0;
-    sd_ci = 0;
 }

--- a/ai_evol_eval_output_impl_uniquevalues.cpp
+++ b/ai_evol_eval_output_impl_uniquevalues.cpp
@@ -2,62 +2,72 @@
 #include <exception>
 #include <unordered_set>
 
-template <typename _T>
-float bcuda::ai::evol::eval::output::Evaluate_UniqueValues(void* Object, Evaluate_UniqueValues_SD<_T>& Settings) {
-    Instance_V<_T*, _T*> oi(Settings.instanceFunctions, Object, Settings.sd_ci);
-    if (Settings.individual) {
-        std::unordered_set<_T>* s = new std::unordered_set<_T>[Settings.outputCount];
-        for (size_t i = 0; i < Settings.outputCount; ++i) {
-            s[i] = std::unordered_set<_T>();
-        }
-        for (uint64_t i = 0; i < Settings.iterationCount; ++i) {
-            _T* o = oi.IterateInstance(0);
-            for (size_t j = 0; j < Settings.outputCount; ++j) {
-                s[j].insert(o[j]);
+namespace bcuda {
+    namespace ai {
+        namespace evol {
+            namespace eval {
+                namespace output {
+                    template <typename _T>
+                    float Evaluate_UniqueValues(void* Object, Evaluate_UniqueValues_SD<_T>& Settings) {
+                        Instance_V<_T*, _T*> oi(Settings.instanceFunctions, Object, Settings.sd_ci);
+                        if (Settings.individual) {
+                            std::unordered_set<_T>* s = new std::unordered_set<_T>[Settings.outputCount];
+                            for (size_t i = 0; i < Settings.outputCount; ++i) {
+                                s[i] = std::unordered_set<_T>();
+                            }
+                            for (uint64_t i = 0; i < Settings.iterationCount; ++i) {
+                                _T* o = oi.IterateInstance(0);
+                                for (size_t j = 0; j < Settings.outputCount; ++j) {
+                                    s[j].insert(o[j]);
+                                }
+                                delete[] o;
+                            }
+                            size_t c = 0;
+                            for (size_t i = 0; i < Settings.outputCount; ++i) {
+                                c += s[i].size();
+                            }
+                            delete[] s;
+                            oi.DestroyInstance();
+                            return c / (float)(Settings.iterationCount * Settings.outputCount);
+                        }
+                        else {
+                            std::unordered_set<_T> s;
+                            for (uint64_t i = 0; i < Settings.iterationCount; ++i) {
+                                _T* o = oi.IterateInstance(0);
+                                for (size_t j = 0; j < Settings.outputCount; ++j) {
+                                    s.insert(o[j]);
+                                }
+                                delete[] o;
+                            }
+                            oi.DestroyInstance();
+                            return s.size() / (float)(Settings.iterationCount * Settings.outputCount);
+                        }
+                    }
+
+                    template <typename _T>
+                    float Evaluate_UniqueValues(void* Object, void* Settings) {
+                        return Evaluate_UniqueValues(Object, *(Evaluate_UniqueValues_SD<_T>*)Settings);
+                    }
+
+                    template float Evaluate_UniqueValues<uint8_t>(void*, Evaluate_UniqueValues_SD<uint8_t>&);
+                    template float Evaluate_UniqueValues<int8_t>(void*, Evaluate_UniqueValues_SD<int8_t>&);
+                    template float Evaluate_UniqueValues<uint16_t>(void*, Evaluate_UniqueValues_SD<uint16_t>&);
+                    template float Evaluate_UniqueValues<int16_t>(void*, Evaluate_UniqueValues_SD<int16_t>&);
+                    template float Evaluate_UniqueValues<uint32_t>(void*, Evaluate_UniqueValues_SD<uint32_t>&);
+                    template float Evaluate_UniqueValues<int32_t>(void*, Evaluate_UniqueValues_SD<int32_t>&);
+                    template float Evaluate_UniqueValues<uint64_t>(void*, Evaluate_UniqueValues_SD<uint64_t>&);
+                    template float Evaluate_UniqueValues<int64_t>(void*, Evaluate_UniqueValues_SD<int64_t>&);
+
+                    template float Evaluate_UniqueValues<uint8_t>(void*, void*);
+                    template float Evaluate_UniqueValues<int8_t>(void*, void*);
+                    template float Evaluate_UniqueValues<uint16_t>(void*, void*);
+                    template float Evaluate_UniqueValues<int16_t>(void*, void*);
+                    template float Evaluate_UniqueValues<uint32_t>(void*, void*);
+                    template float Evaluate_UniqueValues<int32_t>(void*, void*);
+                    template float Evaluate_UniqueValues<uint64_t>(void*, void*);
+                    template float Evaluate_UniqueValues<int64_t>(void*, void*);
+                }
             }
-            delete[] o;
         }
-        size_t c = 0;
-        for (size_t i = 0; i < Settings.outputCount; ++i) {
-            c += s[i].size();
-        }
-        delete[] s;
-        oi.DestroyInstance();
-        return c / (float)(Settings.iterationCount * Settings.outputCount);
-    }
-    else {
-        std::unordered_set<_T> s;
-        for (uint64_t i = 0; i < Settings.iterationCount; ++i) {
-            _T* o = oi.IterateInstance(0);
-            for (size_t j = 0; j < Settings.outputCount; ++j) {
-                s.insert(o[j]);
-            }
-            delete[] o;
-        }
-        oi.DestroyInstance();
-        return s.size() / (float)(Settings.iterationCount * Settings.outputCount);
     }
 }
-
-template <typename _T>
-float bcuda::ai::evol::eval::output::Evaluate_UniqueValues(void* Object, void* Settings) {
-    return Evaluate_UniqueValues(Object, *(Evaluate_UniqueValues_SD<_T>*)Settings);
-}
-
-template float bcuda::ai::evol::eval::output::Evaluate_UniqueValues<uint8_t>(void*, Evaluate_UniqueValues_SD<uint8_t>&);
-template float bcuda::ai::evol::eval::output::Evaluate_UniqueValues<int8_t>(void*, Evaluate_UniqueValues_SD<int8_t>&);
-template float bcuda::ai::evol::eval::output::Evaluate_UniqueValues<uint16_t>(void*, Evaluate_UniqueValues_SD<uint16_t>&);
-template float bcuda::ai::evol::eval::output::Evaluate_UniqueValues<int16_t>(void*, Evaluate_UniqueValues_SD<int16_t>&);
-template float bcuda::ai::evol::eval::output::Evaluate_UniqueValues<uint32_t>(void*, Evaluate_UniqueValues_SD<uint32_t>&);
-template float bcuda::ai::evol::eval::output::Evaluate_UniqueValues<int32_t>(void*, Evaluate_UniqueValues_SD<int32_t>&);
-template float bcuda::ai::evol::eval::output::Evaluate_UniqueValues<uint64_t>(void*, Evaluate_UniqueValues_SD<uint64_t>&);
-template float bcuda::ai::evol::eval::output::Evaluate_UniqueValues<int64_t>(void*, Evaluate_UniqueValues_SD<int64_t>&);
-
-template float bcuda::ai::evol::eval::output::Evaluate_UniqueValues<uint8_t>(void*, void*);
-template float bcuda::ai::evol::eval::output::Evaluate_UniqueValues<int8_t>(void*, void*);
-template float bcuda::ai::evol::eval::output::Evaluate_UniqueValues<uint16_t>(void*, void*);
-template float bcuda::ai::evol::eval::output::Evaluate_UniqueValues<int16_t>(void*, void*);
-template float bcuda::ai::evol::eval::output::Evaluate_UniqueValues<uint32_t>(void*, void*);
-template float bcuda::ai::evol::eval::output::Evaluate_UniqueValues<int32_t>(void*, void*);
-template float bcuda::ai::evol::eval::output::Evaluate_UniqueValues<uint64_t>(void*, void*);
-template float bcuda::ai::evol::eval::output::Evaluate_UniqueValues<int64_t>(void*, void*);

--- a/ai_evol_eval_output_impl_uniquevalues.h
+++ b/ai_evol_eval_output_impl_uniquevalues.h
@@ -14,7 +14,8 @@ namespace bcuda {
                         size_t outputCount;
                         bool individual;
                         void* sd_ci;
-                        __forceinline Evaluate_UniqueValues_SD() = default;
+                        inline constexpr Evaluate_UniqueValues_SD()
+                            : InstanceFunctions(), iterationCount(0), outputCount(0), individual(0), sd_ci(0) { }
                     };
 
                     template <typename _T>

--- a/ai_evol_evolver.cpp
+++ b/ai_evol_evolver.cpp
@@ -1,88 +1,80 @@
 #include "ai_evol_evolver.h"
 #include <algorithm>
 
-bcuda::ai::evol::Evolver::Evolver(
-    size_t ContestantCount,
-    evaluationFunction_t EvaluationFunction,
-    reproductionFunction_t ReproductionFunction,
-    disposeFunction_t DisposeFunction
-) : objs(ContestantCount) {
-    evaluationFunction = EvaluationFunction;
-    reproductionFunction = ReproductionFunction;
-    disposeFunction = DisposeFunction;
-}
-bcuda::ai::evol::Evolver::Evolver(
-    size_t ContestantCount,
-    evaluationFunction_t EvaluationFunction,
-    reproductionFunction_t ReproductionFunction,
-    disposeFunction_t DisposeFunction,
-    creationFunction_t CreationFunction,
-    void* CreationSharedData
-) : Evolver(ContestantCount, EvaluationFunction, ReproductionFunction, DisposeFunction) {
-    InitAllNoDisposal(CreationFunction, CreationSharedData);
-}
-bcuda::ArrayV<void*> bcuda::ai::evol::Evolver::Objects() {
-    return objs;
-}
-void bcuda::ai::evol::Evolver::InitAllNoDisposal(creationFunction_t CreationFunction, void* CreationSharedData) {
-    std::uniform_int_distribution<uint64_t> dis(std::numeric_limits<uint64_t>::min(), std::numeric_limits<uint64_t>::max());
+namespace bcuda {
+    namespace ai {
+        namespace evol {
+            Evolver::Evolver(size_t ContestantCount, evaluationFunction_t EvaluationFunction, reproductionFunction_t ReproductionFunction, disposeFunction_t DisposeFunction)
+                : objs(ContestantCount), evaluationFunction(EvaluationFunction), reproductionFunction(ReproductionFunction), disposeFunction(DisposeFunction) { }
+            Evolver::Evolver(size_t ContestantCount, evaluationFunction_t EvaluationFunction, reproductionFunction_t ReproductionFunction, disposeFunction_t DisposeFunction, creationFunction_t CreationFunction, void* CreationSharedData)
+                : Evolver(ContestantCount, EvaluationFunction, ReproductionFunction, DisposeFunction) {
+                InitAllNoDisposal(CreationFunction, CreationSharedData);
+            }
+            bcuda::ArrayV<void*> Evolver::Objects() {
+                return objs;
+            }
+            void Evolver::InitAllNoDisposal(creationFunction_t CreationFunction, void* CreationSharedData) {
+                std::uniform_int_distribution<uint64_t> dis(std::numeric_limits<uint64_t>::min(), std::numeric_limits<uint64_t>::max());
 
-    for (size_t i = 0; i < objs.Size(); ++i) {
-        objs[i] = CreationFunction(CreationSharedData);
-    }
-}
-void bcuda::ai::evol::Evolver::InitAll(void* DisposeSharedData, creationFunction_t CreationFunction, void* CreationSharedData) {
-    std::uniform_int_distribution<uint64_t> dis(std::numeric_limits<uint64_t>::min(), std::numeric_limits<uint64_t>::max());
+                for (size_t i = 0; i < objs.Size(); ++i) {
+                    objs[i] = CreationFunction(CreationSharedData);
+                }
+            }
+            void Evolver::InitAll(void* DisposeSharedData, creationFunction_t CreationFunction, void* CreationSharedData) {
+                std::uniform_int_distribution<uint64_t> dis(std::numeric_limits<uint64_t>::min(), std::numeric_limits<uint64_t>::max());
 
-    for (size_t i = 0; i < objs.Size(); ++i) {
-        void*& v = objs[i];
-        disposeFunction(v, DisposeSharedData);
-        v = CreationFunction(CreationSharedData);
-    }
-}
-bcuda::ArrayV<std::pair<float, size_t>> bcuda::ai::evol::Evolver::EvaluateAll(void* EvaluationSharedData) {
-    std::uniform_int_distribution<uint64_t> dis(std::numeric_limits<uint64_t>::min(), std::numeric_limits<uint64_t>::max());
+                for (size_t i = 0; i < objs.Size(); ++i) {
+                    void*& v = objs[i];
+                    disposeFunction(v, DisposeSharedData);
+                    v = CreationFunction(CreationSharedData);
+                }
+            }
+            bcuda::ArrayV<std::pair<float, size_t>> Evolver::EvaluateAll(void* EvaluationSharedData) {
+                std::uniform_int_distribution<uint64_t> dis(std::numeric_limits<uint64_t>::min(), std::numeric_limits<uint64_t>::max());
 
-    ArrayV<std::pair<float, size_t>> scores(objs.Size());
-    for (size_t i = 0; i < objs.Size(); ++i) {
-        scores[i] = std::pair<float, size_t>(evaluationFunction(objs[i], EvaluationSharedData), i);
-    }
-    return scores;
-}
-void bcuda::ai::evol::SortEvaluations(ArrayV<std::pair<float, size_t>> Evaluations) {
-    std::sort(Evaluations.Data(), Evaluations.Data() + Evaluations.Size(), [](const auto& a, const auto& b) {
-        return a.first < b.first;
-    });
-}
-void bcuda::ai::evol::Evolver::ActOnSortedEvaluations(ArrayV<std::pair<float, size_t>> Evaluations, void* DisposeSharedData, void* ReproductionSharedData) {
-    std::uniform_int_distribution<uint64_t> dis(std::numeric_limits<uint64_t>::min(), std::numeric_limits<uint64_t>::max());
-    
-    if (Evaluations.Size() != objs.Size())
-        throw new std::exception("Input array 'Evaluations' must be the same size as field 'Objects'.");
+                ArrayV<std::pair<float, size_t>> scores(objs.Size());
+                for (size_t i = 0; i < objs.Size(); ++i) {
+                    scores[i] = std::pair<float, size_t>(evaluationFunction(objs[i], EvaluationSharedData), i);
+                }
+                return scores;
+            }
+            void SortEvaluations(ArrayV<std::pair<float, size_t>> Evaluations) {
+                std::sort(Evaluations.Data(), Evaluations.Data() + Evaluations.Size(), [](const auto& a, const auto& b) {
+                    return a.first < b.first;
+                    });
+            }
+            void Evolver::ActOnSortedEvaluations(ArrayV<std::pair<float, size_t>> Evaluations, void* DisposeSharedData, void* ReproductionSharedData) {
+                std::uniform_int_distribution<uint64_t> dis(std::numeric_limits<uint64_t>::min(), std::numeric_limits<uint64_t>::max());
 
-    size_t s1_2 = objs.Size() >> 1;
+                if (Evaluations.Size() != objs.Size())
+                    throw new std::exception("Input array 'Evaluations' must be the same size as field 'Objects'.");
 
-    size_t i;
-    size_t j = objs.Size() - s1_2;
-    for (i = 0; i < s1_2; ++i) {
-        void*& iVP(objs[Evaluations[i].second]);
-        void*& jVP(objs[Evaluations[j].second]);
-        void* n = reproductionFunction(jVP, ReproductionSharedData);
-        disposeFunction(iVP, DisposeSharedData);
-        iVP = n;
+                size_t s1_2 = objs.Size() >> 1;
 
-        ++j;
-    }
-}
-bcuda::ArrayV<std::pair<float, size_t>> bcuda::ai::evol::Evolver::RunStep(void* EvaluationSharedData, void* ReproductionSharedData, void* DisposeSharedData) {
-    auto eval = EvaluateAll(EvaluationSharedData);
-    SortEvaluations(eval);
-    ActOnSortedEvaluations(eval, DisposeSharedData, ReproductionSharedData);
-    return eval;
-}
-void bcuda::ai::evol::Evolver::Dispose(void* DisposeSharedData) {
-    for (size_t i = 0; i < objs.Size(); ++i) {
-        void* v = objs[i];
-        if (v) disposeFunction(v, DisposeSharedData);
+                size_t i;
+                size_t j = objs.Size() - s1_2;
+                for (i = 0; i < s1_2; ++i) {
+                    void*& iVP(objs[Evaluations[i].second]);
+                    void*& jVP(objs[Evaluations[j].second]);
+                    void* n = reproductionFunction(jVP, ReproductionSharedData);
+                    disposeFunction(iVP, DisposeSharedData);
+                    iVP = n;
+
+                    ++j;
+                }
+            }
+            bcuda::ArrayV<std::pair<float, size_t>> Evolver::RunStep(void* EvaluationSharedData, void* ReproductionSharedData, void* DisposeSharedData) {
+                auto eval = EvaluateAll(EvaluationSharedData);
+                SortEvaluations(eval);
+                ActOnSortedEvaluations(eval, DisposeSharedData, ReproductionSharedData);
+                return eval;
+            }
+            void Evolver::Dispose(void* DisposeSharedData) {
+                for (size_t i = 0; i < objs.Size(); ++i) {
+                    void* v = objs[i];
+                    if (v) disposeFunction(v, DisposeSharedData);
+                }
+            }
+        }
     }
 }

--- a/ai_evol_evolver.h
+++ b/ai_evol_evolver.h
@@ -12,45 +12,33 @@ namespace bcuda {
             class Evolver {
             public:
                 //Creates an instance of the bcuda::ai::evol::Evolver class.
-                Evolver(
-                    size_t ContestantCount,
-                    evaluationFunction_t EvaluationFunction,
-                    reproductionFunction_t ReproductionFunction,
-                    disposeFunction_t DisposeFunction
-                );
-                //Creates an instance of the bcuda::ai::evol::Evolver class.
-                Evolver(
-                    size_t ContestantCount,
-                    evaluationFunction_t EvaluationFunction,
-                    reproductionFunction_t ReproductionFunction,
-                    disposeFunction_t DisposeFunction,
-                    creationFunction_t CreationFunction,
-                    void* CreationSharedData
-                );
-                //An array of all the objects in the evolutionary system.
+                Evolver(size_t ContestantCount, evaluationFunction_t EvaluationFunction, reproductionFunction_t ReproductionFunction, disposeFunction_t DisposeFunction);
+                // Creates an instance of the bcuda::ai::evol::Evolver class.
+                Evolver(size_t ContestantCount, evaluationFunction_t EvaluationFunction, reproductionFunction_t ReproductionFunction, disposeFunction_t DisposeFunction, creationFunction_t CreationFunction, void* CreationSharedData);
+                // An array of all the objects in the evolutionary system.
                 ArrayV<void*> Objects();
-                //Initializes the array of objects without attempting to dispose of any existing objects, if valid.
+                // Initializes the array of objects without attempting to dispose of any existing objects, if valid.
                 void InitAllNoDisposal(creationFunction_t CreationFunction, void* CreationSharedData);
-                //Disposes of previous objects and then reinitializes the array to be of all new objects.
+                // Disposes of previous objects and then reinitializes the array to be of all new objects.
                 void InitAll(void* DisposeSharedData, creationFunction_t CreationFunction, void* CreationSharedData);
-                //Disposes of the class, including the objects current in the evolutionary system.
+                // Disposes of the class, including the objects current in the evolutionary system.
                 void Dispose(void* DisposeSharedData);
-                //Evaluates the objects currently present, and returns their respective scores in a format ready for sorting.
+                // Evaluates the objects currently present, and returns their respective scores in a format ready for sorting.
                 ArrayV<std::pair<float, size_t>> EvaluateAll(void* EvaluationSharedData);
-                //Disposes of below-average performers, and replaces them with the offspring of the above-average performers.
+                // Disposes of below-average performers, and replaces them with the offspring of the above-average performers.
                 void ActOnSortedEvaluations(ArrayV<std::pair<float, size_t>> Evaluations, void* DisposeSharedData, void* ReproductionSharedData);
-                //Evaluates and undergoes the reproduction of all the objects present.
+                // Evaluates and undergoes the reproduction of all the objects present.
                 ArrayV<std::pair<float, size_t>> RunStep(void* EvaluationSharedData, void* ReproductionSharedData, void* DisposeSharedData);
-                //The evaluation function of the evolutionary system, utilized in EvaluateAll and, by proxy, RunStep.
+                // The evaluation function of the evolutionary system, utilized in EvaluateAll and, by proxy, RunStep.
                 evaluationFunction_t evaluationFunction;
-                //The reproduction function of the evolutionary system, utilized in ActOnSortedEvaluations and, by proxy, RunStep.
+                // The reproduction function of the evolutionary system, utilized in ActOnSortedEvaluations and, by proxy, RunStep.
                 reproductionFunction_t reproductionFunction;
-                //The disposal function of the evolutionary system, utilized in InitAll, ActOnSortedEvaluations, and, by proxy, RunStep.
+                // The disposal function of the evolutionary system, utilized in InitAll, ActOnSortedEvaluations, and, by proxy, RunStep.
                 disposeFunction_t disposeFunction;
             private:
                 ArrayV<void*> objs;
             };
-            //Sorts the evaluations of evaluated objects evaluated in the evaluation process of an evolutionary system.
+            // Sorts the evaluations of evaluated objects evaluated in the evaluation process of an evolutionary system.
             void SortEvaluations(ArrayV<std::pair<float, size_t>> Evaluations);
         }
     }

--- a/ai_genetics_genefixedmlp.h
+++ b/ai_genetics_genefixedmlp.h
@@ -21,196 +21,129 @@ namespace bcuda {
                 inputArray_t base;
                 mlp_t mlp;
 
-                void ZeroOverwrite();
+                void ZeroOverwrite() {
+                    rand::ClearArray<false, _T>(Span<_T>(base, mlp.InputLength()));
+                    mlp.ZeroOverwrite();
+                }
                 template <std::uniform_random_bit_generator _TRNG>
-                void RandomOverwrite(_TRNG& RNG);
+                void RandomOverwrite(_TRNG& RNG) {
+                    rand::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), RNG);
+                    mlp.RandomOverwrite(RNG);
+                }
                 template <std::uniform_random_bit_generator _TRNG>
-                void RandomOverwrite(_T LowerBound, _T UpperBound, _TRNG& RNG);
+                void RandomOverwrite(_T LowerBound, _T UpperBound, _TRNG& RNG) {
+                    rand::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), LowerBound, UpperBound, RNG);
+                    mlp.RandomOverwrite(LowerBound, UpperBound, RNG);
+                }
                 template <KernelCurandState _TRNG>
-                __device__ void RandomOverwrite(_TRNG& RNG);
+                __device__ void RandomOverwrite(_TRNG& RNG) {
+                    rand::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), RNG);
+                    mlp.RandomOverwrite(RNG);
+                }
                 template <KernelCurandState _TRNG>
-                __device__ void RandomOverwrite(_T LowerBound, _T UpperBound, _TRNG& RNG);
+                __device__ void RandomOverwrite(_T LowerBound, _T UpperBound, _TRNG& RNG) {
+                    rand::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), LowerBound, UpperBound, RNG);
+                    mlp.RandomOverwrite(LowerBound, UpperBound, RNG);
+                }
 
-                outputArray_t* Run();
-                void Run(outputArray_t* OutputArray);
+                outputArray_t* Run() {
+                    auto* outputArr = new outputArray_t;
+                    Run(outputArr);
+                    return outputArr;
+                }
+                void Run(outputArray_t* OutputArray) {
+                    mlp.Run(base.data(), OutputArray->data());
+                }
 
                 template <std::uniform_random_bit_generator _TRNG>
-                void Randomize(_T Scalar, _TRNG& RNG);
+                void Randomize(_T Scalar, _TRNG& RNG) {
+                    rand::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, RNG);
+                    mlp.Randomize(Scalar, RNG);
+                }
                 template <std::uniform_random_bit_generator _TRNG>
-                void Randomize(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG);
+                void Randomize(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+                    rand::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, LowerBound, UpperBound, RNG);
+                    mlp.Randomize(Scalar, LowerBound, UpperBound, RNG);
+                }
                 template <std::uniform_random_bit_generator _TRNG>
-                void Randomize(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG);
+                void Randomize(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
+                    rand::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, RNG);
+                    mlp.Randomize(Scalar_MLP, RNG);
+                }
                 template <std::uniform_random_bit_generator _TRNG>
-                void Randomize(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG);
+                void Randomize(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+                    rand::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, LowerBound, UpperBound, RNG);
+                    mlp.Randomize(Scalar_MLP, LowerBound, UpperBound, RNG);
+                }
                 template <std::uniform_random_bit_generator _TRNG>
-                this_t Reproduce(_T Scalar, _TRNG& RNG);
+                this_t Reproduce(_T Scalar, _TRNG& RNG) {
+                    this_t n = Clone();
+                    n.Randomize(Scalar, RNG);
+                    return n;
+                }
                 template <std::uniform_random_bit_generator _TRNG>
-                this_t Reproduce(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG);
+                this_t Reproduce(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+                    this_t n = Clone();
+                    n.Randomize(Scalar, LowerBound, UpperBound, RNG);
+                    return n;
+                }
                 template <std::uniform_random_bit_generator _TRNG>
-                this_t Reproduce(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG);
+                this_t Reproduce(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
+                    this_t n = Clone();
+                    n.Randomize(Scalar_Base, Scalar_MLP, RNG);
+                    return n;
+                }
                 template <std::uniform_random_bit_generator _TRNG>
-                this_t Reproduce(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG);
+                this_t Reproduce(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+                    this_t n = Clone();
+                    n.Randomize(Scalar_Base, Scalar_MLP, LowerBound, UpperBound, RNG);
+                    return n;
+                }
                 template <KernelCurandState _TRNG>
-                __device__ void Randomize(_T Scalar, _TRNG& RNG);
+                __device__ void Randomize(_T Scalar, _TRNG& RNG) {
+                    rand::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, RNG);
+                    mlp.Randomize(Scalar, RNG);
+                }
                 template <KernelCurandState _TRNG>
-                __device__ void Randomize(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG);
+                __device__ void Randomize(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+                    rand::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, LowerBound, UpperBound, RNG);
+                    mlp.Randomize(Scalar, LowerBound, UpperBound, RNG);
+                }
                 template <KernelCurandState _TRNG>
-                __device__ void Randomize(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG);
+                __device__ void Randomize(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
+                    rand::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, RNG);
+                    mlp.Randomize(Scalar_MLP, RNG);
+                }
                 template <KernelCurandState _TRNG>
-                __device__ void Randomize(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG);
+                __device__ void Randomize(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+                    rand::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, LowerBound, UpperBound, RNG);
+                    mlp.Randomize(Scalar_MLP, LowerBound, UpperBound, RNG);
+                }
                 template <KernelCurandState _TRNG>
-                __device__ this_t Reproduce(_T Scalar, _TRNG& RNG);
+                __device__ this_t Reproduce(_T Scalar, _TRNG& RNG) {
+                    this_t n = Clone();
+                    n.Randomize(Scalar, RNG);
+                    return n;
+                }
                 template <KernelCurandState _TRNG>
-                __device__ this_t Reproduce(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG);
+                __device__ this_t Reproduce(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+                    this_t n = Clone();
+                    n.Randomize(Scalar, LowerBound, UpperBound, RNG);
+                    return n;
+                }
                 template <KernelCurandState _TRNG>
-                __device__ this_t Reproduce(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG);
+                __device__ this_t Reproduce(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
+                    this_t n = Clone();
+                    n.Randomize(Scalar_Base, Scalar_MLP, RNG);
+                    return n;
+                }
                 template <KernelCurandState _TRNG>
-                __device__ this_t Reproduce(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG);
+                __device__ this_t Reproduce(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+                    this_t n = Clone();
+                    n.Randomize(Scalar_Base, Scalar_MLP, LowerBound, UpperBound, RNG);
+                    return n;
+                }
             };
         }
     }
-}
-
-template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-auto bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Run() -> outputArray_t* {
-    auto* outputArr = new outputArray_t;
-    Run(outputArr);
-    return outputArr;
-}
-template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Run(outputArray_t* OutputArray) {
-    mlp.Run(base.data(), OutputArray->data());
-}
-template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <std::uniform_random_bit_generator _TRNG>
-void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _TRNG& RNG) {
-    rand::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, RNG);
-    mlp.Randomize(Scalar, RNG);
-}
-template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <std::uniform_random_bit_generator _TRNG>
-void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
-    rand::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, LowerBound, UpperBound, RNG);
-    mlp.Randomize(Scalar, LowerBound, UpperBound, RNG);
-}
-template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <std::uniform_random_bit_generator _TRNG>
-void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
-    rand::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, RNG);
-    mlp.Randomize(Scalar_MLP, RNG);
-}
-template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <std::uniform_random_bit_generator _TRNG>
-void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
-    rand::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, LowerBound, UpperBound, RNG);
-    mlp.Randomize(Scalar_MLP, LowerBound, UpperBound, RNG);
-}
-template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <std::uniform_random_bit_generator _TRNG>
-bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _TRNG& RNG) {
-    GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
-    n.Randomize(Scalar, RNG);
-    return n;
-}
-template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <std::uniform_random_bit_generator _TRNG>
-bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
-    GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
-    n.Randomize(Scalar, LowerBound, UpperBound, RNG);
-    return n;
-}
-template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <std::uniform_random_bit_generator _TRNG>
-bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
-    GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
-    n.Randomize(Scalar_Base, Scalar_MLP, RNG);
-    return n;
-}
-template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <std::uniform_random_bit_generator _TRNG>
-bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
-    GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
-    n.Randomize(Scalar_Base, Scalar_MLP, LowerBound, UpperBound, RNG);
-    return n;
-}
-template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <bcuda::KernelCurandState _TRNG>
-__device__ void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _TRNG& RNG) {
-    rand::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, RNG);
-    mlp.Randomize(Scalar, RNG);
-}
-template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <bcuda::KernelCurandState _TRNG>
-__device__ void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
-    rand::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, LowerBound, UpperBound, RNG);
-    mlp.Randomize(Scalar, LowerBound, UpperBound, RNG);
-}
-template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <bcuda::KernelCurandState _TRNG>
-__device__ void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
-    rand::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, RNG);
-    mlp.Randomize(Scalar_MLP, RNG);
-}
-template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <bcuda::KernelCurandState _TRNG>
-__device__ void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Randomize(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
-    rand::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, LowerBound, UpperBound, RNG);
-    mlp.Randomize(Scalar_MLP, LowerBound, UpperBound, RNG);
-}
-template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <bcuda::KernelCurandState _TRNG>
-__device__ bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _TRNG& RNG) {
-    GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
-    n.Randomize(Scalar, RNG);
-    return n;
-}
-template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <bcuda::KernelCurandState _TRNG>
-__device__ bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
-    GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
-    n.Randomize(Scalar, LowerBound, UpperBound, RNG);
-    return n;
-}
-template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <bcuda::KernelCurandState _TRNG>
-__device__ bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
-    GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
-    n.Randomize(Scalar_Base, Scalar_MLP, RNG);
-    return n;
-}
-template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <bcuda::KernelCurandState _TRNG>
-__device__ bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::Reproduce(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
-    GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...> n = Clone();
-    n.Randomize(Scalar_Base, Scalar_MLP, LowerBound, UpperBound, RNG);
-    return n;
-}
-template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::ZeroOverwrite() {
-    rand::ClearArray<false, _T>(Span<_T>(base, mlp.InputLength()));
-    mlp.ZeroOverwrite();
-}
-template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <std::uniform_random_bit_generator _TRNG>
-void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_TRNG& RNG) {
-    rand::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), RNG);
-    mlp.RandomOverwrite(RNG);
-}
-template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <std::uniform_random_bit_generator _TRNG>
-void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_T LowerBound, _T UpperBound, _TRNG& RNG) {
-    rand::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), LowerBound, UpperBound, RNG);
-    mlp.RandomOverwrite(LowerBound, UpperBound, RNG);
-}
-template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <bcuda::KernelCurandState _TRNG>
-__device__ void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_TRNG& RNG) {
-    rand::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), RNG);
-    mlp.RandomOverwrite(RNG);
-}
-template <typename _T, bcuda::ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
-template <bcuda::KernelCurandState _TRNG>
-__device__ void bcuda::ai::genes::GeneFixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _LayerCounts...>::RandomOverwrite(_T LowerBound, _T UpperBound, _TRNG& RNG) {
-    rand::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), LowerBound, UpperBound, RNG);
-    mlp.RandomOverwrite(LowerBound, UpperBound, RNG);
 }

--- a/ai_genetics_genefixedmlp.h
+++ b/ai_genetics_genefixedmlp.h
@@ -21,128 +21,132 @@ namespace bcuda {
                 inputArray_t base;
                 mlp_t mlp;
 
-                void ZeroOverwrite() {
+                inline void ZeroOverwrite() {
                     rand::ClearArray<false, _T>(Span<_T>(base, mlp.InputLength()));
                     mlp.ZeroOverwrite();
                 }
                 template <std::uniform_random_bit_generator _TRNG>
-                void RandomOverwrite(_TRNG& RNG) {
+                inline void RandomOverwrite(_TRNG& RNG) {
                     rand::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), RNG);
                     mlp.RandomOverwrite(RNG);
                 }
                 template <std::uniform_random_bit_generator _TRNG>
-                void RandomOverwrite(_T LowerBound, _T UpperBound, _TRNG& RNG) {
+                inline void RandomOverwrite(_T LowerBound, _T UpperBound, _TRNG& RNG) {
                     rand::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), LowerBound, UpperBound, RNG);
                     mlp.RandomOverwrite(LowerBound, UpperBound, RNG);
                 }
+#ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
-                __device__ void RandomOverwrite(_TRNG& RNG) {
+                __device__ inline void RandomOverwrite(_TRNG& RNG) {
                     rand::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), RNG);
                     mlp.RandomOverwrite(RNG);
                 }
                 template <KernelCurandState _TRNG>
-                __device__ void RandomOverwrite(_T LowerBound, _T UpperBound, _TRNG& RNG) {
+                __device__ inline void RandomOverwrite(_T LowerBound, _T UpperBound, _TRNG& RNG) {
                     rand::InitRandomArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), LowerBound, UpperBound, RNG);
                     mlp.RandomOverwrite(LowerBound, UpperBound, RNG);
                 }
+#endif
 
-                outputArray_t* Run() {
+                inline outputArray_t* Run() {
                     auto* outputArr = new outputArray_t;
                     Run(outputArr);
                     return outputArr;
                 }
-                void Run(outputArray_t* OutputArray) {
+                inline void Run(outputArray_t* OutputArray) {
                     mlp.Run(base.data(), OutputArray->data());
                 }
 
                 template <std::uniform_random_bit_generator _TRNG>
-                void Randomize(_T Scalar, _TRNG& RNG) {
+                inline void Randomize(_T Scalar, _TRNG& RNG) {
                     rand::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, RNG);
                     mlp.Randomize(Scalar, RNG);
                 }
                 template <std::uniform_random_bit_generator _TRNG>
-                void Randomize(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+                inline void Randomize(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
                     rand::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, LowerBound, UpperBound, RNG);
                     mlp.Randomize(Scalar, LowerBound, UpperBound, RNG);
                 }
                 template <std::uniform_random_bit_generator _TRNG>
-                void Randomize(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
+                inline void Randomize(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
                     rand::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, RNG);
                     mlp.Randomize(Scalar_MLP, RNG);
                 }
                 template <std::uniform_random_bit_generator _TRNG>
-                void Randomize(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+                inline void Randomize(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
                     rand::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, LowerBound, UpperBound, RNG);
                     mlp.Randomize(Scalar_MLP, LowerBound, UpperBound, RNG);
                 }
                 template <std::uniform_random_bit_generator _TRNG>
-                this_t Reproduce(_T Scalar, _TRNG& RNG) {
+                inline this_t Reproduce(_T Scalar, _TRNG& RNG) {
                     this_t n = Clone();
                     n.Randomize(Scalar, RNG);
                     return n;
                 }
                 template <std::uniform_random_bit_generator _TRNG>
-                this_t Reproduce(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+                inline this_t Reproduce(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
                     this_t n = Clone();
                     n.Randomize(Scalar, LowerBound, UpperBound, RNG);
                     return n;
                 }
                 template <std::uniform_random_bit_generator _TRNG>
-                this_t Reproduce(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
+                inline this_t Reproduce(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
                     this_t n = Clone();
                     n.Randomize(Scalar_Base, Scalar_MLP, RNG);
                     return n;
                 }
                 template <std::uniform_random_bit_generator _TRNG>
-                this_t Reproduce(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+                inline this_t Reproduce(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
                     this_t n = Clone();
                     n.Randomize(Scalar_Base, Scalar_MLP, LowerBound, UpperBound, RNG);
                     return n;
                 }
+#ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
-                __device__ void Randomize(_T Scalar, _TRNG& RNG) {
+                __device__ inline void Randomize(_T Scalar, _TRNG& RNG) {
                     rand::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, RNG);
                     mlp.Randomize(Scalar, RNG);
                 }
                 template <KernelCurandState _TRNG>
-                __device__ void Randomize(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+                __device__ inline void Randomize(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
                     rand::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar, LowerBound, UpperBound, RNG);
                     mlp.Randomize(Scalar, LowerBound, UpperBound, RNG);
                 }
                 template <KernelCurandState _TRNG>
-                __device__ void Randomize(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
+                __device__ inline void Randomize(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
                     rand::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, RNG);
                     mlp.Randomize(Scalar_MLP, RNG);
                 }
                 template <KernelCurandState _TRNG>
-                __device__ void Randomize(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+                __device__ inline void Randomize(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
                     rand::RandomizeArray<false, _T, _TRNG>(Span<_T>(base, mlp.InputLength()), Scalar_Base, LowerBound, UpperBound, RNG);
                     mlp.Randomize(Scalar_MLP, LowerBound, UpperBound, RNG);
                 }
                 template <KernelCurandState _TRNG>
-                __device__ this_t Reproduce(_T Scalar, _TRNG& RNG) {
+                __device__ inline this_t Reproduce(_T Scalar, _TRNG& RNG) {
                     this_t n = Clone();
                     n.Randomize(Scalar, RNG);
                     return n;
                 }
                 template <KernelCurandState _TRNG>
-                __device__ this_t Reproduce(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+                __device__ inline this_t Reproduce(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
                     this_t n = Clone();
                     n.Randomize(Scalar, LowerBound, UpperBound, RNG);
                     return n;
                 }
                 template <KernelCurandState _TRNG>
-                __device__ this_t Reproduce(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
+                __device__ inline this_t Reproduce(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
                     this_t n = Clone();
                     n.Randomize(Scalar_Base, Scalar_MLP, RNG);
                     return n;
                 }
                 template <KernelCurandState _TRNG>
-                __device__ this_t Reproduce(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+                __device__ inline this_t Reproduce(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
                     this_t n = Clone();
                     n.Randomize(Scalar_Base, Scalar_MLP, LowerBound, UpperBound, RNG);
                     return n;
                 }
+#endif
             };
         }
     }

--- a/ai_mlp_fixedmlp.h
+++ b/ai_mlp_fixedmlp.h
@@ -67,7 +67,7 @@ namespace bcuda {
                 _T weights[_InputCount][_OutputCount];
                 _T bias[_OutputCount];
 
-                __host__ __device__ void FillWith0() {
+                __host__ __device__ inline void FillWith0() {
                     for (size_t i = 0; i < _OutputCount; ++i) {
                         for (size_t j = 0; j < _InputCount; ++j)
                             weights[i][j] = 0.;
@@ -75,7 +75,7 @@ namespace bcuda {
                     }
                 }
                 template <std::uniform_random_bit_generator _TRNG>
-                __host__ void FillWithRandom(_TRNG& RNG) {
+                __host__ inline void FillWithRandom(_TRNG& RNG) {
                     std::uniform_real_distribution<_T> dis(-1., 1.);
 
                     for (size_t i = 0; i < _OutputCount; ++i) {
@@ -86,7 +86,7 @@ namespace bcuda {
                 }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
-                __device__ void FillWithRandom(_TRNG& RNG) {
+                __device__ inline void FillWithRandom(_TRNG& RNG) {
                     if constexpr (std::same_as<_T, float>)
                         for (size_t i = 0; i < _OutputCount; ++i) {
                             for (size_t j = 0; j < _InputCount; ++j)
@@ -102,7 +102,7 @@ namespace bcuda {
                  }
 #endif
                 template <std::uniform_random_bit_generator _TRNG>
-                __host__ void ChangeWithRandom(_T Scalar, _TRNG& RNG) {
+                __host__ inline void ChangeWithRandom(_T Scalar, _TRNG& RNG) {
                     std::uniform_real_distribution<_T> dis(-Scalar, Scalar);
 
                     for (size_t i = 0; i < _OutputCount; ++i) {
@@ -113,7 +113,7 @@ namespace bcuda {
                 }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
-                __device__ void ChangeWithRandom(_T Scalar, _TRNG& RNG) {
+                __device__ inline void ChangeWithRandom(_T Scalar, _TRNG& RNG) {
                     if constexpr (std::same_as<_T, float>)
                         for (size_t i = 0; i < _OutputCount; ++i) {
                             for (size_t j = 0; j < _InputCount; ++j)
@@ -129,7 +129,7 @@ namespace bcuda {
                 }
 #endif
                 template <std::uniform_random_bit_generator _TRNG>
-                __host__ void ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+                __host__ inline void ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
                     std::uniform_real_distribution<_T> dis(-Scalar, Scalar);
 
                     for (size_t i = 0; i < _OutputCount; ++i) {
@@ -143,7 +143,7 @@ namespace bcuda {
                 }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
-                __device__ void ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+                __device__ inline void ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
                     if constexpr (std::same_as<_T, float>)
                         for (size_t i = 0; i < _OutputCount; ++i) {
                             for (size_t j = 0; j < _InputCount; ++j) {
@@ -187,19 +187,19 @@ namespace bcuda {
                     }
                 }
 
-                size_t SerializedSize() const {
+                inline size_t SerializedSize() const {
                     return sizeof(this_t);
                 }
-                void Serialize(void*& Data) const {
+                inline void Serialize(void*& Data) const {
                     BSerializer::SerializeArray(Data, weights, _InputCount * _OutputCount);
                     BSerializer::SerializeArray(Data, bias, _OutputCount);
                 }
-                static this_t Deserialize(const void*& Data) {
+                inline static this_t Deserialize(const void*& Data) {
                     uint8_t bytes[sizeof(this_t)];
                     Deserialize(Data, &bytes);
                     return *(this_t*)&bytes;
                 }
-                static void Deserialize(const void*& Data, void* ObjMem) {
+                inline static void Deserialize(const void*& Data, void* ObjMem) {
                     this_t& obj = &(this_t*)ObjMem;
                     BSerializer::DeserializeArray(Data, obj.weights, _InputCount * _OutputCount);
                     BSerializer::DeserializeArray(Data, obj.bias, _OutputCount);
@@ -222,50 +222,50 @@ namespace bcuda {
                 FixedMLPL<_T, _ActivationFunction, _InputCount, _Output1Count> layer;
                 FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...> nextLayers;
 
-                __host__ __device__ void FillWith0() {
+                __host__ __device__ inline void FillWith0() {
                     layer.FillWith0();
                     nextLayers.FillWith0();
                 }
                 template <std::uniform_random_bit_generator _TRNG>
-                __host__ void FillWithRandom(_TRNG& RNG) {
+                __host__ inline void FillWithRandom(_TRNG& RNG) {
                     layer.FillWithRandom(RNG);
                     nextLayers.FillWithRandom(RNG);
                 }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
-                __device__ void FillWithRandom(_TRNG& RNG) {
+                __device__ inline void FillWithRandom(_TRNG& RNG) {
                     layer.FillWithRandom(RNG);
                     nextLayers.FillWithRandom(RNG);
                 }
 #endif
                 template <std::uniform_random_bit_generator _TRNG>
-                __host__ void ChangeWithRandom(_T Scalar, _TRNG& RNG) {
+                __host__ inline void ChangeWithRandom(_T Scalar, _TRNG& RNG) {
                     layer.ChangeWithRandom(Scalar, RNG);
                     nextLayers.ChangeWithRandom(Scalar, RNG);
                 }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
-                __device__ void ChangeWithRandom(_T Scalar, _TRNG& RNG) {
+                __device__ inline void ChangeWithRandom(_T Scalar, _TRNG& RNG) {
                     layer.ChangeWithRandom(Scalar, RNG);
                     nextLayers.ChangeWithRandom(Scalar, RNG);
                 }
 #endif
                 template <std::uniform_random_bit_generator _TRNG>
-                __host__ void ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+                __host__ inline void ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
                     layer.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
                     nextLayers.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
                 }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
-                __device__ void ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+                __device__ inline void ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
                     layer.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
                     nextLayers.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
                 }
 #endif
-                __host__ __device__ void Run(const _T* Input, _T* Output) const {
+                __host__ __device__ inline void Run(const _T* Input, _T* Output) const {
                     Run(Input, 0, 0, Output);
                 }
-                __host__ __device__ void Run(const _T* Input, _T* Intermediate1, _T* Intermediate2, _T* Output) const {
+                __host__ __device__ inline void Run(const _T* Input, _T* Intermediate1, _T* Intermediate2, _T* Output) const {
                     _T* i1 = Intermediate1 ? Intermediate1 : new _T[Intermediate0Count()];
                     _T* i2 = Intermediate2 ? Intermediate2 : new _T[Intermediate1Count()];
 
@@ -276,7 +276,7 @@ namespace bcuda {
                     if (!Intermediate2) delete[] i2;
                 }
                 template <size_t _Index>
-                __host__ __device__ layerType_t<_Index>& Layer() {
+                __host__ __device__ inline layerType_t<_Index>& Layer() {
                     if constexpr (_Index) {
                         return nextLayers.Layer<_Index - 1>();
                     }
@@ -305,19 +305,19 @@ namespace bcuda {
                     return sizeof...(_ContinuedOutputCounts) + 2;
                 }
 
-                size_t SerializedSize() const {
+                inline size_t SerializedSize() const {
                     return sizeof(this_t);
                 }
-                void Serialize(void*& Data) const {
+                inline void Serialize(void*& Data) const {
                     layer.Serialize(Data);
                     nextLayers.Serialize(Data);
                 }
-                static this_t Deserialize(const void*& Data) {
+                inline static this_t Deserialize(const void*& Data) {
                     uint8_t bytes[sizeof(this_t)];
                     Deserialize(Data, &bytes);
                     return *(this_t*)&bytes;
                 }
-                static void Deserialize(const void*& Data, void* ObjMem) {
+                inline static void Deserialize(const void*& Data, void* ObjMem) {
                     this_t& obj = &(this_t*)ObjMem;
                     BSerializer::Deserialize<layerType_t<0>>(Data, &obj.layer);
                     BSerializer::Deserialize<FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>>(Data, &obj.nextLayers);
@@ -337,47 +337,47 @@ namespace bcuda {
 
                 FixedMLPL<_T, _ActivationFunction, _InputCount, _Output1Count> layer;
 
-                __host__ __device__ void FillWith0() {
+                __host__ __device__ inline void FillWith0() {
                     layer.FillWith0();
                 }
                 template <std::uniform_random_bit_generator _TRNG>
-                __host__ void FillWithRandom(_TRNG& RNG) {
+                __host__ inline void FillWithRandom(_TRNG& RNG) {
                     layer.FillWithRandom(RNG);
                 }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
-                __device__ void FillWithRandom(_TRNG& RNG) {
+                __device__ inline void FillWithRandom(_TRNG& RNG) {
                     layer.FillWithRandom(RNG);
                 }
 #endif
                 template <std::uniform_random_bit_generator _TRNG>
-                __host__ void ChangeWithRandom(_T Scalar, _TRNG& RNG) {
+                __host__ inline void ChangeWithRandom(_T Scalar, _TRNG& RNG) {
                     layer.ChangeWithRandom(Scalar, RNG);
                 }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
-                __device__ void ChangeWithRandom(_T Scalar, _TRNG& RNG) {
+                __device__ inline void ChangeWithRandom(_T Scalar, _TRNG& RNG) {
                     layer.ChangeWithRandom(Scalar, RNG);
                 }
 #endif
                 template <std::uniform_random_bit_generator _TRNG>
-                __host__ void ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+                __host__ inline void ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
                     layer.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
                 }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
-                __device__ void ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+                __device__ inline void ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
                     layer.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
                 }
 #endif
-                __host__ __device__ void Run(const _T* Input, _T* Output) const {
+                __host__ __device__ inline void Run(const _T* Input, _T* Output) const {
                     layer.Run(Input, Output);
                 }
-                __host__ __device__ void Run(const _T* Input, _T* Intermediate1, _T* Intermediate2, _T* Output) const {
+                __host__ __device__ inline void Run(const _T* Input, _T* Intermediate1, _T* Intermediate2, _T* Output) const {
                     layer.Run(Input, Output);
                 }
                 template <size_t _Index>
-                __host__ __device__ layerType_t<_Index>& Layer() {
+                __host__ __device__ inline layerType_t<_Index>& Layer() {
                     static_assert(!_Index, "_Index is out of bounds (too large).");
 
                     return layer;
@@ -402,18 +402,18 @@ namespace bcuda {
                     return 1;
                 }
 
-                size_t SerializedSize() const {
+                inline size_t SerializedSize() const {
                     return sizeof(this_t);
                 }
-                void Serialize(void*& Data) const {
+                inline void Serialize(void*& Data) const {
                     layer.Serialize(Data);
                 }
-                static this_t Deserialize(const void*& Data) {
+                inline static this_t Deserialize(const void*& Data) {
                     uint8_t bytes[sizeof(this_t)];
                     Deserialize(Data, &bytes);
                     return *(this_t*)&bytes;
                 }
-                static void Deserialize(const void*& Data, void* ObjMem) {
+                inline static void Deserialize(const void*& Data, void* ObjMem) {
                     this_t& obj = &(this_t*)ObjMem;
                     BSerializer::Deserialize<layerType_t<0>>(Data, &obj.layer);
                 }
@@ -440,7 +440,7 @@ namespace bcuda {
     }
     namespace details {
         template <ai::mlp::IsFixedMLP _TFixedMLP>
-        void FixedMLP_Run(const _TFixedMLP* Mlp, const typename _TFixedMLP::element_t* Inputs, typename _TFixedMLP::element_t* Intermediate0, typename _TFixedMLP::element_t* Intermediate1, typename _TFixedMLP::element_t* Outputs) {
+        inline static void FixedMLP_Run(const _TFixedMLP* Mlp, const typename _TFixedMLP::element_t* Inputs, typename _TFixedMLP::element_t* Intermediate0, typename _TFixedMLP::element_t* Intermediate1, typename _TFixedMLP::element_t* Outputs) {
             using element_t = typename _TFixedMLP::element_t;
 
             if constexpr (_TFixedMLP::LayerCount() == 1) {
@@ -456,19 +456,19 @@ namespace bcuda {
         namespace mlp {
             template <typename _TFixedMLPL>
                 requires IsFixedMLPL<std::remove_const_t<_TFixedMLPL>>
-            __host__ __device__ Span<std::conditional_t<std::is_const_v<_TFixedMLPL>, const typename _TFixedMLPL::element_t, typename _TFixedMLPL::element_t>> FixedMLPL_GetElementSpan(_TFixedMLPL* MLPL) {
+            __host__ __device__ inline static Span<std::conditional_t<std::is_const_v<_TFixedMLPL>, const typename _TFixedMLPL::element_t, typename _TFixedMLPL::element_t>> FixedMLPL_GetElementSpan(_TFixedMLPL* MLPL) {
                 using element_t = std::conditional_t<std::is_const_v<_TFixedMLPL>, const typename _TFixedMLPL::element_t, typename _TFixedMLPL::element_t>;
                 return Span<element_t>((element_t*)MLPL, sizeof(_TFixedMLPL) / sizeof(element_t));
             }
             template <typename _TFixedMLP>
                 requires IsFixedMLP<std::remove_const_t<_TFixedMLP>>
-            __host__ __device__ Span<std::conditional_t<std::is_const_v<_TFixedMLP>, const typename _TFixedMLP::element_t, typename _TFixedMLP::element_t>> FixedMLP_GetElementSpan(_TFixedMLP* MLP) {
+            __host__ __device__ inline static Span<std::conditional_t<std::is_const_v<_TFixedMLP>, const typename _TFixedMLP::element_t, typename _TFixedMLP::element_t>> FixedMLP_GetElementSpan(_TFixedMLP* MLP) {
                 using element_t = std::conditional_t<std::is_const_v<_TFixedMLP>, const typename _TFixedMLP::element_t, typename _TFixedMLP::element_t>;
                 return Span<element_t>((element_t*)MLP, sizeof(_TFixedMLP) / sizeof(element_t));
             }
 
             template <IsFixedMLPL _TFixedMLPL, bool _InputOnHost, bool _OutputOnHost>
-            void FixedMLPL_Run(const _TFixedMLPL* MLPL, const typename _TFixedMLPL::element_t* Inputs, typename _TFixedMLPL::element_t* Outputs) {
+            inline static void FixedMLPL_Run(const _TFixedMLPL* MLPL, const typename _TFixedMLPL::element_t* Inputs, typename _TFixedMLPL::element_t* Outputs) {
                 using element_t = typename _TFixedMLPL::element_t;
                 if constexpr (_InputOnHost) {
                     if constexpr (_OutputOnHost) {
@@ -509,7 +509,7 @@ namespace bcuda {
                 }
             }
             template <IsFixedMLP _TFixedMLP, bool _InputOnHost, bool _OutputOnHost>
-            void FixedMLP_Run(const _TFixedMLP* MLP, const typename _TFixedMLP::element_t* Inputs, typename _TFixedMLP::element_t* Outputs) {
+            inline static void FixedMLP_Run(const _TFixedMLP* MLP, const typename _TFixedMLP::element_t* Inputs, typename _TFixedMLP::element_t* Outputs) {
                 using element_t = typename _TFixedMLP::element_t;
                 if constexpr (_InputOnHost) {
                     if constexpr (_OutputOnHost) {
@@ -553,50 +553,50 @@ namespace bcuda {
             }
 
             template <IsFixedMLPL _TFixedMLPL>
-            void FixedMLPL_FillWith0(_TFixedMLPL* MLPL) {
+            inline static void FixedMLPL_FillWith0(_TFixedMLPL* MLPL) {
                 using element_t = typename _TFixedMLPL::element_t;
 
                 rand::ClearArray<false, element_t>(FixedMLPL_GetElementSpan(MLPL));
             }
             template <IsFixedMLPL _TFixedMLPL, std::uniform_random_bit_generator _TRNG>
-            void FixedMLPL_FillWithRandom(_TFixedMLPL* MLPL, _TRNG& RNG) {
+            inline static void FixedMLPL_FillWithRandom(_TFixedMLPL* MLPL, _TRNG& RNG) {
                 using element_t = typename _TFixedMLPL::element_t;
 
                 rand::InitRandomArray<false, element_t, _TRNG>(FixedMLPL_GetElementSpan(MLPL), RNG);
             }
             template <IsFixedMLPL _TFixedMLPL, std::uniform_random_bit_generator _TRNG>
-            void FixedMLPL_ChangeWithRandom(_TFixedMLPL* MLPL, typename _TFixedMLPL::element_t Scalar, _TRNG& RNG) {
+            inline static void FixedMLPL_ChangeWithRandom(_TFixedMLPL* MLPL, typename _TFixedMLPL::element_t Scalar, _TRNG& RNG) {
                 using element_t = typename _TFixedMLPL::element_t;
 
                 rand::RandomizeArray<false, element_t, _TRNG>(FixedMLPL_GetElementSpan(MLPL), Scalar, RNG);
             }
             template <IsFixedMLPL _TFixedMLPL, std::uniform_random_bit_generator _TRNG>
-            void FixedMLPL_ChangeWithRandom(_TFixedMLPL* MLPL, typename _TFixedMLPL::element_t Scalar, typename _TFixedMLPL::element_t LowerBound, typename _TFixedMLPL::element_t UpperBound, _TRNG& RNG) {
+            inline static void FixedMLPL_ChangeWithRandom(_TFixedMLPL* MLPL, typename _TFixedMLPL::element_t Scalar, typename _TFixedMLPL::element_t LowerBound, typename _TFixedMLPL::element_t UpperBound, _TRNG& RNG) {
                 using element_t = typename _TFixedMLPL::element_t;
 
                 rand::RandomizeArray<false, element_t, _TRNG>(FixedMLPL_GetElementSpan(MLPL), Scalar, LowerBound, UpperBound, RNG);
             }
 
             template <IsFixedMLP _TFixedMLP>
-            void FixedMLP_FillWith0(_TFixedMLP* MLP) {
+            inline static void FixedMLP_FillWith0(_TFixedMLP* MLP) {
                 using element_t = typename _TFixedMLP::element_t;
 
                 rand::ClearArray<false, element_t>(FixedMLP_GetElementSpan(MLP));
             }
             template <IsFixedMLP _TFixedMLP, std::uniform_random_bit_generator _TRNG>
-            void FixedMLP_FillWithRandom(_TFixedMLP* MLP, _TRNG& RNG) {
+            inline static void FixedMLP_FillWithRandom(_TFixedMLP* MLP, _TRNG& RNG) {
                 using element_t = typename _TFixedMLP::element_t;
 
                 rand::InitRandomArray<false, element_t, _TRNG>(FixedMLP_GetElementSpan(MLP), RNG);
             }
             template <IsFixedMLP _TFixedMLP, std::uniform_random_bit_generator _TRNG>
-            void FixedMLP_ChangeWithRandom(_TFixedMLP* MLP, typename _TFixedMLP::element_t Scalar, _TRNG& RNG) {
+            inline static void FixedMLP_ChangeWithRandom(_TFixedMLP* MLP, typename _TFixedMLP::element_t Scalar, _TRNG& RNG) {
                 using element_t = typename _TFixedMLP::element_t;
 
                 rand::RandomizeArray<false, element_t, _TRNG>(FixedMLP_GetElementSpan(MLP), Scalar, RNG);
             }
             template <IsFixedMLP _TFixedMLP, std::uniform_random_bit_generator _TRNG>
-            void FixedMLP_ChangeWithRandom(_TFixedMLP* MLP, typename _TFixedMLP::element_t Scalar, typename _TFixedMLP::element_t LowerBound, typename _TFixedMLP::element_t UpperBound, _TRNG& RNG) {
+            inline static void FixedMLP_ChangeWithRandom(_TFixedMLP* MLP, typename _TFixedMLP::element_t Scalar, typename _TFixedMLP::element_t LowerBound, typename _TFixedMLP::element_t UpperBound, _TRNG& RNG) {
                 using element_t = typename _TFixedMLP::element_t;
 
                 rand::RandomizeArray<false, element_t, _TRNG>(FixedMLP_GetElementSpan(MLP), Scalar, LowerBound, UpperBound, RNG);

--- a/ai_mlp_fixedmlp.h
+++ b/ai_mlp_fixedmlp.h
@@ -224,46 +224,53 @@ namespace bcuda {
 
                 __host__ __device__ void FillWith0() {
                     layer.FillWith0();
+                    nextLayers.FillWith0();
                 }
                 template <std::uniform_random_bit_generator _TRNG>
                 __host__ void FillWithRandom(_TRNG& RNG) {
                     layer.FillWithRandom(RNG);
+                    nextLayers.FillWithRandom(RNG);
                 }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
                 __device__ void FillWithRandom(_TRNG& RNG) {
                     layer.FillWithRandom(RNG);
+                    nextLayers.FillWithRandom(RNG);
                 }
 #endif
                 template <std::uniform_random_bit_generator _TRNG>
                 __host__ void ChangeWithRandom(_T Scalar, _TRNG& RNG) {
                     layer.ChangeWithRandom(Scalar, RNG);
+                    nextLayers.ChangeWithRandom(Scalar, RNG);
                 }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
                 __device__ void ChangeWithRandom(_T Scalar, _TRNG& RNG) {
                     layer.ChangeWithRandom(Scalar, RNG);
+                    nextLayers.ChangeWithRandom(Scalar, RNG);
                 }
 #endif
                 template <std::uniform_random_bit_generator _TRNG>
                 __host__ void ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
                     layer.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
+                    nextLayers.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
                 }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
                 __device__ void ChangeWithRandom(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
                     layer.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
+                    nextLayers.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
                 }
 #endif
-                __host__ __device__ void Run(const _T* Input, _T* output) const {
-                    Run(Input, 0, 0, output);
+                __host__ __device__ void Run(const _T* Input, _T* Output) const {
+                    Run(Input, 0, 0, Output);
                 }
-                __host__ __device__ void Run(const _T* Input, _T* Intermediate1, _T* Intermediate2, _T* output) const {
+                __host__ __device__ void Run(const _T* Input, _T* Intermediate1, _T* Intermediate2, _T* Output) const {
                     _T* i1 = Intermediate1 ? Intermediate1 : new _T[Intermediate0Count()];
                     _T* i2 = Intermediate2 ? Intermediate2 : new _T[Intermediate1Count()];
 
                     layer.Run(Input, i1);
-                    nextLayers.Run(i1, i2, i1, output);
+                    nextLayers.Run(i1, i2, i1, Output);
 
                     if (!Intermediate1) delete[] i1;
                     if (!Intermediate2) delete[] i2;
@@ -295,7 +302,7 @@ namespace bcuda {
                     return _Output1Count > maxNextLayers ? _Output1Count : maxNextLayers;
                 }
                 static constexpr size_t LayerCount() {
-                    return FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::LayerCount() + 1;
+                    return sizeof...(_ContinuedOutputCounts) + 2;
                 }
 
                 size_t SerializedSize() const {
@@ -303,6 +310,7 @@ namespace bcuda {
                 }
                 void Serialize(void*& Data) const {
                     layer.Serialize(Data);
+                    nextLayers.Serialize(Data);
                 }
                 static this_t Deserialize(const void*& Data) {
                     uint8_t bytes[sizeof(this_t)];

--- a/ai_mlpb_fixedmlpb.h
+++ b/ai_mlpb_fixedmlpb.h
@@ -71,42 +71,42 @@ namespace bcuda {
                 }
 #endif
                 template <std::uniform_random_bit_generator _TRNG>
-                __host__ __forceinline void RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+                __host__ inline void RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
                     for (size_t i = 0; i < details::bitCount<_TOutput>; ++i)
                         weights[i] = bcuda::rand::RandomizeWFlips(weights[i], WeightsFlipProb, RNG);
                     bias = bcuda::rand::RandomizeWFlips(bias, BiasFlipProb, RNG);
                 }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
-                __device__ __forceinline void RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+                __device__ inline void RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
                     for (size_t i = 0; i < details::bitCount<_TOutput>; ++i)
                         weights[i] = bcuda::rand::RandomizeWFlips(weights[i], WeightsFlipProb, RNG);
                     bias = bcuda::rand::RandomizeWFlips(bias, BiasFlipProb, RNG);
                 }
 #endif
                 template <std::uniform_random_bit_generator _TRNG>
-                __host__ __forceinline void RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+                __host__ inline void RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
                     for (size_t i = 0; i < details::bitCount<_TOutput>; ++i)
                         weights[i] = bcuda::rand::RandomizeWTargets(weights[i], WeightsFlipProb, RNG);
                     bias = bcuda::rand::RandomizeWTargets(bias, BiasFlipProb, RNG);
                 }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
-                __device__ __forceinline void RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+                __device__ inline void RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
                     for (size_t i = 0; i < details::bitCount<_TOutput>; ++i)
                         weights[i] = bcuda::rand::RandomizeWTargets(weights[i], WeightsFlipProb, RNG);
                     bias = bcuda::rand::RandomizeWTargets(bias, BiasFlipProb, RNG);
                 }
 #endif
                 template <std::uniform_random_bit_generator _TRNG>
-                __host__ __forceinline void RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
+                __host__ inline void RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
                     for (size_t i = 0; i < details::bitCount<_TOutput>; ++i)
                         weights[i] = bcuda::rand::RandomizeWMutations(weights[i], WeightsProbOf1, RNG);
                     bias = bcuda::rand::RandomizeWMutations(bias, BiasProbOf1, RNG);
                 }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
-                __device__ __forceinline void RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
+                __device__ inline void RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
                     for (size_t i = 0; i < details::bitCount<_TOutput>; ++i)
                         weights[i] = bcuda::rand::RandomizeWMutations(weights[i], WeightsProbOf1, RNG);
                     bias = bcuda::rand::RandomizeWMutations(bias, BiasProbOf1, RNG);
@@ -173,37 +173,37 @@ namespace bcuda {
                 }
 #endif
                 template <std::uniform_random_bit_generator _TRNG>
-                __host__ __forceinline void RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+                __host__ inline void RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
                     layer.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
                     nextLayers.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
                 }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
-                __device__ __forceinline void RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+                __device__ inline void RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
                     layer.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
                     nextLayers.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
                 }
 #endif
                 template <std::uniform_random_bit_generator _TRNG>
-                __host__ __forceinline void RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+                __host__ inline void RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
                     layer.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
                     nextLayers.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
                 }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
-                __device__ __forceinline void RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+                __device__ inline void RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
                     layer.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
                     nextLayers.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
                 }
 #endif
                 template <std::uniform_random_bit_generator _TRNG>
-                __host__ __forceinline void RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
+                __host__ inline void RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
                     layer.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
                     nextLayers.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
                 }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
-                __device__ __forceinline void RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG);
+                __device__ inline void RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG);
 #endif
                 __host__ __device__ output_t Run(_TInput Input) const {
                     return (output_t)RunG((uint64_t)Input);
@@ -272,32 +272,32 @@ namespace bcuda {
                 }
 #endif
                 template <std::uniform_random_bit_generator _TRNG>
-                __host__ __forceinline void RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+                __host__ inline void RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
                     layer.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
                 }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
-                __device__ __forceinline void RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+                __device__ inline void RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
                     layer.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
                 }
 #endif
                 template <std::uniform_random_bit_generator _TRNG>
-                __host__ __forceinline void RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+                __host__ inline void RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
                     layer.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
                 }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
-                __device__ __forceinline void RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+                __device__ inline void RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
                     layer.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
                 }
 #endif
                 template <std::uniform_random_bit_generator _TRNG>
-                __host__ __forceinline void RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
+                __host__ inline void RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
                     layer.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
                 }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
-                __device__ __forceinline void RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
+                __device__ inline void RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
                     layer.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
                 }
 #endif

--- a/ai_mlpb_fixedmlpb.h
+++ b/ai_mlpb_fixedmlpb.h
@@ -51,20 +51,20 @@ namespace bcuda {
                 _TInput weights[details::bitCount<_TOutput>];
                 _TOutput bias;
 
-                __host__ __device__ void FillWith0() {
+                __host__ __device__ inline void FillWith0() {
                     for (size_t i = 0; i < details::bitCount<_TOutput>; ++i)
                         weights[i] = (_TInput)0;
                     bias = (_TOutput)0;
                 }
                 template <std::uniform_random_bit_generator _TRNG>
-                __host__ void FillWithRandom(_TRNG& RNG) {
+                __host__ inline void FillWithRandom(_TRNG& RNG) {
                     for (size_t i = 0; i < details::bitCount<_TOutput>; ++i)
                         weights[i] = details::GetIntBin<_TInput>(RNG);
                     bias = details::GetIntBin<_TOutput>(RNG);
                 }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
-                __device__ void FillWithRandom(_TRNG& RNG) {
+                __device__ inline void FillWithRandom(_TRNG& RNG) {
                     for (size_t i = 0; i < details::bitCount<_TOutput>; ++i)
                         weights[i] = details::GetIntBin<_TInput>(RNG);
                     bias = details::GetIntBin<_TOutput>(RNG);
@@ -112,29 +112,29 @@ namespace bcuda {
                     bias = bcuda::rand::RandomizeWMutations(bias, BiasProbOf1, RNG);
                 }
 #endif
-                __host__ __device__ _TOutput Run(_TInput Input) const {
+                __host__ __device__ inline _TOutput Run(_TInput Input) const {
                     _TOutput o = bias;
                     for (size_t i = 0; i < details::bitCount<_TOutput>; ++i)
                         if (Input & weights[i]) o |= ((_TOutput)1) << i;
                     return o;
                 }
-                __host__ __device__ uint64_t RunG(uint64_t Input) const {
+                __host__ __device__ inline uint64_t RunG(uint64_t Input) const {
                     return (uint64_t)Run((_TInput)Input);
                 }
 
-                size_t SerializedSize() const {
+                inline size_t SerializedSize() const {
                     return sizeof(this_t);
                 }
-                void Serialize(void*& Data) const {
+                inline void Serialize(void*& Data) const {
                     BSerializer::SerializeArray(Data, weights, details::bitCount<_TOutput>);
                     BSerializer::Serialize(Data, bias);
                 }
-                static this_t Deserialize(const void*& Data) {
+                inline static this_t Deserialize(const void*& Data) {
                     uint8_t bytes[sizeof(this_t)];
                     Deserialize(Data, &bytes);
                     return *(this_t*)&bytes;
                 }
-                static void Deserialize(const void*& Data, void* ObjMem) {
+                inline static void Deserialize(const void*& Data, void* ObjMem) {
                     this_t& obj = *(this_t*)ObjMem;
                     BSerializer::DeserializeArray(Data, obj.weights, details::bitCount<_TOutput>);
                     BSerializer::Deserialize(Data, &obj.bias);
@@ -156,18 +156,18 @@ namespace bcuda {
                 FixedMLPBL<_TInput, _TOutput1> layer;
                 FixedMLPB<_TOutput1, _TOutput2, _TsContinuedOutputs...> nextLayers;
 
-                __host__ __device__ void FillWith0() {
+                __host__ __device__ inline void FillWith0() {
                     layer.FillWith0();
                     nextLayers.FillWith0();
                 }
                 template <std::uniform_random_bit_generator _TRNG>
-                __host__ void FillWithRandom(_TRNG& RNG) {
+                __host__ inline void FillWithRandom(_TRNG& RNG) {
                     layer.FillWithRandom(RNG);
                     nextLayers.FillWithRandom(RNG);
                 }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
-                __device__ void FillWithRandom(_TRNG& RNG) {
+                __device__ inline void FillWithRandom(_TRNG& RNG) {
                     layer.FillWithRandom(RNG);
                     nextLayers.FillWithRandom(RNG);
                 }
@@ -205,16 +205,16 @@ namespace bcuda {
                 template <KernelCurandState _TRNG>
                 __device__ inline void RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG);
 #endif
-                __host__ __device__ output_t Run(_TInput Input) const {
+                __host__ __device__ inline output_t Run(_TInput Input) const {
                     return (output_t)RunG((uint64_t)Input);
                 }
-                __host__ __device__ uint64_t RunG(uint64_t Input) const {
+                __host__ __device__ inline uint64_t RunG(uint64_t Input) const {
                     Input = layer.RunG(Input);
                     Input = nextLayers.RunG(Input);
                     return Input;
                 }
                 template <size_t _Index>
-                __host__ __device__ layerType_t<_Index>& Layer() {
+                __host__ __device__ inline layerType_t<_Index>& Layer() {
                     if constexpr (_Index) {
                         return nextLayers.Layer<_Index - 1>();
                     }
@@ -227,19 +227,19 @@ namespace bcuda {
                     return sizeof...(_TsContinuedOutputs) + 2;
                 }
 
-                size_t SerializedSize() const {
+                inline size_t SerializedSize() const {
                     return sizeof(this_t);
                 }
-                void Serialize(void*& Data) const {
+                inline void Serialize(void*& Data) const {
                     layer.Serialize(Data);
                     nextLayers.Serialize(Data);
                 }
-                static this_t Deserialize(const void*& Data) {
+                inline static this_t Deserialize(const void*& Data) {
                     uint8_t bytes[sizeof(this_t)];
                     Deserialize(Data, &bytes);
                     return *(this_t*)&bytes;
                 }
-                static void Deserialize(const void*& Data, void* ObjMem) {
+                inline static void Deserialize(const void*& Data, void* ObjMem) {
                     this_t& obj = &(this_t*)ObjMem;
                     BSerializer::Deserialize(Data, &obj.layer);
                     BSerializer::Deserialize(Data, &obj.nextLayers);
@@ -258,16 +258,16 @@ namespace bcuda {
 
                 FixedMLPBL<_TInput, _TOutput1> layer;
 
-                __host__ __device__ void FillWith0() {
+                __host__ __device__ inline void FillWith0() {
                     layer.FillWith0();
                 }
                 template <std::uniform_random_bit_generator _TRNG>
-                __host__ void FillWithRandom(_TRNG& RNG) {
+                __host__ inline void FillWithRandom(_TRNG& RNG) {
                     layer.FillWithRandom(RNG);
                 }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
-                __device__ void FillWithRandom(_TRNG& RNG) {
+                __device__ inline void FillWithRandom(_TRNG& RNG) {
                     layer.FillWithRandom(RNG);
                 }
 #endif
@@ -301,15 +301,15 @@ namespace bcuda {
                     layer.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
                 }
 #endif
-                __host__ __device__ output_t Run(_TInput Input) const {
+                __host__ __device__ inline output_t Run(_TInput Input) const {
                     return (output_t)RunG((uint64_t)Input);
                 }
-                __host__ __device__ uint64_t RunG(uint64_t Input) const {
+                __host__ __device__ inline uint64_t RunG(uint64_t Input) const {
                     Input = layer.RunG(Input);
                     return Input;
                 }
                 template <size_t _Index>
-                __host__ __device__ layerType_t<_Index>& Layer() {
+                __host__ __device__ inline layerType_t<_Index>& Layer() {
                     static_assert(!_Index, "_Index is out of bounds.");
                     return layer;
                 }
@@ -318,18 +318,18 @@ namespace bcuda {
                     return 1;
                 }
 
-                size_t SerializedSize() const {
+                inline size_t SerializedSize() const {
                     return sizeof(this_t);
                 }
-                void Serialize(void*& Data) const {
+                inline void Serialize(void*& Data) const {
                     layer.Serialize(Data);
                 }
-                static this_t Deserialize(const void*& Data) {
+                inline static this_t Deserialize(const void*& Data) {
                     uint8_t bytes[sizeof(this_t)];
                     Deserialize(Data, &bytes);
                     return *(this_t*)&bytes;
                 }
-                static void Deserialize(const void*& Data, void* ObjMem) {
+                inline static void Deserialize(const void*& Data, void* ObjMem) {
                     this_t& obj = &(this_t*)ObjMem;
                     BSerializer::Deserialize(Data, &obj.layer);
                 }

--- a/ai_mlpb_fixedmlpb.h
+++ b/ai_mlpb_fixedmlpb.h
@@ -39,7 +39,7 @@ namespace bcuda {
         using mlpbLayerType_t = MLPBLayerType<_Index, _TInput, _TOutput1, _TsContinuedOutputs...>;
 
         template <std::integral _T>
-        constexpr size_t BitCount = sizeof(_T) << 3;
+        constexpr size_t bitCount = sizeof(_T) << 3;
     }
     namespace ai {
         namespace mlpb {
@@ -48,41 +48,97 @@ namespace bcuda {
             private:
                 using this_t = FixedMLPBL<_TInput, _TOutput>;
             public:
-                _TInput weights[details::BitCount<_TOutput>];
+                _TInput weights[details::bitCount<_TOutput>];
                 _TOutput bias;
 
-                __host__ __device__ void FillWith0();
+                __host__ __device__ void FillWith0() {
+                    for (size_t i = 0; i < details::bitCount<_TOutput>; ++i)
+                        weights[i] = (_TInput)0;
+                    bias = (_TOutput)0;
+                }
                 template <std::uniform_random_bit_generator _TRNG>
-                __host__ void FillWithRandom(_TRNG& RNG);
+                __host__ void FillWithRandom(_TRNG& RNG) {
+                    for (size_t i = 0; i < details::bitCount<_TOutput>; ++i)
+                        weights[i] = details::GetIntBin<_TInput>(RNG);
+                    bias = details::GetIntBin<_TOutput>(RNG);
+                }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
-                __device__ void FillWithRandom(_TRNG& RNG);
+                __device__ void FillWithRandom(_TRNG& RNG) {
+                    for (size_t i = 0; i < details::bitCount<_TOutput>; ++i)
+                        weights[i] = details::GetIntBin<_TInput>(RNG);
+                    bias = details::GetIntBin<_TOutput>(RNG);
+                }
 #endif
                 template <std::uniform_random_bit_generator _TRNG>
-                __host__ __forceinline void RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG);
+                __host__ __forceinline void RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+                    for (size_t i = 0; i < details::bitCount<_TOutput>; ++i)
+                        weights[i] = bcuda::rand::RandomizeWFlips(weights[i], WeightsFlipProb, RNG);
+                    bias = bcuda::rand::RandomizeWFlips(bias, BiasFlipProb, RNG);
+                }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
-                __device__ __forceinline void RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG);
+                __device__ __forceinline void RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+                    for (size_t i = 0; i < details::bitCount<_TOutput>; ++i)
+                        weights[i] = bcuda::rand::RandomizeWFlips(weights[i], WeightsFlipProb, RNG);
+                    bias = bcuda::rand::RandomizeWFlips(bias, BiasFlipProb, RNG);
+                }
 #endif
                 template <std::uniform_random_bit_generator _TRNG>
-                __host__ __forceinline void RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG);
+                __host__ __forceinline void RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+                    for (size_t i = 0; i < details::bitCount<_TOutput>; ++i)
+                        weights[i] = bcuda::rand::RandomizeWTargets(weights[i], WeightsFlipProb, RNG);
+                    bias = bcuda::rand::RandomizeWTargets(bias, BiasFlipProb, RNG);
+                }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
-                __device__ __forceinline void RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG);
+                __device__ __forceinline void RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+                    for (size_t i = 0; i < details::bitCount<_TOutput>; ++i)
+                        weights[i] = bcuda::rand::RandomizeWTargets(weights[i], WeightsFlipProb, RNG);
+                    bias = bcuda::rand::RandomizeWTargets(bias, BiasFlipProb, RNG);
+                }
 #endif
                 template <std::uniform_random_bit_generator _TRNG>
-                __host__ __forceinline void RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG);
+                __host__ __forceinline void RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
+                    for (size_t i = 0; i < details::bitCount<_TOutput>; ++i)
+                        weights[i] = bcuda::rand::RandomizeWMutations(weights[i], WeightsProbOf1, RNG);
+                    bias = bcuda::rand::RandomizeWMutations(bias, BiasProbOf1, RNG);
+                }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
-                __device__ __forceinline void RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG);
+                __device__ __forceinline void RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
+                    for (size_t i = 0; i < details::bitCount<_TOutput>; ++i)
+                        weights[i] = bcuda::rand::RandomizeWMutations(weights[i], WeightsProbOf1, RNG);
+                    bias = bcuda::rand::RandomizeWMutations(bias, BiasProbOf1, RNG);
+                }
 #endif
-                __host__ __device__ _TOutput Run(_TInput Input) const;
-                __host__ __device__ uint64_t RunG(uint64_t Input) const;
+                __host__ __device__ _TOutput Run(_TInput Input) const {
+                    _TOutput o = bias;
+                    for (size_t i = 0; i < details::bitCount<_TOutput>; ++i)
+                        if (Input & weights[i]) o |= ((_TOutput)1) << i;
+                    return o;
+                }
+                __host__ __device__ uint64_t RunG(uint64_t Input) const {
+                    return (uint64_t)Run((_TInput)Input);
+                }
 
-                size_t SerializedSize() const;
-                void Serialize(void*& Data) const;
-                static this_t Deserialize(const void*& Data);
-                static void Deserialize(const void*& Data, void* ObjMem);
+                size_t SerializedSize() const {
+                    return sizeof(this_t);
+                }
+                void Serialize(void*& Data) const {
+                    BSerializer::SerializeArray(Data, weights, details::bitCount<_TOutput>);
+                    BSerializer::Serialize(Data, bias);
+                }
+                static this_t Deserialize(const void*& Data) {
+                    uint8_t bytes[sizeof(this_t)];
+                    Deserialize(Data, &bytes);
+                    return *(this_t*)&bytes;
+                }
+                static void Deserialize(const void*& Data, void* ObjMem) {
+                    this_t& obj = *(this_t*)ObjMem;
+                    BSerializer::DeserializeArray(Data, obj.weights, details::bitCount<_TOutput>);
+                    BSerializer::Deserialize(Data, &obj.bias);
+                }
             };
             template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral... _LayerCounts>
             struct FixedMLPB;
@@ -100,42 +156,94 @@ namespace bcuda {
                 FixedMLPBL<_TInput, _TOutput1> layer;
                 FixedMLPB<_TOutput1, _TOutput2, _TsContinuedOutputs...> nextLayers;
 
-                __host__ __device__ void FillWith0();
+                __host__ __device__ void FillWith0() {
+                    layer.FillWith0();
+                    nextLayers.FillWith0();
+                }
                 template <std::uniform_random_bit_generator _TRNG>
-                __host__ void FillWithRandom(_TRNG& RNG);
+                __host__ void FillWithRandom(_TRNG& RNG) {
+                    layer.FillWithRandom(RNG);
+                    nextLayers.FillWithRandom(RNG);
+                }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
-                __device__ void FillWithRandom(_TRNG& RNG);
+                __device__ void FillWithRandom(_TRNG& RNG) {
+                    layer.FillWithRandom(RNG);
+                    nextLayers.FillWithRandom(RNG);
+                }
 #endif
                 template <std::uniform_random_bit_generator _TRNG>
-                __host__ __forceinline void RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG);
+                __host__ __forceinline void RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+                    layer.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
+                    nextLayers.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
+                }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
-                __device__ __forceinline void RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG);
+                __device__ __forceinline void RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+                    layer.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
+                    nextLayers.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
+                }
 #endif
                 template <std::uniform_random_bit_generator _TRNG>
-                __host__ __forceinline void RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG);
+                __host__ __forceinline void RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+                    layer.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
+                    nextLayers.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
+                }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
-                __device__ __forceinline void RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG);
+                __device__ __forceinline void RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+                    layer.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
+                    nextLayers.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
+                }
 #endif
                 template <std::uniform_random_bit_generator _TRNG>
-                __host__ __forceinline void RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG);
+                __host__ __forceinline void RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
+                    layer.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
+                    nextLayers.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
+                }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
                 __device__ __forceinline void RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG);
 #endif
-                __host__ __device__ output_t Run(_TInput Input) const;
-                __host__ __device__ uint64_t RunG(uint64_t Input) const;
+                __host__ __device__ output_t Run(_TInput Input) const {
+                    return (output_t)RunG((uint64_t)Input);
+                }
+                __host__ __device__ uint64_t RunG(uint64_t Input) const {
+                    Input = layer.RunG(Input);
+                    Input = nextLayers.RunG(Input);
+                    return Input;
+                }
                 template <size_t _Index>
-                __host__ __device__ layerType_t<_Index>& Layer();
+                __host__ __device__ layerType_t<_Index>& Layer() {
+                    if constexpr (_Index) {
+                        return nextLayers.Layer<_Index - 1>();
+                    }
+                    else {
+                        return layer;
+                    }
+                }
 
-                static constexpr size_t LayerCount();
+                static constexpr size_t LayerCount() {
+                    return sizeof...(_TsContinuedOutputs) + 2;
+                }
 
-                size_t SerializedSize() const;
-                void Serialize(void*& Data) const;
-                static this_t Deserialize(const void*& Data);
-                static void Deserialize(const void*& Data, void* ObjMem);
+                size_t SerializedSize() const {
+                    return sizeof(this_t);
+                }
+                void Serialize(void*& Data) const {
+                    layer.Serialize(Data);
+                    nextLayers.Serialize(Data);
+                }
+                static this_t Deserialize(const void*& Data) {
+                    uint8_t bytes[sizeof(this_t)];
+                    Deserialize(Data, &bytes);
+                    return *(this_t*)&bytes;
+                }
+                static void Deserialize(const void*& Data, void* ObjMem) {
+                    this_t& obj = &(this_t*)ObjMem;
+                    BSerializer::Deserialize(Data, &obj.layer);
+                    BSerializer::Deserialize(Data, &obj.nextLayers);
+                }
             };
             template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
             struct FixedMLPB<_TInput, _TOutput1> {
@@ -150,394 +258,82 @@ namespace bcuda {
 
                 FixedMLPBL<_TInput, _TOutput1> layer;
 
-                __host__ __device__ void FillWith0();
+                __host__ __device__ void FillWith0() {
+                    layer.FillWith0();
+                }
                 template <std::uniform_random_bit_generator _TRNG>
-                __host__ void FillWithRandom(_TRNG& RNG);
+                __host__ void FillWithRandom(_TRNG& RNG) {
+                    layer.FillWithRandom(RNG);
+                }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
-                __device__ void FillWithRandom(_TRNG& RNG);
+                __device__ void FillWithRandom(_TRNG& RNG) {
+                    layer.FillWithRandom(RNG);
+                }
 #endif
                 template <std::uniform_random_bit_generator _TRNG>
-                __host__ __forceinline void RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG);
+                __host__ __forceinline void RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+                    layer.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
+                }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
-                __device__ __forceinline void RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG);
+                __device__ __forceinline void RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+                    layer.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
+                }
 #endif
                 template <std::uniform_random_bit_generator _TRNG>
-                __host__ __forceinline void RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG);
+                __host__ __forceinline void RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+                    layer.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
+                }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
-                __device__ __forceinline void RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG);
+                __device__ __forceinline void RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
+                    layer.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
+                }
 #endif
                 template <std::uniform_random_bit_generator _TRNG>
-                __host__ __forceinline void RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG);
+                __host__ __forceinline void RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
+                    layer.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
+                }
 #ifdef __CUDACC__
                 template <KernelCurandState _TRNG>
-                __device__ __forceinline void RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG);
+                __device__ __forceinline void RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
+                    layer.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
+                }
 #endif
-                __host__ __device__ output_t Run(_TInput Input) const;
-                __host__ __device__ uint64_t RunG(uint64_t Input) const;
+                __host__ __device__ output_t Run(_TInput Input) const {
+                    return (output_t)RunG((uint64_t)Input);
+                }
+                __host__ __device__ uint64_t RunG(uint64_t Input) const {
+                    Input = layer.RunG(Input);
+                    return Input;
+                }
                 template <size_t _Index>
-                __host__ __device__ layerType_t<_Index>& Layer();
+                __host__ __device__ layerType_t<_Index>& Layer() {
+                    static_assert(!_Index, "_Index is out of bounds.");
+                    return layer;
+                }
 
-                static constexpr size_t LayerCount();
+                static constexpr size_t LayerCount() {
+                    return 1;
+                }
 
-                size_t SerializedSize() const;
-                void Serialize(void*& Data) const;
-                static this_t Deserialize(const void*& Data);
-                static void Deserialize(const void*& Data, void* ObjMem);
+                size_t SerializedSize() const {
+                    return sizeof(this_t);
+                }
+                void Serialize(void*& Data) const {
+                    layer.Serialize(Data);
+                }
+                static this_t Deserialize(const void*& Data) {
+                    uint8_t bytes[sizeof(this_t)];
+                    Deserialize(Data, &bytes);
+                    return *(this_t*)&bytes;
+                }
+                static void Deserialize(const void*& Data, void* ObjMem) {
+                    this_t& obj = &(this_t*)ObjMem;
+                    BSerializer::Deserialize(Data, &obj.layer);
+                }
             };
         }
     }
-}
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-__host__ __device__ void bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::FillWith0() {
-    for (size_t i = 0; i < details::BitCount<_TOutput>; ++i) {
-        weights[i] = (_TInput)0;
-    }
-    bias = (_TOutput)0;
-}
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-template <std::uniform_random_bit_generator _TRNG>
-__host__ void bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::FillWithRandom(_TRNG& RNG) {
-    for (size_t i = 0; i < details::BitCount<_TOutput>; ++i) {
-        weights[i] = details::GetIntBin<_TInput>(RNG);
-    }
-    bias = details::GetIntBin<_TOutput>(RNG);
-}
-
-#ifdef __CUDACC__
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-template <bcuda::KernelCurandState _TRNG>
-__device__ void bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::FillWithRandom(_TRNG& RNG) {
-    for (size_t i = 0; i < details::BitCount<_TOutput>; ++i) {
-        weights[i] = details::GetIntBin<_TInput>(RNG);
-    }
-    bias = details::GetIntBin<_TOutput>(RNG);
-}
-#endif
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
-    for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
-        weights[i] = bcuda::rand::RandomizeWFlips(weights[i], WeightsFlipProb, RNG);
-    bias = bcuda::rand::RandomizeWFlips(bias, BiasFlipProb, RNG);
-}
-
-#ifdef __CUDACC__
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-template <bcuda::KernelCurandState _TRNG>
-__device__ __forceinline void bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
-    for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
-        weights[i] = bcuda::rand::RandomizeWFlips(weights[i], WeightsFlipProb, RNG);
-    bias = bcuda::rand::RandomizeWFlips(bias, BiasFlipProb, RNG);
-}
-#endif
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
-    for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
-        weights[i] = bcuda::rand::RandomizeWTargets(weights[i], WeightsFlipProb, RNG);
-    bias = bcuda::rand::RandomizeWTargets(bias, BiasFlipProb, RNG);
-}
-
-#ifdef __CUDACC__
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-template <bcuda::KernelCurandState _TRNG>
-__device__ __forceinline void bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
-    for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
-        weights[i] = bcuda::rand::RandomizeWTargets(weights[i], WeightsFlipProb, RNG);
-    bias = bcuda::rand::RandomizeWTargets(bias, BiasFlipProb, RNG);
-}
-#endif
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
-    for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
-        weights[i] = bcuda::rand::RandomizeWMutations(weights[i], WeightsProbOf1, RNG);
-    bias = bcuda::rand::RandomizeWMutations(bias, BiasProbOf1, RNG);
-}
-
-#ifdef __CUDACC__
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-template <bcuda::KernelCurandState _TRNG>
-__device__ __forceinline void bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
-    for (size_t i = 0; i < details::BitCount<_TOutput>; ++i)
-        weights[i] = bcuda::rand::RandomizeWMutations(weights[i], WeightsProbOf1, RNG);
-    bias = bcuda::rand::RandomizeWMutations(bias, BiasProbOf1, RNG);
-}
-#endif
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-__host__ __device__ _TOutput bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::Run(_TInput Input) const {
-    _TOutput o = bias;
-    for (size_t i = 0; i < details::BitCount<_TOutput>; ++i) {
-        if (Input & weights[i]) o |= ((_TOutput)1) << i;
-    }
-    return o;
-}
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-__host__ __device__ uint64_t bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::RunG(uint64_t Input) const {
-    return (uint64_t)Run((_TInput)Input);
-}
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-size_t bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::SerializedSize() const {
-    return sizeof(this_t);
-}
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-void bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::Serialize(void*& Data) const {
-    BSerializer::SerializeArray(Data, weights, details::BitCount<_TOutput>);
-    BSerializer::Serialize(Data, bias);
-}
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput> bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::Deserialize(const void*& Data) {
-    uint8_t bytes[sizeof(this_t)];
-    Deserialize(Data, &bytes);
-    return *(this_t*)&bytes;
-}
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput>
-void bcuda::ai::mlpb::FixedMLPBL<_TInput, _TOutput>::Deserialize(const void*& Data, void* ObjMem) {
-    this_t& obj = *(this_t*)ObjMem;
-    BSerializer::DeserializeArray(Data, obj.weights, details::BitCount<_TOutput>);
-    BSerializer::Deserialize(Data, &obj.bias);
-}
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-__host__ __device__ void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::FillWith0() {
-    layer.FillWith0();
-}
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-template <std::uniform_random_bit_generator _TRNG>
-__host__ void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::FillWithRandom(_TRNG& RNG) {
-    layer.FillWithRandom(RNG);
-}
-
-#ifdef __CUDACC__
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-template <bcuda::KernelCurandState _TRNG>
-__device__ void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::FillWithRandom(_TRNG& RNG) {
-    layer.FillWithRandom(RNG);
-}
-#endif
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
-    layer.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
-}
-
-#ifdef __CUDACC__
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-template <bcuda::KernelCurandState _TRNG>
-__device__ __forceinline void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
-    layer.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
-}
-#endif
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
-    layer.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
-}
-
-#ifdef __CUDACC__
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-template <bcuda::KernelCurandState _TRNG>
-__device__ __forceinline void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
-    layer.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
-}
-#endif
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
-    layer.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
-}
-
-#ifdef __CUDACC__
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-template <bcuda::KernelCurandState _TRNG>
-__device__ __forceinline void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
-    layer.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
-}
-#endif
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-__host__ __device__ auto bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::Run(_TInput Input) const -> output_t {
-    return (output_t)RunG((uint64_t)Input);
-}
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-__host__ __device__ uint64_t bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::RunG(uint64_t Input) const {
-    Input = layer.RunG(Input);
-    return Input;
-}
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-__host__ __device__ void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::FillWith0() {
-    layer.FillWith0();
-    nextLayers.FillWith0();
-}
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-template <std::uniform_random_bit_generator _TRNG>
-__host__ void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::FillWithRandom(_TRNG& RNG) {
-    layer.FillWithRandom(RNG);
-    nextLayers.FillWithRandom(RNG);
-}
-
-#ifdef __CUDACC__
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-template <bcuda::KernelCurandState _TRNG>
-__device__ void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::FillWithRandom(_TRNG& RNG) {
-    layer.FillWithRandom(RNG);
-    nextLayers.FillWithRandom(RNG);
-}
-#endif
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
-    layer.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
-    nextLayers.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
-}
-
-#ifdef __CUDACC__
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-template <bcuda::KernelCurandState _TRNG>
-__device__ __forceinline void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWFlips(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
-    layer.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
-    nextLayers.RandomizeWFlips(WeightsFlipProb, BiasFlipProb, RNG);
-}
-#endif
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
-    layer.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
-    nextLayers.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
-}
-
-#ifdef __CUDACC__
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-template <bcuda::KernelCurandState _TRNG>
-__device__ __forceinline void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWTargets(uint32_t WeightsFlipProb, uint32_t BiasFlipProb, _TRNG& RNG) {
-    layer.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
-    nextLayers.RandomizeWTargets(WeightsFlipProb, BiasFlipProb, RNG);
-}
-#endif
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
-    layer.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
-    nextLayers.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
-}
-
-#ifdef __CUDACC__
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-template <bcuda::KernelCurandState _TRNG>
-__device__ __forceinline void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG) {
-    layer.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
-    nextLayers.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
-}
-#endif
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-__host__ __device__ auto bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Run(_TInput Input) const -> output_t {
-    return (output_t)RunG((uint64_t)Input);
-}
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-__host__ __device__ uint64_t bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::RunG(uint64_t Input) const {
-    Input = layer.RunG(Input);
-    Input = nextLayers.RunG(Input);
-    return Input;
-}
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-template <size_t _Index>
-__host__ __device__ bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::layerType_t<_Index>& bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Layer() {
-    if constexpr (_Index) {
-        return nextLayers.Layer<_Index - 1>();
-    }
-    else {
-        return layer;
-    }
-}
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-template <size_t _Index>
-__host__ __device__ bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::layerType_t<_Index>& bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::Layer() {
-    static_assert(!_Index, "_Index is out of bounds.");
-    return layer;
-}
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-constexpr size_t bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::LayerCount() {
-    return FixedMLPB<_TOutput1, _TOutput2, _TsContinuedOutputs...>::LayerCount() + 1;
-}
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-size_t bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::SerializedSize() const {
-    return sizeof(this_t);
-}
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Serialize(void*& Data) const {
-    layer.Serialize(Data);
-    nextLayers.Serialize(Data);
-}
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...> bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Deserialize(const void*& Data) {
-    uint8_t bytes[sizeof(this_t)];
-    Deserialize(Data, &bytes);
-    return *(this_t*)&bytes;
-}
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1, std::unsigned_integral _TOutput2, std::unsigned_integral... _TsContinuedOutputs>
-void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1, _TOutput2, _TsContinuedOutputs...>::Deserialize(const void*& Data, void* ObjMem) {
-    this_t& obj = &(this_t*)ObjMem;
-    BSerializer::Deserialize(Data, &obj.layer);
-    BSerializer::Deserialize(Data, &obj.nextLayers);
-}
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-constexpr size_t bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::LayerCount() {
-    return 1;
-}
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-size_t bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::SerializedSize() const {
-    return sizeof(this_t);
-}
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::Serialize(void*& Data) const {
-    layer.Serialize(Data);
-}
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1> bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::Deserialize(const void*& Data) {
-    uint8_t bytes[sizeof(this_t)];
-    Deserialize(Data, &bytes);
-    return *(this_t*)&bytes;
-}
-
-template <std::unsigned_integral _TInput, std::unsigned_integral _TOutput1>
-void bcuda::ai::mlpb::FixedMLPB<_TInput, _TOutput1>::Deserialize(const void*& Data, void* ObjMem) {
-    this_t& obj = &(this_t*)ObjMem;
-    BSerializer::Deserialize(Data, &obj.layer);
 }

--- a/arrays.h
+++ b/arrays.h
@@ -16,29 +16,29 @@ namespace bcuda {
     public:
         using element_t = _T;
 
-        __forceinline ArrayV() = default;
-        __host__ __device__ __forceinline ArrayV(_T* Ptr, size_t Size)
+        inline ArrayV() = default;
+        __host__ __device__ inline ArrayV(_T* Ptr, size_t Size)
             : ptr(Ptr), size(Size) { }
-        __host__ __device__ __forceinline ArrayV(size_t Size)
+        __host__ __device__ inline ArrayV(size_t Size)
             : ptr(new _T[Size]), size(Size) { }
-        __host__ __device__ __forceinline ArrayV(const ArrayV<_T>& Array)
+        __host__ __device__ inline ArrayV(const ArrayV<_T>& Array)
             : ArrayV(Array.size) {
             std::copy_n(Array.ptr, Array.size, ptr);
         }
-        __host__ __device__ __forceinline ArrayV(ArrayV<_T>&& Array)
+        __host__ __device__ inline ArrayV(ArrayV<_T>&& Array)
             : ArrayV(Array.ptr, Array.size) {
             Array.ptr = 0;
         }
-        __host__ __device__ __forceinline ArrayV(std::initializer_list<_T> InitList)
+        __host__ __device__ inline ArrayV(std::initializer_list<_T> InitList)
             : size(InitList.size()), ptr(new _T[InitList.size()]) {
             std::copy(InitList.begin(), InitList.end(), ptr);
         }
 
-        __host__ __device__ __forceinline ~ArrayV() {
+        __host__ __device__ inline ~ArrayV() {
             delete[] ptr;
         }
 
-        __host__ __device__ __forceinline ArrayV<_T>& operator=(ArrayV<_T> Array) {
+        __host__ __device__ inline ArrayV<_T>& operator=(ArrayV<_T> Array) {
             std::swap(ptr, Array.ptr);
             std::swap(size, Array.size);
             return *this;
@@ -54,24 +54,24 @@ namespace bcuda {
             return size;
         }
 
-        __host__ __device__ __forceinline _T& operator[](size_t Idx) {
+        __host__ __device__ inline _T& operator[](size_t Idx) {
             return ptr[Idx];
         }
-        __host__ __device__ __forceinline const _T& operator[](size_t Idx) const {
+        __host__ __device__ inline const _T& operator[](size_t Idx) const {
             return ptr[Idx];
         }
-        __host__ __device__ __forceinline _T* operator+(size_t Idx) {
+        __host__ __device__ inline _T* operator+(size_t Idx) {
             return ptr + Idx;
         }
-        __host__ __device__ __forceinline const _T* operator+(size_t Idx) const {
+        __host__ __device__ inline const _T* operator+(size_t Idx) const {
             return ptr + Idx;
         }
 
-        __host__ __device__ __forceinline Span<_T> Split(size_t Start, size_t NewSize) {
+        __host__ __device__ inline Span<_T> Split(size_t Start, size_t NewSize) {
             return Span<_T>(*this).Split(Start, NewSize);
         }
 
-        __host__ __device__ __forceinline Span<const _T> Split(size_t Start, size_t NewSize) const {
+        __host__ __device__ inline Span<const _T> Split(size_t Start, size_t NewSize) const {
             return Span<const _T>(*this).Split(Start, NewSize);
         }
     };
@@ -83,36 +83,36 @@ namespace bcuda {
         _T* ptr;
         size_t size;
 
-        __host__ __device__ __forceinline Span(_T* Ptr, size_t Size)
+        __host__ __device__ inline Span(_T* Ptr, size_t Size)
             : ptr(Ptr), size(Size) { }
 
         template <size_t _Size>
-        __host__ __device__ __forceinline Span(std::array<std::remove_const_t<_T>, _Size>& Array)
+        __host__ __device__ inline Span(std::array<std::remove_const_t<_T>, _Size>& Array)
             : ptr(Array.data()), size(Array.size()) { }
         template <size_t _Size>
-        __host__ __device__ __forceinline Span(const std::array<std::remove_const_t<_T>, _Size>& Array) requires (std::is_const_v<_T>)
+        __host__ __device__ inline Span(const std::array<std::remove_const_t<_T>, _Size>& Array) requires (std::is_const_v<_T>)
             : ptr(Array.data()), size(Array.size()) { }
-        __host__ __device__ __forceinline Span(std::vector<std::remove_const_t<_T>>& Vector)
+        __host__ __device__ inline Span(std::vector<std::remove_const_t<_T>>& Vector)
             : ptr(Vector.data()), size(Vector.size()) { }
-        __host__ __device__ __forceinline Span(const std::vector<std::remove_const_t<_T>>& Vector) requires (std::is_const_v<_T>)
+        __host__ __device__ inline Span(const std::vector<std::remove_const_t<_T>>& Vector) requires (std::is_const_v<_T>)
             : ptr(Vector.data()), size(Vector.size()) { }
-        __host__ __device__ __forceinline Span(ArrayV<std::remove_const_t<_T>>& Array)
+        __host__ __device__ inline Span(ArrayV<std::remove_const_t<_T>>& Array)
             : ptr(Array.Data()), size(Array.Size()) { }
-        __host__ __device__ __forceinline Span(const ArrayV<std::remove_const_t<_T>>& Array)
+        __host__ __device__ inline Span(const ArrayV<std::remove_const_t<_T>>& Array)
             : ptr(Array.Data()), size(Array.Size()) { }
-        __host__ __device__ __forceinline Span(const Span<_T>& Span)
+        __host__ __device__ inline Span(const Span<_T>& Span)
             : ptr(Span.ptr), size(Span.size) { }
-        __host__ __device__ __forceinline Span(const Span<std::remove_const_t<_T>>& Span) requires std::is_const_v<_T>
+        __host__ __device__ inline Span(const Span<std::remove_const_t<_T>>& Span) requires std::is_const_v<_T>
             : ptr(Span.ptr), size(Span.size) { }
 
-        __host__ __device__ __forceinline _T& operator[](size_t Idx) const {
+        __host__ __device__ inline _T& operator[](size_t Idx) const {
             return ptr[Idx];
         }
-        __host__ __device__ __forceinline _T* operator+(size_t Idx) {
+        __host__ __device__ inline _T* operator+(size_t Idx) {
             return ptr + Idx;
         }
 
-        __host__ __device__ __forceinline Span<_T> Split(size_t Start, size_t NewSize) const {
+        __host__ __device__ inline Span<_T> Split(size_t Start, size_t NewSize) const {
             return Span<_T>(ptr + Start, NewSize);
         }
     };

--- a/arrays.h
+++ b/arrays.h
@@ -16,7 +16,8 @@ namespace bcuda {
     public:
         using element_t = _T;
 
-        inline ArrayV() = default;
+        __host__ __device__ inline constexpr ArrayV()
+            : ptr(0), size(0) { }
         __host__ __device__ inline ArrayV(_T* Ptr, size_t Size)
             : ptr(Ptr), size(Size) { }
         __host__ __device__ inline ArrayV(size_t Size)
@@ -44,13 +45,13 @@ namespace bcuda {
             return *this;
         }
 
-        __host__ __device__ _T* Data() {
+        __host__ __device__ inline _T* Data() {
             return ptr;
         }
-        __host__ __device__ const _T* Data() const {
+        __host__ __device__ inline const _T* Data() const {
             return ptr;
         }
-        __host__ __device__ size_t Size() const {
+        __host__ __device__ inline size_t Size() const {
             return size;
         }
 

--- a/binary_basic.cu
+++ b/binary_basic.cu
@@ -1,248 +1,499 @@
 #include "binary_basic.h"
 
-__host__ __device__ uint32_t bcuda::binary::CountBitsF(uint64_t n) {
-    if (n >> 32) {
-        if (n >> 48) {
-            if (n >> 56) {
-                if (n >> 60) {
-                    if (n >> 62) {
-                        if (n >> 63) {
-                            return 64ui32;
+namespace bcuda {
+    namespace binary {
+        __host__ __device__ uint32_t CountBitsF(uint64_t n) {
+            if (n >> 32) {
+                if (n >> 48) {
+                    if (n >> 56) {
+                        if (n >> 60) {
+                            if (n >> 62) {
+                                if (n >> 63) {
+                                    return 64ui32;
+                                }
+                                else {
+                                    return 63ui32;
+                                }
+                            }
+                            else {
+                                if (n >> 61) {
+                                    return 62ui32;
+                                }
+                                else {
+                                    return 61ui32;
+                                }
+                            }
                         }
                         else {
-                            return 63ui32;
+                            if (n >> 58) {
+                                if (n >> 59) {
+                                    return 60ui32;
+                                }
+                                else {
+                                    return 59ui32;
+                                }
+                            }
+                            else {
+                                if (n >> 57) {
+                                    return 58ui32;
+                                }
+                                else {
+                                    return 57ui32;
+                                }
+                            }
                         }
                     }
                     else {
-                        if (n >> 61) {
-                            return 62ui32;
+                        if (n >> 52) {
+                            if (n >> 54) {
+                                if (n >> 55) {
+                                    return 56ui32;
+                                }
+                                else {
+                                    return 55ui32;
+                                }
+                            }
+                            else {
+                                if (n >> 53) {
+                                    return 54ui32;
+                                }
+                                else {
+                                    return 53ui32;
+                                }
+                            }
                         }
                         else {
-                            return 61ui32;
+                            if (n >> 50) {
+                                if (n >> 51) {
+                                    return 52ui32;
+                                }
+                                else {
+                                    return 51ui32;
+                                }
+                            }
+                            else {
+                                if (n >> 49) {
+                                    return 50ui32;
+                                }
+                                else {
+                                    return 49ui32;
+                                }
+                            }
                         }
                     }
                 }
                 else {
-                    if (n >> 58) {
-                        if (n >> 59) {
-                            return 60ui32;
+                    if (n >> 40) {
+                        if (n >> 44) {
+                            if (n >> 46) {
+                                if (n >> 47) {
+                                    return 48ui32;
+                                }
+                                else {
+                                    return 47ui32;
+                                }
+                            }
+                            else {
+                                if (n >> 45) {
+                                    return 46ui32;
+                                }
+                                else {
+                                    return 45ui32;
+                                }
+                            }
                         }
                         else {
-                            return 59ui32;
+                            if (n >> 42) {
+                                if (n >> 43) {
+                                    return 44ui32;
+                                }
+                                else {
+                                    return 43ui32;
+                                }
+                            }
+                            else {
+                                if (n >> 41) {
+                                    return 42ui32;
+                                }
+                                else {
+                                    return 41ui32;
+                                }
+                            }
                         }
                     }
                     else {
-                        if (n >> 57) {
-                            return 58ui32;
+                        if (n >> 36) {
+                            if (n >> 38) {
+                                if (n >> 39) {
+                                    return 40ui32;
+                                }
+                                else {
+                                    return 39ui32;
+                                }
+                            }
+                            else {
+                                if (n >> 37) {
+                                    return 38ui32;
+                                }
+                                else {
+                                    return 37ui32;
+                                }
+                            }
                         }
                         else {
-                            return 57ui32;
+                            if (n >> 34) {
+                                if (n >> 35) {
+                                    return 36ui32;
+                                }
+                                else {
+                                    return 35ui32;
+                                }
+                            }
+                            else {
+                                if (n >> 33) {
+                                    return 34ui32;
+                                }
+                                else {
+                                    return 33ui32;
+                                }
+                            }
                         }
                     }
                 }
             }
             else {
-                if (n >> 52) {
-                    if (n >> 54) {
-                        if (n >> 55) {
-                            return 56ui32;
+                if (n >> 16) {
+                    if (n >> 24) {
+                        if (n >> 28) {
+                            if (n >> 30) {
+                                if (n >> 31) {
+                                    return 32ui32;
+                                }
+                                else {
+                                    return 31ui32;
+                                }
+                            }
+                            else {
+                                if (n >> 29) {
+                                    return 30ui32;
+                                }
+                                else {
+                                    return 29ui32;
+                                }
+                            }
                         }
                         else {
-                            return 55ui32;
+                            if (n >> 26) {
+                                if (n >> 27) {
+                                    return 28ui32;
+                                }
+                                else {
+                                    return 27ui32;
+                                }
+                            }
+                            else {
+                                if (n >> 25) {
+                                    return 26ui32;
+                                }
+                                else {
+                                    return 25ui32;
+                                }
+                            }
                         }
                     }
                     else {
-                        if (n >> 53) {
-                            return 54ui32;
+                        if (n >> 20) {
+                            if (n >> 22) {
+                                if (n >> 23) {
+                                    return 24ui32;
+                                }
+                                else {
+                                    return 23ui32;
+                                }
+                            }
+                            else {
+                                if (n >> 21) {
+                                    return 22ui32;
+                                }
+                                else {
+                                    return 21ui32;
+                                }
+                            }
                         }
                         else {
-                            return 53ui32;
+                            if (n >> 18) {
+                                if (n >> 19) {
+                                    return 20ui32;
+                                }
+                                else {
+                                    return 19ui32;
+                                }
+                            }
+                            else {
+                                if (n >> 17) {
+                                    return 18ui32;
+                                }
+                                else {
+                                    return 17ui32;
+                                }
+                            }
                         }
                     }
                 }
                 else {
-                    if (n >> 50) {
-                        if (n >> 51) {
-                            return 52ui32;
+                    if (n >> 8) {
+                        if (n >> 12) {
+                            if (n >> 14) {
+                                if (n >> 15) {
+                                    return 16ui32;
+                                }
+                                else {
+                                    return 15ui32;
+                                }
+                            }
+                            else {
+                                if (n >> 13) {
+                                    return 14ui32;
+                                }
+                                else {
+                                    return 13ui32;
+                                }
+                            }
                         }
                         else {
-                            return 51ui32;
+                            if (n >> 10) {
+                                if (n >> 11) {
+                                    return 12ui32;
+                                }
+                                else {
+                                    return 11ui32;
+                                }
+                            }
+                            else {
+                                if (n >> 9) {
+                                    return 10ui32;
+                                }
+                                else {
+                                    return 9ui32;
+                                }
+                            }
                         }
                     }
                     else {
-                        if (n >> 49) {
-                            return 50ui32;
+                        if (n >> 4) {
+                            if (n >> 6) {
+                                if (n >> 7) {
+                                    return 8ui32;
+                                }
+                                else {
+                                    return 7ui32;
+                                }
+                            }
+                            else {
+                                if (n >> 5) {
+                                    return 6ui32;
+                                }
+                                else {
+                                    return 5ui32;
+                                }
+                            }
                         }
                         else {
-                            return 49ui32;
+                            if (n >> 2) {
+                                if (n >> 3) {
+                                    return 4ui32;
+                                }
+                                else {
+                                    return 3ui32;
+                                }
+                            }
+                            else {
+                                if (n >> 1) {
+                                    return 2ui32;
+                                }
+                                else {
+                                    if (n) {
+                                        return 1ui32;
+                                    }
+                                    else {
+                                        return 0ui32;
+                                    }
+                                }
+                            }
                         }
                     }
                 }
             }
         }
-        else {
-            if (n >> 40) {
-                if (n >> 44) {
-                    if (n >> 46) {
-                        if (n >> 47) {
-                            return 48ui32;
+        __host__ __device__ uint32_t CountBitsF(uint32_t n) {
+            if (n >> 16) {
+                if (n >> 24) {
+                    if (n >> 28) {
+                        if (n >> 30) {
+                            if (n >> 31) {
+                                return 32ui32;
+                            }
+                            else {
+                                return 31ui32;
+                            }
                         }
                         else {
-                            return 47ui32;
+                            if (n >> 29) {
+                                return 30ui32;
+                            }
+                            else {
+                                return 29ui32;
+                            }
                         }
                     }
                     else {
-                        if (n >> 45) {
-                            return 46ui32;
+                        if (n >> 26) {
+                            if (n >> 27) {
+                                return 28ui32;
+                            }
+                            else {
+                                return 27ui32;
+                            }
                         }
                         else {
-                            return 45ui32;
+                            if (n >> 25) {
+                                return 26ui32;
+                            }
+                            else {
+                                return 25ui32;
+                            }
                         }
                     }
                 }
                 else {
-                    if (n >> 42) {
-                        if (n >> 43) {
-                            return 44ui32;
+                    if (n >> 20) {
+                        if (n >> 22) {
+                            if (n >> 23) {
+                                return 24ui32;
+                            }
+                            else {
+                                return 23ui32;
+                            }
                         }
                         else {
-                            return 43ui32;
+                            if (n >> 21) {
+                                return 22ui32;
+                            }
+                            else {
+                                return 21ui32;
+                            }
                         }
                     }
                     else {
-                        if (n >> 41) {
-                            return 42ui32;
+                        if (n >> 18) {
+                            if (n >> 19) {
+                                return 20ui32;
+                            }
+                            else {
+                                return 19ui32;
+                            }
                         }
                         else {
-                            return 41ui32;
+                            if (n >> 17) {
+                                return 18ui32;
+                            }
+                            else {
+                                return 17ui32;
+                            }
                         }
                     }
                 }
             }
             else {
-                if (n >> 36) {
-                    if (n >> 38) {
-                        if (n >> 39) {
-                            return 40ui32;
+                if (n >> 8) {
+                    if (n >> 12) {
+                        if (n >> 14) {
+                            if (n >> 15) {
+                                return 16ui32;
+                            }
+                            else {
+                                return 15ui32;
+                            }
                         }
                         else {
-                            return 39ui32;
+                            if (n >> 13) {
+                                return 14ui32;
+                            }
+                            else {
+                                return 13ui32;
+                            }
                         }
                     }
                     else {
-                        if (n >> 37) {
-                            return 38ui32;
+                        if (n >> 10) {
+                            if (n >> 11) {
+                                return 12ui32;
+                            }
+                            else {
+                                return 11ui32;
+                            }
                         }
                         else {
-                            return 37ui32;
+                            if (n >> 9) {
+                                return 10ui32;
+                            }
+                            else {
+                                return 9ui32;
+                            }
                         }
                     }
                 }
                 else {
-                    if (n >> 34) {
-                        if (n >> 35) {
-                            return 36ui32;
+                    if (n >> 4) {
+                        if (n >> 6) {
+                            if (n >> 7) {
+                                return 8ui32;
+                            }
+                            else {
+                                return 7ui32;
+                            }
                         }
                         else {
-                            return 35ui32;
+                            if (n >> 5) {
+                                return 6ui32;
+                            }
+                            else {
+                                return 5ui32;
+                            }
                         }
                     }
                     else {
-                        if (n >> 33) {
-                            return 34ui32;
+                        if (n >> 2) {
+                            if (n >> 3) {
+                                return 4ui32;
+                            }
+                            else {
+                                return 3ui32;
+                            }
                         }
                         else {
-                            return 33ui32;
+                            if (n >> 1) {
+                                return 2ui32;
+                            }
+                            else {
+                                if (n) {
+                                    return 1ui32;
+                                }
+                                else {
+                                    return 0ui32;
+                                }
+                            }
                         }
                     }
                 }
             }
         }
-    }
-    else {
-        if (n >> 16) {
-            if (n >> 24) {
-                if (n >> 28) {
-                    if (n >> 30) {
-                        if (n >> 31) {
-                            return 32ui32;
-                        }
-                        else {
-                            return 31ui32;
-                        }
-                    }
-                    else {
-                        if (n >> 29) {
-                            return 30ui32;
-                        }
-                        else {
-                            return 29ui32;
-                        }
-                    }
-                }
-                else {
-                    if (n >> 26) {
-                        if (n >> 27) {
-                            return 28ui32;
-                        }
-                        else {
-                            return 27ui32;
-                        }
-                    }
-                    else {
-                        if (n >> 25) {
-                            return 26ui32;
-                        }
-                        else {
-                            return 25ui32;
-                        }
-                    }
-                }
-            }
-            else {
-                if (n >> 20) {
-                    if (n >> 22) {
-                        if (n >> 23) {
-                            return 24ui32;
-                        }
-                        else {
-                            return 23ui32;
-                        }
-                    }
-                    else {
-                        if (n >> 21) {
-                            return 22ui32;
-                        }
-                        else {
-                            return 21ui32;
-                        }
-                    }
-                }
-                else {
-                    if (n >> 18) {
-                        if (n >> 19) {
-                            return 20ui32;
-                        }
-                        else {
-                            return 19ui32;
-                        }
-                    }
-                    else {
-                        if (n >> 17) {
-                            return 18ui32;
-                        }
-                        else {
-                            return 17ui32;
-                        }
-                    }
-                }
-            }
-        }
-        else {
-            if (n >> 8) {
-                if (n >> 12) {
-                    if (n >> 14) {
-                        if (n >> 15) {
+        __host__ __device__ uint32_t CountBitsF(uint16_t n) {
+            uint32_t ni = (uint32_t)n;
+            if (ni >> 8) {
+                if (ni >> 12) {
+                    if (ni >> 14) {
+                        if (ni >> 15) {
                             return 16ui32;
                         }
                         else {
@@ -250,7 +501,7 @@ __host__ __device__ uint32_t bcuda::binary::CountBitsF(uint64_t n) {
                         }
                     }
                     else {
-                        if (n >> 13) {
+                        if (ni >> 13) {
                             return 14ui32;
                         }
                         else {
@@ -259,8 +510,8 @@ __host__ __device__ uint32_t bcuda::binary::CountBitsF(uint64_t n) {
                     }
                 }
                 else {
-                    if (n >> 10) {
-                        if (n >> 11) {
+                    if (ni >> 10) {
+                        if (ni >> 11) {
                             return 12ui32;
                         }
                         else {
@@ -268,7 +519,7 @@ __host__ __device__ uint32_t bcuda::binary::CountBitsF(uint64_t n) {
                         }
                     }
                     else {
-                        if (n >> 9) {
+                        if (ni >> 9) {
                             return 10ui32;
                         }
                         else {
@@ -278,9 +529,9 @@ __host__ __device__ uint32_t bcuda::binary::CountBitsF(uint64_t n) {
                 }
             }
             else {
-                if (n >> 4) {
-                    if (n >> 6) {
-                        if (n >> 7) {
+                if (ni >> 4) {
+                    if (ni >> 6) {
+                        if (ni >> 7) {
                             return 8ui32;
                         }
                         else {
@@ -288,7 +539,7 @@ __host__ __device__ uint32_t bcuda::binary::CountBitsF(uint64_t n) {
                         }
                     }
                     else {
-                        if (n >> 5) {
+                        if (ni >> 5) {
                             return 6ui32;
                         }
                         else {
@@ -297,8 +548,8 @@ __host__ __device__ uint32_t bcuda::binary::CountBitsF(uint64_t n) {
                     }
                 }
                 else {
-                    if (n >> 2) {
-                        if (n >> 3) {
+                    if (ni >> 2) {
+                        if (ni >> 3) {
                             return 4ui32;
                         }
                         else {
@@ -306,11 +557,11 @@ __host__ __device__ uint32_t bcuda::binary::CountBitsF(uint64_t n) {
                         }
                     }
                     else {
-                        if (n >> 1) {
+                        if (ni >> 1) {
                             return 2ui32;
                         }
                         else {
-                            if (n) {
+                            if (ni) {
                                 return 1ui32;
                             }
                             else {
@@ -321,130 +572,11 @@ __host__ __device__ uint32_t bcuda::binary::CountBitsF(uint64_t n) {
                 }
             }
         }
-    }
-}
-__host__ __device__ uint32_t bcuda::binary::CountBitsF(uint32_t n) {
-    if (n >> 16) {
-        if (n >> 24) {
-            if (n >> 28) {
-                if (n >> 30) {
-                    if (n >> 31) {
-                        return 32ui32;
-                    }
-                    else {
-                        return 31ui32;
-                    }
-                }
-                else {
-                    if (n >> 29) {
-                        return 30ui32;
-                    }
-                    else {
-                        return 29ui32;
-                    }
-                }
-            }
-            else {
-                if (n >> 26) {
-                    if (n >> 27) {
-                        return 28ui32;
-                    }
-                    else {
-                        return 27ui32;
-                    }
-                }
-                else {
-                    if (n >> 25) {
-                        return 26ui32;
-                    }
-                    else {
-                        return 25ui32;
-                    }
-                }
-            }
-        }
-        else {
-            if (n >> 20) {
-                if (n >> 22) {
-                    if (n >> 23) {
-                        return 24ui32;
-                    }
-                    else {
-                        return 23ui32;
-                    }
-                }
-                else {
-                    if (n >> 21) {
-                        return 22ui32;
-                    }
-                    else {
-                        return 21ui32;
-                    }
-                }
-            }
-            else {
-                if (n >> 18) {
-                    if (n >> 19) {
-                        return 20ui32;
-                    }
-                    else {
-                        return 19ui32;
-                    }
-                }
-                else {
-                    if (n >> 17) {
-                        return 18ui32;
-                    }
-                    else {
-                        return 17ui32;
-                    }
-                }
-            }
-        }
-    }
-    else {
-        if (n >> 8) {
-            if (n >> 12) {
-                if (n >> 14) {
-                    if (n >> 15) {
-                        return 16ui32;
-                    }
-                    else {
-                        return 15ui32;
-                    }
-                }
-                else {
-                    if (n >> 13) {
-                        return 14ui32;
-                    }
-                    else {
-                        return 13ui32;
-                    }
-                }
-            }
-            else {
-                if (n >> 10) {
-                    if (n >> 11) {
-                        return 12ui32;
-                    }
-                    else {
-                        return 11ui32;
-                    }
-                }
-                else {
-                    if (n >> 9) {
-                        return 10ui32;
-                    }
-                    else {
-                        return 9ui32;
-                    }
-                }
-            }
-        }
-        else {
-            if (n >> 4) {
-                if (n >> 6) {
-                    if (n >> 7) {
+        __host__ __device__ uint32_t CountBitsF(uint8_t n) {
+            uint32_t ni = (uint32_t)n;
+            if (ni >> 4) {
+                if (ni >> 6) {
+                    if (ni >> 7) {
                         return 8ui32;
                     }
                     else {
@@ -452,7 +584,7 @@ __host__ __device__ uint32_t bcuda::binary::CountBitsF(uint32_t n) {
                     }
                 }
                 else {
-                    if (n >> 5) {
+                    if (ni >> 5) {
                         return 6ui32;
                     }
                     else {
@@ -461,8 +593,8 @@ __host__ __device__ uint32_t bcuda::binary::CountBitsF(uint32_t n) {
                 }
             }
             else {
-                if (n >> 2) {
-                    if (n >> 3) {
+                if (ni >> 2) {
+                    if (ni >> 3) {
                         return 4ui32;
                     }
                     else {
@@ -470,11 +602,11 @@ __host__ __device__ uint32_t bcuda::binary::CountBitsF(uint32_t n) {
                     }
                 }
                 else {
-                    if (n >> 1) {
+                    if (ni >> 1) {
                         return 2ui32;
                     }
                     else {
-                        if (n) {
+                        if (ni) {
                             return 1ui32;
                         }
                         else {
@@ -484,379 +616,498 @@ __host__ __device__ uint32_t bcuda::binary::CountBitsF(uint32_t n) {
                 }
             }
         }
-    }
-}
-__host__ __device__ uint32_t bcuda::binary::CountBitsF(uint16_t n) {
-    uint32_t ni = (uint32_t)n;
-    if (ni >> 8) {
-        if (ni >> 12) {
-            if (ni >> 14) {
-                if (ni >> 15) {
-                    return 16ui32;
-                }
-                else {
-                    return 15ui32;
-                }
-            }
-            else {
-                if (ni >> 13) {
-                    return 14ui32;
-                }
-                else {
-                    return 13ui32;
-                }
-            }
-        }
-        else {
-            if (ni >> 10) {
-                if (ni >> 11) {
-                    return 12ui32;
-                }
-                else {
-                    return 11ui32;
-                }
-            }
-            else {
-                if (ni >> 9) {
-                    return 10ui32;
-                }
-                else {
-                    return 9ui32;
-                }
-            }
-        }
-    }
-    else {
-        if (ni >> 4) {
-            if (ni >> 6) {
-                if (ni >> 7) {
-                    return 8ui32;
-                }
-                else {
-                    return 7ui32;
-                }
-            }
-            else {
-                if (ni >> 5) {
-                    return 6ui32;
-                }
-                else {
-                    return 5ui32;
-                }
-            }
-        }
-        else {
-            if (ni >> 2) {
-                if (ni >> 3) {
-                    return 4ui32;
-                }
-                else {
-                    return 3ui32;
-                }
-            }
-            else {
-                if (ni >> 1) {
-                    return 2ui32;
-                }
-                else {
-                    if (ni) {
-                        return 1ui32;
-                    }
-                    else {
-                        return 0ui32;
-                    }
-                }
-            }
-        }
-    }
-}
-__host__ __device__ uint32_t bcuda::binary::CountBitsF(uint8_t n) {
-    uint32_t ni = (uint32_t)n;
-    if (ni >> 4) {
-        if (ni >> 6) {
-            if (ni >> 7) {
-                return 8ui32;
-            }
-            else {
-                return 7ui32;
-            }
-        }
-        else {
-            if (ni >> 5) {
-                return 6ui32;
-            }
-            else {
-                return 5ui32;
-            }
-        }
-    }
-    else {
-        if (ni >> 2) {
-            if (ni >> 3) {
-                return 4ui32;
-            }
-            else {
-                return 3ui32;
-            }
-        }
-        else {
-            if (ni >> 1) {
-                return 2ui32;
-            }
-            else {
-                if (ni) {
-                    return 1ui32;
-                }
-                else {
-                    return 0ui32;
-                }
-            }
-        }
-    }
-}
-__host__ __device__ uint32_t bcuda::binary::CountBitsB(uint64_t n) {
-    if (n << 32) {
-        if (n << 48) {
-            if (n << 56) {
-                if (n << 60) {
-                    if (n << 62) {
-                        if (n << 63) {
-                            return 64ui32;
+        __host__ __device__ uint32_t CountBitsB(uint64_t n) {
+            if (n << 32) {
+                if (n << 48) {
+                    if (n << 56) {
+                        if (n << 60) {
+                            if (n << 62) {
+                                if (n << 63) {
+                                    return 64ui32;
+                                }
+                                else {
+                                    return 63ui32;
+                                }
+                            }
+                            else {
+                                if (n << 61) {
+                                    return 62ui32;
+                                }
+                                else {
+                                    return 61ui32;
+                                }
+                            }
                         }
                         else {
-                            return 63ui32;
+                            if (n << 58) {
+                                if (n << 59) {
+                                    return 60ui32;
+                                }
+                                else {
+                                    return 59ui32;
+                                }
+                            }
+                            else {
+                                if (n << 57) {
+                                    return 58ui32;
+                                }
+                                else {
+                                    return 57ui32;
+                                }
+                            }
                         }
                     }
                     else {
-                        if (n << 61) {
-                            return 62ui32;
+                        if (n << 52) {
+                            if (n << 54) {
+                                if (n << 55) {
+                                    return 56ui32;
+                                }
+                                else {
+                                    return 55ui32;
+                                }
+                            }
+                            else {
+                                if (n << 53) {
+                                    return 54ui32;
+                                }
+                                else {
+                                    return 53ui32;
+                                }
+                            }
                         }
                         else {
-                            return 61ui32;
+                            if (n << 50) {
+                                if (n << 51) {
+                                    return 52ui32;
+                                }
+                                else {
+                                    return 51ui32;
+                                }
+                            }
+                            else {
+                                if (n << 49) {
+                                    return 50ui32;
+                                }
+                                else {
+                                    return 49ui32;
+                                }
+                            }
                         }
                     }
                 }
                 else {
-                    if (n << 58) {
-                        if (n << 59) {
-                            return 60ui32;
+                    if (n << 40) {
+                        if (n << 44) {
+                            if (n << 46) {
+                                if (n << 47) {
+                                    return 48ui32;
+                                }
+                                else {
+                                    return 47ui32;
+                                }
+                            }
+                            else {
+                                if (n << 45) {
+                                    return 46ui32;
+                                }
+                                else {
+                                    return 45ui32;
+                                }
+                            }
                         }
                         else {
-                            return 59ui32;
+                            if (n << 42) {
+                                if (n << 43) {
+                                    return 44ui32;
+                                }
+                                else {
+                                    return 43ui32;
+                                }
+                            }
+                            else {
+                                if (n << 41) {
+                                    return 42ui32;
+                                }
+                                else {
+                                    return 41ui32;
+                                }
+                            }
                         }
                     }
                     else {
-                        if (n << 57) {
-                            return 58ui32;
+                        if (n << 36) {
+                            if (n << 38) {
+                                if (n << 39) {
+                                    return 40ui32;
+                                }
+                                else {
+                                    return 39ui32;
+                                }
+                            }
+                            else {
+                                if (n << 37) {
+                                    return 38ui32;
+                                }
+                                else {
+                                    return 37ui32;
+                                }
+                            }
                         }
                         else {
-                            return 57ui32;
+                            if (n << 34) {
+                                if (n << 35) {
+                                    return 36ui32;
+                                }
+                                else {
+                                    return 35ui32;
+                                }
+                            }
+                            else {
+                                if (n << 33) {
+                                    return 34ui32;
+                                }
+                                else {
+                                    return 33ui32;
+                                }
+                            }
                         }
                     }
                 }
             }
             else {
-                if (n << 52) {
-                    if (n << 54) {
-                        if (n << 55) {
-                            return 56ui32;
+                if (n << 16) {
+                    if (n << 24) {
+                        if (n << 28) {
+                            if (n << 30) {
+                                if (n << 31) {
+                                    return 32ui32;
+                                }
+                                else {
+                                    return 31ui32;
+                                }
+                            }
+                            else {
+                                if (n << 29) {
+                                    return 30ui32;
+                                }
+                                else {
+                                    return 29ui32;
+                                }
+                            }
                         }
                         else {
-                            return 55ui32;
+                            if (n << 26) {
+                                if (n << 27) {
+                                    return 28ui32;
+                                }
+                                else {
+                                    return 27ui32;
+                                }
+                            }
+                            else {
+                                if (n << 25) {
+                                    return 26ui32;
+                                }
+                                else {
+                                    return 25ui32;
+                                }
+                            }
                         }
                     }
                     else {
-                        if (n << 53) {
-                            return 54ui32;
+                        if (n << 20) {
+                            if (n << 22) {
+                                if (n << 23) {
+                                    return 24ui32;
+                                }
+                                else {
+                                    return 23ui32;
+                                }
+                            }
+                            else {
+                                if (n << 21) {
+                                    return 22ui32;
+                                }
+                                else {
+                                    return 21ui32;
+                                }
+                            }
                         }
                         else {
-                            return 53ui32;
+                            if (n << 18) {
+                                if (n << 19) {
+                                    return 20ui32;
+                                }
+                                else {
+                                    return 19ui32;
+                                }
+                            }
+                            else {
+                                if (n << 17) {
+                                    return 18ui32;
+                                }
+                                else {
+                                    return 17ui32;
+                                }
+                            }
                         }
                     }
                 }
                 else {
-                    if (n << 50) {
-                        if (n << 51) {
-                            return 52ui32;
+                    if (n << 8) {
+                        if (n << 12) {
+                            if (n << 14) {
+                                if (n << 15) {
+                                    return 16ui32;
+                                }
+                                else {
+                                    return 15ui32;
+                                }
+                            }
+                            else {
+                                if (n << 13) {
+                                    return 14ui32;
+                                }
+                                else {
+                                    return 13ui32;
+                                }
+                            }
                         }
                         else {
-                            return 51ui32;
+                            if (n << 10) {
+                                if (n << 11) {
+                                    return 12ui32;
+                                }
+                                else {
+                                    return 11ui32;
+                                }
+                            }
+                            else {
+                                if (n << 9) {
+                                    return 10ui32;
+                                }
+                                else {
+                                    return 9ui32;
+                                }
+                            }
                         }
                     }
                     else {
-                        if (n << 49) {
-                            return 50ui32;
+                        if (n << 4) {
+                            if (n << 6) {
+                                if (n << 7) {
+                                    return 8ui32;
+                                }
+                                else {
+                                    return 7ui32;
+                                }
+                            }
+                            else {
+                                if (n << 5) {
+                                    return 6ui32;
+                                }
+                                else {
+                                    return 5ui32;
+                                }
+                            }
                         }
                         else {
-                            return 49ui32;
+                            if (n << 2) {
+                                if (n << 3) {
+                                    return 4ui32;
+                                }
+                                else {
+                                    return 3ui32;
+                                }
+                            }
+                            else {
+                                if (n << 1) {
+                                    return 2ui32;
+                                }
+                                else {
+                                    if (n) {
+                                        return 1ui32;
+                                    }
+                                    else {
+                                        return 0ui32;
+                                    }
+                                }
+                            }
                         }
                     }
                 }
             }
         }
-        else {
-            if (n << 40) {
-                if (n << 44) {
-                    if (n << 46) {
-                        if (n << 47) {
-                            return 48ui32;
+        __host__ __device__ uint32_t CountBitsB(uint32_t n) {
+            if (n << 16) {
+                if (n << 24) {
+                    if (n << 28) {
+                        if (n << 30) {
+                            if (n << 31) {
+                                return 32ui32;
+                            }
+                            else {
+                                return 31ui32;
+                            }
                         }
                         else {
-                            return 47ui32;
+                            if (n << 29) {
+                                return 30ui32;
+                            }
+                            else {
+                                return 29ui32;
+                            }
                         }
                     }
                     else {
-                        if (n << 45) {
-                            return 46ui32;
+                        if (n << 26) {
+                            if (n << 27) {
+                                return 28ui32;
+                            }
+                            else {
+                                return 27ui32;
+                            }
                         }
                         else {
-                            return 45ui32;
+                            if (n << 25) {
+                                return 26ui32;
+                            }
+                            else {
+                                return 25ui32;
+                            }
                         }
                     }
                 }
                 else {
-                    if (n << 42) {
-                        if (n << 43) {
-                            return 44ui32;
+                    if (n << 20) {
+                        if (n << 22) {
+                            if (n << 23) {
+                                return 24ui32;
+                            }
+                            else {
+                                return 23ui32;
+                            }
                         }
                         else {
-                            return 43ui32;
+                            if (n << 21) {
+                                return 22ui32;
+                            }
+                            else {
+                                return 21ui32;
+                            }
                         }
                     }
                     else {
-                        if (n << 41) {
-                            return 42ui32;
+                        if (n << 18) {
+                            if (n << 19) {
+                                return 20ui32;
+                            }
+                            else {
+                                return 19ui32;
+                            }
                         }
                         else {
-                            return 41ui32;
+                            if (n << 17) {
+                                return 18ui32;
+                            }
+                            else {
+                                return 17ui32;
+                            }
                         }
                     }
                 }
             }
             else {
-                if (n << 36) {
-                    if (n << 38) {
-                        if (n << 39) {
-                            return 40ui32;
+                if (n << 8) {
+                    if (n << 12) {
+                        if (n << 14) {
+                            if (n << 15) {
+                                return 16ui32;
+                            }
+                            else {
+                                return 15ui32;
+                            }
                         }
                         else {
-                            return 39ui32;
+                            if (n << 13) {
+                                return 14ui32;
+                            }
+                            else {
+                                return 13ui32;
+                            }
                         }
                     }
                     else {
-                        if (n << 37) {
-                            return 38ui32;
+                        if (n << 10) {
+                            if (n << 11) {
+                                return 12ui32;
+                            }
+                            else {
+                                return 11ui32;
+                            }
                         }
                         else {
-                            return 37ui32;
+                            if (n << 9) {
+                                return 10ui32;
+                            }
+                            else {
+                                return 9ui32;
+                            }
                         }
                     }
                 }
                 else {
-                    if (n << 34) {
-                        if (n << 35) {
-                            return 36ui32;
+                    if (n << 4) {
+                        if (n << 6) {
+                            if (n << 7) {
+                                return 8ui32;
+                            }
+                            else {
+                                return 7ui32;
+                            }
                         }
                         else {
-                            return 35ui32;
+                            if (n << 5) {
+                                return 6ui32;
+                            }
+                            else {
+                                return 5ui32;
+                            }
                         }
                     }
                     else {
-                        if (n << 33) {
-                            return 34ui32;
+                        if (n << 2) {
+                            if (n << 3) {
+                                return 4ui32;
+                            }
+                            else {
+                                return 3ui32;
+                            }
                         }
                         else {
-                            return 33ui32;
+                            if (n << 1) {
+                                return 2ui32;
+                            }
+                            else {
+                                if (n) {
+                                    return 1ui32;
+                                }
+                                else {
+                                    return 0ui32;
+                                }
+                            }
                         }
                     }
                 }
             }
         }
-    }
-    else {
-        if (n << 16) {
-            if (n << 24) {
-                if (n << 28) {
-                    if (n << 30) {
-                        if (n << 31) {
-                            return 32ui32;
-                        }
-                        else {
-                            return 31ui32;
-                        }
-                    }
-                    else {
-                        if (n << 29) {
-                            return 30ui32;
-                        }
-                        else {
-                            return 29ui32;
-                        }
-                    }
-                }
-                else {
-                    if (n << 26) {
-                        if (n << 27) {
-                            return 28ui32;
-                        }
-                        else {
-                            return 27ui32;
-                        }
-                    }
-                    else {
-                        if (n << 25) {
-                            return 26ui32;
-                        }
-                        else {
-                            return 25ui32;
-                        }
-                    }
-                }
-            }
-            else {
-                if (n << 20) {
-                    if (n << 22) {
-                        if (n << 23) {
-                            return 24ui32;
-                        }
-                        else {
-                            return 23ui32;
-                        }
-                    }
-                    else {
-                        if (n << 21) {
-                            return 22ui32;
-                        }
-                        else {
-                            return 21ui32;
-                        }
-                    }
-                }
-                else {
-                    if (n << 18) {
-                        if (n << 19) {
-                            return 20ui32;
-                        }
-                        else {
-                            return 19ui32;
-                        }
-                    }
-                    else {
-                        if (n << 17) {
-                            return 18ui32;
-                        }
-                        else {
-                            return 17ui32;
-                        }
-                    }
-                }
-            }
-        }
-        else {
-            if (n << 8) {
-                if (n << 12) {
-                    if (n << 14) {
-                        if (n << 15) {
+        __host__ __device__ uint32_t CountBitsB(uint16_t n) {
+            uint32_t ni = (uint32_t)n;
+            if (ni << 8) {
+                if (ni << 12) {
+                    if (ni << 14) {
+                        if (ni << 15) {
                             return 16ui32;
                         }
                         else {
@@ -864,7 +1115,7 @@ __host__ __device__ uint32_t bcuda::binary::CountBitsB(uint64_t n) {
                         }
                     }
                     else {
-                        if (n << 13) {
+                        if (ni << 13) {
                             return 14ui32;
                         }
                         else {
@@ -873,8 +1124,8 @@ __host__ __device__ uint32_t bcuda::binary::CountBitsB(uint64_t n) {
                     }
                 }
                 else {
-                    if (n << 10) {
-                        if (n << 11) {
+                    if (ni << 10) {
+                        if (ni << 11) {
                             return 12ui32;
                         }
                         else {
@@ -882,7 +1133,7 @@ __host__ __device__ uint32_t bcuda::binary::CountBitsB(uint64_t n) {
                         }
                     }
                     else {
-                        if (n << 9) {
+                        if (ni << 9) {
                             return 10ui32;
                         }
                         else {
@@ -892,9 +1143,9 @@ __host__ __device__ uint32_t bcuda::binary::CountBitsB(uint64_t n) {
                 }
             }
             else {
-                if (n << 4) {
-                    if (n << 6) {
-                        if (n << 7) {
+                if (ni << 4) {
+                    if (ni << 6) {
+                        if (ni << 7) {
                             return 8ui32;
                         }
                         else {
@@ -902,7 +1153,7 @@ __host__ __device__ uint32_t bcuda::binary::CountBitsB(uint64_t n) {
                         }
                     }
                     else {
-                        if (n << 5) {
+                        if (ni << 5) {
                             return 6ui32;
                         }
                         else {
@@ -911,8 +1162,8 @@ __host__ __device__ uint32_t bcuda::binary::CountBitsB(uint64_t n) {
                     }
                 }
                 else {
-                    if (n << 2) {
-                        if (n << 3) {
+                    if (ni << 2) {
+                        if (ni << 3) {
                             return 4ui32;
                         }
                         else {
@@ -920,11 +1171,11 @@ __host__ __device__ uint32_t bcuda::binary::CountBitsB(uint64_t n) {
                         }
                     }
                     else {
-                        if (n << 1) {
+                        if (ni << 1) {
                             return 2ui32;
                         }
                         else {
-                            if (n) {
+                            if (ni) {
                                 return 1ui32;
                             }
                             else {
@@ -935,130 +1186,11 @@ __host__ __device__ uint32_t bcuda::binary::CountBitsB(uint64_t n) {
                 }
             }
         }
-    }
-}
-__host__ __device__ uint32_t bcuda::binary::CountBitsB(uint32_t n) {
-    if (n << 16) {
-        if (n << 24) {
-            if (n << 28) {
-                if (n << 30) {
-                    if (n << 31) {
-                        return 32ui32;
-                    }
-                    else {
-                        return 31ui32;
-                    }
-                }
-                else {
-                    if (n << 29) {
-                        return 30ui32;
-                    }
-                    else {
-                        return 29ui32;
-                    }
-                }
-            }
-            else {
-                if (n << 26) {
-                    if (n << 27) {
-                        return 28ui32;
-                    }
-                    else {
-                        return 27ui32;
-                    }
-                }
-                else {
-                    if (n << 25) {
-                        return 26ui32;
-                    }
-                    else {
-                        return 25ui32;
-                    }
-                }
-            }
-        }
-        else {
-            if (n << 20) {
-                if (n << 22) {
-                    if (n << 23) {
-                        return 24ui32;
-                    }
-                    else {
-                        return 23ui32;
-                    }
-                }
-                else {
-                    if (n << 21) {
-                        return 22ui32;
-                    }
-                    else {
-                        return 21ui32;
-                    }
-                }
-            }
-            else {
-                if (n << 18) {
-                    if (n << 19) {
-                        return 20ui32;
-                    }
-                    else {
-                        return 19ui32;
-                    }
-                }
-                else {
-                    if (n << 17) {
-                        return 18ui32;
-                    }
-                    else {
-                        return 17ui32;
-                    }
-                }
-            }
-        }
-    }
-    else {
-        if (n << 8) {
-            if (n << 12) {
-                if (n << 14) {
-                    if (n << 15) {
-                        return 16ui32;
-                    }
-                    else {
-                        return 15ui32;
-                    }
-                }
-                else {
-                    if (n << 13) {
-                        return 14ui32;
-                    }
-                    else {
-                        return 13ui32;
-                    }
-                }
-            }
-            else {
-                if (n << 10) {
-                    if (n << 11) {
-                        return 12ui32;
-                    }
-                    else {
-                        return 11ui32;
-                    }
-                }
-                else {
-                    if (n << 9) {
-                        return 10ui32;
-                    }
-                    else {
-                        return 9ui32;
-                    }
-                }
-            }
-        }
-        else {
-            if (n << 4) {
-                if (n << 6) {
-                    if (n << 7) {
+        __host__ __device__ uint32_t CountBitsB(uint8_t n) {
+            uint32_t ni = (uint32_t)n;
+            if (ni << 4) {
+                if (ni << 6) {
+                    if (ni << 7) {
                         return 8ui32;
                     }
                     else {
@@ -1066,7 +1198,7 @@ __host__ __device__ uint32_t bcuda::binary::CountBitsB(uint32_t n) {
                     }
                 }
                 else {
-                    if (n << 5) {
+                    if (ni << 5) {
                         return 6ui32;
                     }
                     else {
@@ -1075,8 +1207,8 @@ __host__ __device__ uint32_t bcuda::binary::CountBitsB(uint32_t n) {
                 }
             }
             else {
-                if (n << 2) {
-                    if (n << 3) {
+                if (ni << 2) {
+                    if (ni << 3) {
                         return 4ui32;
                     }
                     else {
@@ -1084,145 +1216,17 @@ __host__ __device__ uint32_t bcuda::binary::CountBitsB(uint32_t n) {
                     }
                 }
                 else {
-                    if (n << 1) {
+                    if (ni << 1) {
                         return 2ui32;
                     }
                     else {
-                        if (n) {
+                        if (ni) {
                             return 1ui32;
                         }
                         else {
                             return 0ui32;
                         }
                     }
-                }
-            }
-        }
-    }
-}
-__host__ __device__ uint32_t bcuda::binary::CountBitsB(uint16_t n) {
-    uint32_t ni = (uint32_t)n;
-    if (ni << 8) {
-        if (ni << 12) {
-            if (ni << 14) {
-                if (ni << 15) {
-                    return 16ui32;
-                }
-                else {
-                    return 15ui32;
-                }
-            }
-            else {
-                if (ni << 13) {
-                    return 14ui32;
-                }
-                else {
-                    return 13ui32;
-                }
-            }
-        }
-        else {
-            if (ni << 10) {
-                if (ni << 11) {
-                    return 12ui32;
-                }
-                else {
-                    return 11ui32;
-                }
-            }
-            else {
-                if (ni << 9) {
-                    return 10ui32;
-                }
-                else {
-                    return 9ui32;
-                }
-            }
-        }
-    }
-    else {
-        if (ni << 4) {
-            if (ni << 6) {
-                if (ni << 7) {
-                    return 8ui32;
-                }
-                else {
-                    return 7ui32;
-                }
-            }
-            else {
-                if (ni << 5) {
-                    return 6ui32;
-                }
-                else {
-                    return 5ui32;
-                }
-            }
-        }
-        else {
-            if (ni << 2) {
-                if (ni << 3) {
-                    return 4ui32;
-                }
-                else {
-                    return 3ui32;
-                }
-            }
-            else {
-                if (ni << 1) {
-                    return 2ui32;
-                }
-                else {
-                    if (ni) {
-                        return 1ui32;
-                    }
-                    else {
-                        return 0ui32;
-                    }
-                }
-            }
-        }
-    }
-}
-__host__ __device__ uint32_t bcuda::binary::CountBitsB(uint8_t n) {
-    uint32_t ni = (uint32_t)n;
-    if (ni << 4) {
-        if (ni << 6) {
-            if (ni << 7) {
-                return 8ui32;
-            }
-            else {
-                return 7ui32;
-            }
-        }
-        else {
-            if (ni << 5) {
-                return 6ui32;
-            }
-            else {
-                return 5ui32;
-            }
-        }
-    }
-    else {
-        if (ni << 2) {
-            if (ni << 3) {
-                return 4ui32;
-            }
-            else {
-                return 3ui32;
-            }
-        }
-        else {
-            if (ni << 1) {
-                return 2ui32;
-            }
-            else {
-                if (ni) {
-                    return 1ui32;
-                }
-                else {
-                    return 0ui32;
                 }
             }
         }

--- a/copyblock.cu
+++ b/copyblock.cu
@@ -1,43 +1,47 @@
 #include "copyblock.h"
 
-__host__ __device__ bcuda::ArrayV<bcuda::details::Landmark> bcuda::details::GetLandmarksInDirection(uint32_t InputLength, uint32_t OutputLength, uint32_t RangeLength, uint32_t InputIndex, uint32_t OutputIndex) {
-    Landmark* landmarks = 0;
-    size_t landmarkSize = 0;
-    size_t landmarkCapacity = 0;
+namespace bcuda {
+    namespace details {
+        __host__ __device__ ArrayV<Landmark> GetLandmarksInDirection(uint32_t InputLength, uint32_t OutputLength, uint32_t RangeLength, uint32_t InputIndex, uint32_t OutputIndex) {
+            Landmark* landmarks = 0;
+            size_t landmarkSize = 0;
+            size_t landmarkCapacity = 0;
 
-    while (RangeLength) {
-        uint32_t dInput = InputLength - InputIndex;
-        uint32_t dOutput = OutputLength - OutputIndex;
-        bool oG = dOutput > dInput;
-        uint32_t dMin = oG ? dInput : dOutput;
-        if (dMin > RangeLength) dMin = RangeLength;
+            while (RangeLength) {
+                uint32_t dInput = InputLength - InputIndex;
+                uint32_t dOutput = OutputLength - OutputIndex;
+                bool oG = dOutput > dInput;
+                uint32_t dMin = oG ? dInput : dOutput;
+                if (dMin > RangeLength) dMin = RangeLength;
 
-        if (landmarkCapacity <= landmarkSize + 1) {
-            if (landmarkCapacity == 0) landmarkCapacity = 1;
-            else landmarkCapacity <<= 1;
-            Landmark* newArr = new Landmark[landmarkCapacity];
-            memcpy(newArr, landmarks, landmarkSize * sizeof(Landmark));
+                if (landmarkCapacity <= landmarkSize + 1) {
+                    if (landmarkCapacity == 0) landmarkCapacity = 1;
+                    else landmarkCapacity <<= 1;
+                    Landmark* newArr = new Landmark[landmarkCapacity];
+                    memcpy(newArr, landmarks, landmarkSize * sizeof(Landmark));
+                    delete[] landmarks;
+                    landmarks = newArr;
+                }
+                landmarks[landmarkSize++] = Landmark(InputIndex, OutputIndex, dMin);
+
+                if (oG) {
+                    InputIndex = 0;
+                    OutputIndex += dMin;
+                }
+                else if (dInput == dOutput) {
+                    InputIndex = 0;
+                    OutputIndex = 0;
+                }
+                else {
+                    InputIndex += dMin;
+                    OutputIndex = 0;
+                }
+                RangeLength -= dMin;
+            }
+            ArrayV<Landmark> landmarkArray(landmarkSize);
+            if (landmarks) memcpy(landmarkArray.Data(), landmarks, sizeof(Landmark) * landmarkSize);
             delete[] landmarks;
-            landmarks = newArr;
+            return landmarkArray;
         }
-        landmarks[landmarkSize++] = Landmark(InputIndex, OutputIndex, dMin);
-
-        if (oG) {
-            InputIndex = 0;
-            OutputIndex += dMin;
-        }
-        else if (dInput == dOutput) {
-            InputIndex = 0;
-            OutputIndex = 0;
-        }
-        else {
-            InputIndex += dMin;
-            OutputIndex = 0;
-        }
-        RangeLength -= dMin;
     }
-    ArrayV<Landmark> landmarkArray(landmarkSize);
-    if (landmarks) memcpy(landmarkArray.Data(), landmarks, sizeof(Landmark) * landmarkSize);
-    delete[] landmarks;
-    return landmarkArray;
 }

--- a/copyblock.h
+++ b/copyblock.h
@@ -23,286 +23,273 @@ namespace bcuda {
         __host__ __device__ ArrayV<Landmark> GetLandmarksInDirection(uint32_t InputLength, uint32_t OutputLength, uint32_t RangeLength, uint32_t InputIndex, uint32_t OutputIndex);
     }
     template <typename _T, size_t _VectorLength, bool _InputOnHost, bool _OutputOnHost, bool _Wrap = false>
-    __host__ static void CopyBlock(const _T* Input, _T* Output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates);
+    __host__ static void CopyBlock(const _T* Input, _T* Output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates) {
+        using vector_t = FixedVector<uint32_t, _VectorLength>;
+
+        if constexpr (_Wrap) {
+            ArrayV<details::Landmark> landmarksArray[_VectorLength];
+            for (size_t i = 0; i < _VectorLength; ++i)
+                new (landmarksArray + i) ArrayV<details::Landmark>(details::GetLandmarksInDirection(InputDimensions[i], OutputDimensions[i], RangeDimensions[i], RangeInInputsCoordinates[i], RangeInOutputsCoordinates[i]));
+
+            vector_t i;
+            while (true) {
+                vector_t rangeDimensions;
+                vector_t rangeInInputCoordinates;
+                vector_t rangeInOutputCoordinates;
+                for (size_t j = 0; j < _VectorLength; ++j) {
+                    details::Landmark landmark = landmarksArray[j][i[j]];
+                    rangeDimensions[j] = landmark.size;
+                    rangeInInputCoordinates[j] = landmark.inputIndex;
+                    rangeInOutputCoordinates[j] = landmark.outputIndex;
+                }
+
+                CopyBlock<_T, _VectorLength, _InputOnHost, _OutputOnHost, false>(Input, Output, InputDimensions, OutputDimensions, rangeDimensions, rangeInInputCoordinates, rangeInOutputCoordinates);
+
+                bool toBreak = true;
+                for (size_t j = 0; j < _VectorLength; ++j) {
+                    uint32_t& si = i[j];
+                    if (++si >= landmarksArray[j].Size()) si = 0;
+                    else {
+                        toBreak = false;
+                        break;
+                    }
+                }
+                if (toBreak) break;
+            }
+        }
+        else {
+            if constexpr (_VectorLength == 1) {
+                if constexpr (_InputOnHost)
+                    if constexpr (_OutputOnHost) memcpy(Output + RangeInOutputsCoordinates.x, Input + RangeInInputsCoordinates.x, sizeof(_T) * RangeDimensions.x);
+                    else cudaMemcpy(Output + RangeInOutputsCoordinates.x, Input + RangeInInputsCoordinates.x, sizeof(_T) * RangeDimensions.x, cudaMemcpyHostToDevice);
+                else
+                    if constexpr (_OutputOnHost) cudaMemcpy(Output + RangeInOutputsCoordinates.x, Input + RangeInInputsCoordinates.x, sizeof(_T) * RangeDimensions.x, cudaMemcpyDeviceToHost);
+                    else cudaMemcpy(Output + RangeInOutputsCoordinates.x, Input + RangeInInputsCoordinates.x, sizeof(_T) * RangeDimensions.x, cudaMemcpyDeviceToDevice);
+                return;
+            }
+            size_t elementNum = RangeDimensions[0];
+            size_t memcpySize = sizeof(_T) * elementNum;
+            vector_t i;
+            while (true) {
+                size_t iptIdx = CoordinatesToIndex<size_t, uint32_t, _VectorLength, true>(InputDimensions, RangeInInputsCoordinates + i);
+                size_t optIdx = CoordinatesToIndex<size_t, uint32_t, _VectorLength, true>(OutputDimensions, RangeInOutputsCoordinates + i);
+
+                const _T* iptPtr = Input + iptIdx;
+                _T* optPtr = Output + optIdx;
+
+                if constexpr (_InputOnHost)
+                    if constexpr (_OutputOnHost) memcpy(optPtr, iptPtr, memcpySize);
+                    else cudaMemcpy(optPtr, iptPtr, memcpySize, cudaMemcpyHostToDevice);
+                else
+                    if constexpr (_OutputOnHost) cudaMemcpy(optPtr, iptPtr, memcpySize, cudaMemcpyDeviceToHost);
+                    else cudaMemcpy(optPtr, iptPtr, memcpySize, cudaMemcpyDeviceToDevice);
+
+                bool toBreak = true;
+                for (size_t j = 1; j < _VectorLength; ++j) {
+                    uint32_t& si = i[j];
+                    if (++si >= RangeDimensions[j]) si = 0;
+                    else {
+                        toBreak = false;
+                        break;
+                    }
+                }
+                if (toBreak) break;
+            }
+        }
+    }
 #ifdef __CUDACC__
     template <typename _T, size_t _VectorLength, bool _Wrap = false>
-    __device__ static void CopyBlock(const _T* Input, _T* Output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates);
+    __device__ static void CopyBlock(const _T* Input, _T* Output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates) {
+        using vector_t = FixedVector<uint32_t, _VectorLength>;
+
+        if constexpr (_Wrap) {
+            ArrayV<details::Landmark> landmarksArray[_VectorLength];
+            for (size_t i = 0; i < _VectorLength; ++i)
+                new (landmarksArray + i) ArrayV<details::Landmark>(details::GetLandmarksInDirection(InputDimensions[i], OutputDimensions[i], RangeDimensions[i], RangeInInputsCoordinates[i], RangeInOutputsCoordinates[i]));
+
+            vector_t i;
+            while (true) {
+                vector_t rangeDimensions;
+                vector_t rangeInInputCoordinates;
+                vector_t rangeInOutputCoordinates;
+                for (size_t j = 0; j < _VectorLength; ++j) {
+                    details::Landmark landmark = landmarksArray[j][i[j]];
+                    rangeDimensions[j] = landmark.size;
+                    rangeInInputCoordinates[j] = landmark.inputIndex;
+                    rangeInOutputCoordinates[j] = landmark.outputIndex;
+                }
+
+                CopyBlock<_T, _VectorLength, false>(Input, Output, InputDimensions, OutputDimensions, rangeDimensions, rangeInInputCoordinates, rangeInOutputCoordinates);
+
+                bool toBreak = true;
+                for (size_t j = 0; j < _VectorLength; ++j) {
+                    uint32_t& si = i[j];
+                    if (++si >= landmarksArray[j].Size()) si = 0;
+                    else {
+                        toBreak = false;
+                        break;
+                    }
+                }
+                if (toBreak) break;
+            }
+        }
+        else {
+            if constexpr (_VectorLength == 1) {
+                memcpy(Output + RangeInOutputsCoordinates.x, Input + RangeInInputsCoordinates.x, sizeof(_T) * RangeDimensions.x);
+                return;
+            }
+            size_t elementNum = RangeDimensions[0];
+            size_t memcpySize = sizeof(_T) * elementNum;
+            vector_t i;
+            while (true) {
+                size_t iptIdx = CoordinatesToIndex<size_t, uint32_t, _VectorLength, true>(InputDimensions, RangeInInputsCoordinates + i);
+                size_t optIdx = CoordinatesToIndex<size_t, uint32_t, _VectorLength, true>(OutputDimensions, RangeInOutputsCoordinates + i);
+
+                const _T* iptPtr = Input + iptIdx;
+                _T* optPtr = Output + optIdx;
+
+                memcpy(optPtr, iptPtr, memcpySize);
+
+                bool toBreak = true;
+                for (size_t j = 1; j < _VectorLength; ++j) {
+                    uint32_t& si = i[j];
+                    if (++si >= RangeDimensions[j]) si = 0;
+                    else {
+                        toBreak = false;
+                        break;
+                    }
+                }
+                if (toBreak) break;
+            }
+        }
+    }
 #endif
 
     template <typename _T, size_t _VectorLength, copyValFunc_t<_T> _CopyValFunc, bool _Wrap = false>
-    __host__ __device__ static void CopyBlock(const _T* Input, _T* Output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates);
+    __host__ __device__ static void CopyBlock(const _T* Input, _T* Output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates) {
+        using vector_t = FixedVector<uint32_t, _VectorLength>;
+
+        if constexpr (_Wrap) {
+            ArrayV<details::Landmark> landmarksArray[_VectorLength];
+            for (size_t i = 0; i < _VectorLength; ++i)
+                new (landmarksArray + i) ArrayV<details::Landmark>(details::GetLandmarksInDirection(InputDimensions[i], OutputDimensions[i], RangeDimensions[i], RangeInInputsCoordinates[i], RangeInOutputsCoordinates[i]));
+
+            vector_t i;
+            while (true) {
+                vector_t rangeDimensions;
+                vector_t rangeInInputCoordinates;
+                vector_t rangeInOutputCoordinates;
+                for (size_t j = 0; j < _VectorLength; ++j) {
+                    details::Landmark landmark = landmarksArray[j][i[j]];
+                    rangeDimensions[j] = landmark.size;
+                    rangeInInputCoordinates[j] = landmark.inputIndex;
+                    rangeInOutputCoordinates[j] = landmark.outputIndex;
+                }
+
+                CopyBlock<_T, _VectorLength, _CopyValFunc, false>(Input, Output, InputDimensions, OutputDimensions, rangeDimensions, rangeInInputCoordinates, rangeInOutputCoordinates);
+
+                bool toBreak = true;
+                for (size_t j = 0; j < _VectorLength; ++j) {
+                    uint32_t& si = i[j];
+                    if (++si >= landmarksArray[j].Size()) si = 0;
+                    else {
+                        toBreak = false;
+                        break;
+                    }
+                }
+                if (toBreak) break;
+            }
+        }
+        else {
+            if constexpr (_VectorLength == 1) {
+                for (_T* ipu = Input + RangeDimensions.x; Input < ipu; ++Input, ++Output)
+                    _CopyValFunc(Output + RangeInOutputsCoordinates.x, Input + RangeInInputsCoordinates.x);
+                return;
+            }
+            size_t elementNum = RangeDimensions[0];
+            vector_t i;
+            while (true) {
+                size_t iptIdx = CoordinatesToIndex<size_t, uint32_t, _VectorLength, true>(InputDimensions, RangeInInputsCoordinates + i);
+                size_t optIdx = CoordinatesToIndex<size_t, uint32_t, _VectorLength, true>(OutputDimensions, RangeInOutputsCoordinates + i);
+
+                const _T* iptPtr = Input + iptIdx;
+                _T* optPtr = Output + optIdx;
+
+                for (_T* ipu = iptPtr + elementNum; iptPtr < ipu; ++iptPtr, ++optPtr)
+                    _CopyValFunc(optPtr, iptPtr);
+
+                bool toBreak = true;
+                for (size_t j = 1; j < _VectorLength; ++j) {
+                    uint32_t& si = i[j];
+                    if (++si >= RangeDimensions[j]) si = 0;
+                    else {
+                        toBreak = false;
+                        break;
+                    }
+                }
+                if (toBreak) break;
+            }
+        }
+    }
     template <typename _T, size_t _VectorLength, copyArrFunc_t<_T> _CopyArrFunc, bool _Wrap = false>
-    __host__ __device__ static void CopyBlock(const _T* Input, _T* Output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates);
-}
+    __host__ __device__ static void CopyBlock(const _T* Input, _T* Output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates) {
+        using vector_t = FixedVector<uint32_t, _VectorLength>;
 
-template <typename _T, size_t _VectorLength, bool _InputOnHost, bool _OutputOnHost, bool _Wrap>
-__host__ void bcuda::CopyBlock(const _T* Input, _T* Output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates) {
-    using vector_t = FixedVector<uint32_t, _VectorLength>;
-    
-    if constexpr (_Wrap) {
-        ArrayV<details::Landmark> landmarksArray[_VectorLength];
-        for (size_t i = 0; i < _VectorLength; ++i)
-            new (landmarksArray + i) ArrayV<details::Landmark>(details::GetLandmarksInDirection(InputDimensions[i], OutputDimensions[i], RangeDimensions[i], RangeInInputsCoordinates[i], RangeInOutputsCoordinates[i]));
-        
-        vector_t i;
-        while (true) {
-            vector_t rangeDimensions;
-            vector_t rangeInInputCoordinates;
-            vector_t rangeInOutputCoordinates;
-            for (size_t j = 0; j < _VectorLength; ++j) {
-                details::Landmark landmark = landmarksArray[j][i[j]];
-                rangeDimensions[j] = landmark.size;
-                rangeInInputCoordinates[j] = landmark.inputIndex;
-                rangeInOutputCoordinates[j] = landmark.outputIndex;
-            }
+        if constexpr (_Wrap) {
+            ArrayV<details::Landmark> landmarksArray[_VectorLength];
+            for (size_t i = 0; i < _VectorLength; ++i)
+                new (landmarksArray + i) ArrayV<details::Landmark>(details::GetLandmarksInDirection(InputDimensions[i], OutputDimensions[i], RangeDimensions[i], RangeInInputsCoordinates[i], RangeInOutputsCoordinates[i]));
 
-            CopyBlock<_T, _VectorLength, _InputOnHost, _OutputOnHost, false>(Input, Output, InputDimensions, OutputDimensions, rangeDimensions, rangeInInputCoordinates, rangeInOutputCoordinates);
-            
-            bool toBreak = true;
-            for (size_t j = 0; j < _VectorLength; ++j) {
-                uint32_t& si = i[j];
-                if (++si >= landmarksArray[j].Size()) si = 0;
-                else {
-                    toBreak = false;
-                    break;
+            vector_t i;
+            while (true) {
+                vector_t rangeDimensions;
+                vector_t rangeInInputCoordinates;
+                vector_t rangeInOutputCoordinates;
+                for (size_t j = 0; j < _VectorLength; ++j) {
+                    details::Landmark landmark = landmarksArray[j][i[j]];
+                    rangeDimensions[j] = landmark.size;
+                    rangeInInputCoordinates[j] = landmark.inputIndex;
+                    rangeInOutputCoordinates[j] = landmark.outputIndex;
                 }
-            }
-            if (toBreak) break;
-        }
-    }
-    else {
-        if constexpr (_VectorLength == 1) {
-            if constexpr (_InputOnHost)
-                if constexpr (_OutputOnHost) memcpy(Output + RangeInOutputsCoordinates.x, Input + RangeInInputsCoordinates.x, sizeof(_T) * RangeDimensions.x);
-                else cudaMemcpy(Output + RangeInOutputsCoordinates.x, Input + RangeInInputsCoordinates.x, sizeof(_T) * RangeDimensions.x, cudaMemcpyHostToDevice);
-            else
-                if constexpr (_OutputOnHost) cudaMemcpy(Output + RangeInOutputsCoordinates.x, Input + RangeInInputsCoordinates.x, sizeof(_T) * RangeDimensions.x, cudaMemcpyDeviceToHost);
-                else cudaMemcpy(Output + RangeInOutputsCoordinates.x, Input + RangeInInputsCoordinates.x, sizeof(_T) * RangeDimensions.x, cudaMemcpyDeviceToDevice);
-            return;
-        }
-        size_t elementNum = RangeDimensions[0];
-        size_t memcpySize = sizeof(_T) * elementNum;
-        vector_t i;
-        while (true) {
-            size_t iptIdx = CoordinatesToIndex<size_t, uint32_t, _VectorLength, true>(InputDimensions, RangeInInputsCoordinates + i);
-            size_t optIdx = CoordinatesToIndex<size_t, uint32_t, _VectorLength, true>(OutputDimensions, RangeInOutputsCoordinates + i);
 
-            const _T* iptPtr = Input + iptIdx;
-            _T* optPtr = Output + optIdx;
+                CopyBlock<_T, _VectorLength, _CopyArrFunc, false>(Input, Output, InputDimensions, OutputDimensions, rangeDimensions, rangeInInputCoordinates, rangeInOutputCoordinates);
 
-            if constexpr (_InputOnHost)
-                if constexpr (_OutputOnHost) memcpy(optPtr, iptPtr, memcpySize);
-                else cudaMemcpy(optPtr, iptPtr, memcpySize, cudaMemcpyHostToDevice);
-            else
-                if constexpr (_OutputOnHost) cudaMemcpy(optPtr, iptPtr, memcpySize, cudaMemcpyDeviceToHost);
-                else cudaMemcpy(optPtr, iptPtr, memcpySize, cudaMemcpyDeviceToDevice);
-
-            bool toBreak = true;
-            for (size_t j = 1; j < _VectorLength; ++j) {
-                uint32_t& si = i[j];
-                if (++si >= RangeDimensions[j]) si = 0;
-                else {
-                    toBreak = false;
-                    break;
+                bool toBreak = true;
+                for (size_t j = 0; j < _VectorLength; ++j) {
+                    uint32_t& si = i[j];
+                    if (++si >= landmarksArray[j].Size()) si = 0;
+                    else {
+                        toBreak = false;
+                        break;
+                    }
                 }
+                if (toBreak) break;
             }
-            if (toBreak) break;
         }
-    }
-}
-#ifdef __CUDACC__
-template <typename _T, size_t _VectorLength, bool _Wrap>
-__device__ void bcuda::CopyBlock(const _T* Input, _T* Output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates) {
-    using vector_t = FixedVector<uint32_t, _VectorLength>;
-
-    if constexpr (_Wrap) {
-        ArrayV<details::Landmark> landmarksArray[_VectorLength];
-        for (size_t i = 0; i < _VectorLength; ++i)
-            new (landmarksArray + i) ArrayV<details::Landmark>(details::GetLandmarksInDirection(InputDimensions[i], OutputDimensions[i], RangeDimensions[i], RangeInInputsCoordinates[i], RangeInOutputsCoordinates[i]));
-        
-        vector_t i;
-        while (true) {
-            vector_t rangeDimensions;
-            vector_t rangeInInputCoordinates;
-            vector_t rangeInOutputCoordinates;
-            for (size_t j = 0; j < _VectorLength; ++j) {
-                details::Landmark landmark = landmarksArray[j][i[j]];
-                rangeDimensions[j] = landmark.size;
-                rangeInInputCoordinates[j] = landmark.inputIndex;
-                rangeInOutputCoordinates[j] = landmark.outputIndex;
+        else {
+            if constexpr (_VectorLength == 1) {
+                _CopyArrFunc(Output + RangeInOutputsCoordinates.x, Input + RangeInInputsCoordinates.x, RangeDimensions.x);
+                return;
             }
+            size_t elementNum = RangeDimensions[0];
+            vector_t i;
+            while (true) {
+                size_t iptIdx = CoordinatesToIndex<size_t, uint32_t, _VectorLength, true>(InputDimensions, RangeInInputsCoordinates + i);
+                size_t optIdx = CoordinatesToIndex<size_t, uint32_t, _VectorLength, true>(OutputDimensions, RangeInOutputsCoordinates + i);
 
-            CopyBlock<_T, _VectorLength, false>(Input, Output, InputDimensions, OutputDimensions, rangeDimensions, rangeInInputCoordinates, rangeInOutputCoordinates);
+                _CopyArrFunc(Output + optIdx, Input + iptIdx, elementNum);
 
-            bool toBreak = true;
-            for (size_t j = 0; j < _VectorLength; ++j) {
-                uint32_t& si = i[j];
-                if (++si >= landmarksArray[j].Size()) si = 0;
-                else {
-                    toBreak = false;
-                    break;
+                bool toBreak = true;
+                for (size_t j = 1; j < _VectorLength; ++j) {
+                    uint32_t& si = i[j];
+                    if (++si >= RangeDimensions[j]) si = 0;
+                    else {
+                        toBreak = false;
+                        break;
+                    }
                 }
+                if (toBreak) break;
             }
-            if (toBreak) break;
-        }
-    }
-    else {
-        if constexpr (_VectorLength == 1) {
-            memcpy(Output + RangeInOutputsCoordinates.x, Input + RangeInInputsCoordinates.x, sizeof(_T) * RangeDimensions.x);
-            return;
-        }
-        size_t elementNum = RangeDimensions[0];
-        size_t memcpySize = sizeof(_T) * elementNum;
-        vector_t i;
-        while (true) {
-            size_t iptIdx = CoordinatesToIndex<size_t, uint32_t, _VectorLength, true>(InputDimensions, RangeInInputsCoordinates + i);
-            size_t optIdx = CoordinatesToIndex<size_t, uint32_t, _VectorLength, true>(OutputDimensions, RangeInOutputsCoordinates + i);
-
-            const _T* iptPtr = Input + iptIdx;
-            _T* optPtr = Output + optIdx;
-
-            memcpy(optPtr, iptPtr, memcpySize);
-
-            bool toBreak = true;
-            for (size_t j = 1; j < _VectorLength; ++j) {
-                uint32_t& si = i[j];
-                if (++si >= RangeDimensions[j]) si = 0;
-                else {
-                    toBreak = false;
-                    break;
-                }
-            }
-            if (toBreak) break;
-        }
-    }
-}
-#endif
-
-template <typename _T, size_t _VectorLength, bcuda::copyValFunc_t<_T> _CopyValFunc, bool _Wrap>
-__host__ __device__ void bcuda::CopyBlock(const _T* Input, _T* Output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates) {
-    using vector_t = FixedVector<uint32_t, _VectorLength>;
-
-    if constexpr (_Wrap) {
-        ArrayV<details::Landmark> landmarksArray[_VectorLength];
-        for (size_t i = 0; i < _VectorLength; ++i)
-            new (landmarksArray + i) ArrayV<details::Landmark>(details::GetLandmarksInDirection(InputDimensions[i], OutputDimensions[i], RangeDimensions[i], RangeInInputsCoordinates[i], RangeInOutputsCoordinates[i]));
-
-        vector_t i;
-        while (true) {
-            vector_t rangeDimensions;
-            vector_t rangeInInputCoordinates;
-            vector_t rangeInOutputCoordinates;
-            for (size_t j = 0; j < _VectorLength; ++j) {
-                details::Landmark landmark = landmarksArray[j][i[j]];
-                rangeDimensions[j] = landmark.size;
-                rangeInInputCoordinates[j] = landmark.inputIndex;
-                rangeInOutputCoordinates[j] = landmark.outputIndex;
-            }
-
-            CopyBlock<_T, _VectorLength, _CopyValFunc, false>(Input, Output, InputDimensions, OutputDimensions, rangeDimensions, rangeInInputCoordinates, rangeInOutputCoordinates);
-
-            bool toBreak = true;
-            for (size_t j = 0; j < _VectorLength; ++j) {
-                uint32_t& si = i[j];
-                if (++si >= landmarksArray[j].Size()) si = 0;
-                else {
-                    toBreak = false;
-                    break;
-                }
-            }
-            if (toBreak) break;
-        }
-    }
-    else {
-        if constexpr (_VectorLength == 1) {
-            for (_T* ipu = Input + RangeDimensions.x; Input < ipu; ++Input, ++Output)
-                _CopyValFunc(Output + RangeInOutputsCoordinates.x, Input + RangeInInputsCoordinates.x);
-            return;
-        }
-        size_t elementNum = RangeDimensions[0];
-        vector_t i;
-        while (true) {
-            size_t iptIdx = CoordinatesToIndex<size_t, uint32_t, _VectorLength, true>(InputDimensions, RangeInInputsCoordinates + i);
-            size_t optIdx = CoordinatesToIndex<size_t, uint32_t, _VectorLength, true>(OutputDimensions, RangeInOutputsCoordinates + i);
-
-            const _T* iptPtr = Input + iptIdx;
-            _T* optPtr = Output + optIdx;
-
-            for (_T* ipu = iptPtr + elementNum; iptPtr < ipu; ++iptPtr, ++optPtr)
-                _CopyValFunc(optPtr, iptPtr);
-
-            bool toBreak = true;
-            for (size_t j = 1; j < _VectorLength; ++j) {
-                uint32_t& si = i[j];
-                if (++si >= RangeDimensions[j]) si = 0;
-                else {
-                    toBreak = false;
-                    break;
-                }
-            }
-            if (toBreak) break;
-        }
-    }
-}
-
-template <typename _T, size_t _VectorLength, bcuda::copyArrFunc_t<_T> _CopyArrFunc, bool _Wrap>
-__host__ __device__ void bcuda::CopyBlock(const _T* Input, _T* Output, const FixedVector<uint32_t, _VectorLength>& InputDimensions, const FixedVector<uint32_t, _VectorLength>& OutputDimensions, const FixedVector<uint32_t, _VectorLength>& RangeDimensions, const FixedVector<uint32_t, _VectorLength>& RangeInInputsCoordinates, const FixedVector<uint32_t, _VectorLength>& RangeInOutputsCoordinates) {
-    using vector_t = FixedVector<uint32_t, _VectorLength>;
-
-    if constexpr (_Wrap) {
-        ArrayV<details::Landmark> landmarksArray[_VectorLength];
-        for (size_t i = 0; i < _VectorLength; ++i)
-            new (landmarksArray + i) ArrayV<details::Landmark>(details::GetLandmarksInDirection(InputDimensions[i], OutputDimensions[i], RangeDimensions[i], RangeInInputsCoordinates[i], RangeInOutputsCoordinates[i]));
-
-        vector_t i;
-        while (true) {
-            vector_t rangeDimensions;
-            vector_t rangeInInputCoordinates;
-            vector_t rangeInOutputCoordinates;
-            for (size_t j = 0; j < _VectorLength; ++j) {
-                details::Landmark landmark = landmarksArray[j][i[j]];
-                rangeDimensions[j] = landmark.size;
-                rangeInInputCoordinates[j] = landmark.inputIndex;
-                rangeInOutputCoordinates[j] = landmark.outputIndex;
-            }
-
-            CopyBlock<_T, _VectorLength, _CopyArrFunc, false>(Input, Output, InputDimensions, OutputDimensions, rangeDimensions, rangeInInputCoordinates, rangeInOutputCoordinates);
-
-            bool toBreak = true;
-            for (size_t j = 0; j < _VectorLength; ++j) {
-                uint32_t& si = i[j];
-                if (++si >= landmarksArray[j].Size()) si = 0;
-                else {
-                    toBreak = false;
-                    break;
-                }
-            }
-            if (toBreak) break;
-        }
-    }
-    else {
-        if constexpr (_VectorLength == 1) {
-            _CopyArrFunc(Output + RangeInOutputsCoordinates.x, Input + RangeInInputsCoordinates.x, RangeDimensions.x);
-            return;
-        }
-        size_t elementNum = RangeDimensions[0];
-        vector_t i;
-        while (true) {
-            size_t iptIdx = CoordinatesToIndex<size_t, uint32_t, _VectorLength, true>(InputDimensions, RangeInInputsCoordinates + i);
-            size_t optIdx = CoordinatesToIndex<size_t, uint32_t, _VectorLength, true>(OutputDimensions, RangeInOutputsCoordinates + i);
-
-            _CopyArrFunc(Output + optIdx, Input + iptIdx, elementNum);
-
-            bool toBreak = true;
-            for (size_t j = 1; j < _VectorLength; ++j) {
-                uint32_t& si = i[j];
-                if (++si >= RangeDimensions[j]) si = 0;
-                else {
-                    toBreak = false;
-                    break;
-                }
-            }
-            if (toBreak) break;
         }
     }
 }

--- a/copyblock.h
+++ b/copyblock.h
@@ -12,12 +12,10 @@ namespace bcuda {
             uint32_t inputIndex;
             uint32_t outputIndex;
             uint32_t size;
-            Landmark() = default;
-            __host__ __device__ Landmark(uint32_t InputIndex, uint32_t OutputIndex, uint32_t Size) {
-                inputIndex = InputIndex;
-                outputIndex = OutputIndex;
-                size = Size;
-            }
+            __host__ __device__ inline constexpr Landmark()
+                : inputIndex(0), outputIndex(0), size(0) { }
+            __host__ __device__ inline constexpr Landmark(uint32_t InputIndex, uint32_t OutputIndex, uint32_t Size)
+                : inputIndex(InputIndex), outputIndex(OutputIndex), size(Size) { }
         };
 
         __host__ __device__ ArrayV<Landmark> GetLandmarksInDirection(uint32_t InputLength, uint32_t OutputLength, uint32_t RangeLength, uint32_t InputIndex, uint32_t OutputIndex);

--- a/copyptr.h
+++ b/copyptr.h
@@ -48,11 +48,11 @@ namespace bcuda {
     };
 
     template <typename _T>
-    CopyPtr<_T> MakeCopyPtr() requires std::is_default_constructible_v<_T> {
+    static inline CopyPtr<_T> MakeCopyPtr() requires std::is_default_constructible_v<_T> {
         return CopyPtr<_T>(new _T());
     }
     template <typename _T>
-    CopyPtr<_T> MakeCopyPtr(_T Val) {
+    static inline CopyPtr<_T> MakeCopyPtr(_T Val) {
         return CopyPtr<_T>(new _T(Val));
     }
 }

--- a/copyptr.h
+++ b/copyptr.h
@@ -11,38 +11,38 @@ namespace bcuda {
         using element_t = _T;
         static constexpr bool copyable = std::copy_constructible<_T>;
 
-        __forceinline explicit CopyPtr(std::unique_ptr<_T> UniPtr)
+        inline explicit CopyPtr(std::unique_ptr<_T> UniPtr)
             : ptr(std::move(UniPtr)) { }
-        __forceinline CopyPtr(const CopyPtr<_T>& Other) requires copyable
+        inline CopyPtr(const CopyPtr<_T>& Other) requires copyable
             : ptr(Other.ptr ? std::make_unique<_T>(*Other.ptr) : std::unique_ptr<_T>(nullptr)) { }
-        __forceinline CopyPtr(CopyPtr<_T>&& Other)
+        inline CopyPtr(CopyPtr<_T>&& Other)
             : ptr(std::move(Other.ptr)) { }
-        __forceinline explicit CopyPtr(element_t* Val)
+        inline explicit CopyPtr(element_t* Val)
             : ptr(Val) { }
-        __forceinline explicit CopyPtr(std::nullptr_t = nullptr)
+        inline explicit CopyPtr(std::nullptr_t = nullptr)
             : ptr(nullptr) { }
 
-        __forceinline CopyPtr<_T>& operator=(CopyPtr<_T> Other) {
+        inline CopyPtr<_T>& operator=(CopyPtr<_T> Other) {
             std::swap(ptr, Other.ptr);
             return *this;
         }
 
-        __forceinline _T* Get() const {
+        inline _T* Get() const {
             return (_T*)ptr.get();
         }
 
-        __forceinline operator _T*() const {
+        inline operator _T*() const {
             return Get();
         }
-        __forceinline _T* operator->() const {
+        inline _T* operator->() const {
             return Get();
         }
 
-        __forceinline _T* Release() {
+        inline _T* Release() {
             return (_T*)ptr.release();
         }
 
-        __forceinline void Reset(_T* newPtr = 0) {
+        inline void Reset(_T* newPtr = 0) {
             ptr.reset(newPtr);
         }
     };

--- a/copytype.h
+++ b/copytype.h
@@ -32,7 +32,7 @@ namespace bcuda {
     }
 #endif
     template <bool _DestOnHost, bool _SourceOnHost, typename _T>
-    __host__ static __forceinline void CopyArrFunc_Memcpy(_T* DestPtr, _T* SourcePtr, size_t Count) {
+    __host__ static inline void CopyArrFunc_Memcpy(_T* DestPtr, _T* SourcePtr, size_t Count) {
         if constexpr (_DestOnHost)
             if constexpr (_SourceOnHost) memcpy(DestPtr, SourcePtr, Count * sizeof(_T));
             else cudaMemcpy(DestPtr, SourcePtr, Count * sizeof(_T), cudaMemcpyDeviceToHost);

--- a/copytype.h
+++ b/copytype.h
@@ -17,7 +17,7 @@ namespace bcuda {
     using copyArrFunc_t = void(*)(_T* DestPtr, _T* SourcePtr, size_t Count);
 
     template <bool _DestOnHost, bool _SourceOnHost, typename _T>
-    __host__ void CopyFunc_Memcpy(_T* DestPtr, _T* SourcePtr) {
+    __host__ static inline void CopyFunc_Memcpy(_T* DestPtr, _T* SourcePtr) {
         if constexpr (_DestOnHost)
             if constexpr (_SourceOnHost) memcpy(DestPtr, SourcePtr, sizeof(_T));
             else cudaMemcpy(DestPtr, SourcePtr, sizeof(_T), cudaMemcpyDeviceToHost);
@@ -27,7 +27,7 @@ namespace bcuda {
     }
 #ifdef __CUDACC__
     template <typename _T>
-    __device__ void CopyFunc_Memcpy(_T* DestPtr, _T* SourcePtr) {
+    __device__ static inline void CopyFunc_Memcpy(_T* DestPtr, _T* SourcePtr) {
         memcpy(DestPtr, SourcePtr, sizeof(_T));
     }
 #endif
@@ -42,47 +42,47 @@ namespace bcuda {
     }
 #ifdef __CUDACC__
     template <typename _T>
-    __device__ void CopyArrFunc_Memcpy(_T* DestPtr, _T* SourcePtr, size_t Count) {
+    __device__ static inline void CopyArrFunc_Memcpy(_T* DestPtr, _T* SourcePtr, size_t Count) {
         memcpy(DestPtr, SourcePtr, Count * sizeof(_T));
     }
 #endif
 
     template <typename _T>
-    __host__ __device__ void CopyFunc_CopyAssignment(_T* DestPtr, _T* SourcePtr) {
+    __host__ __device__ static inline void CopyFunc_CopyAssignment(_T* DestPtr, _T* SourcePtr) {
         *DestPtr = *SourcePtr;
     }
     template <typename _T>
-    __host__ __device__ void CopyArrFunc_CopyAssignment(_T* DestPtr, _T* SourcePtr, size_t Count) {
+    __host__ __device__ static inline void CopyArrFunc_CopyAssignment(_T* DestPtr, _T* SourcePtr, size_t Count) {
         for (_T* spu = SourcePtr + Count; SourcePtr < spu; ++DestPtr, ++SourcePtr)
             *DestPtr = *SourcePtr;
     }
 
     template <typename _T>
-    __host__ __device__ void CopyFunc_CopyPlacementNew(_T* DestPtr, _T* SourcePtr) {
+    __host__ __device__ static inline void CopyFunc_CopyPlacementNew(_T* DestPtr, _T* SourcePtr) {
         new (DestPtr) _T(*SourcePtr);
     }
     template <typename _T>
-    __host__ __device__ void CopyArrFunc_CopyPlacementNew(_T* DestPtr, _T* SourcePtr, size_t Count) {
+    __host__ __device__ static inline void CopyArrFunc_CopyPlacementNew(_T* DestPtr, _T* SourcePtr, size_t Count) {
         for (_T* spu = SourcePtr + Count; SourcePtr < spu; ++DestPtr, ++SourcePtr)
             new (DestPtr) _T(*SourcePtr);
     }
 
     template <typename _T>
-    __host__ __device__ void CopyFunc_MoveAssignment(_T* DestPtr, _T* SourcePtr) {
+    __host__ __device__ static inline void CopyFunc_MoveAssignment(_T* DestPtr, _T* SourcePtr) {
         *DestPtr = std::move(*SourcePtr);
     }
     template <typename _T>
-    __host__ __device__ void CopyArrFunc_MoveAssignment(_T* DestPtr, _T* SourcePtr, size_t Count) {
+    __host__ __device__ static inline void CopyArrFunc_MoveAssignment(_T* DestPtr, _T* SourcePtr, size_t Count) {
         for (_T* spu = SourcePtr + Count; SourcePtr < spu; ++DestPtr, ++SourcePtr)
             *DestPtr = std::move(*SourcePtr);
     }
 
     template <typename _T>
-    __host__ __device__ void CopyFunc_MovePlacementNew(_T* DestPtr, _T* SourcePtr) {
+    __host__ __device__ static inline void CopyFunc_MovePlacementNew(_T* DestPtr, _T* SourcePtr) {
         new (DestPtr) _T(std::move(*SourcePtr));
     }
     template <typename _T>
-    __host__ __device__ void CopyArrFunc_MovePlacementNew(_T* DestPtr, _T* SourcePtr, size_t Count) {
+    __host__ __device__ static inline void CopyArrFunc_MovePlacementNew(_T* DestPtr, _T* SourcePtr, size_t Count) {
         for (_T* spu = SourcePtr + Count; SourcePtr < spu; ++DestPtr, ++SourcePtr)
             new (DestPtr) _T(std::move(*SourcePtr));
     }

--- a/crossassigns.h
+++ b/crossassigns.h
@@ -5,13 +5,13 @@
 
 namespace bcuda {
     template <typename _T>
-    _T GetVR(_T* DevicePointer) {
+    static inline _T GetVR(_T* DevicePointer) {
         _T v;
         ThrowIfBad(cudaMemcpy(&v, DevicePointer, sizeof(_T), cudaMemcpyDeviceToHost));
         return v;
     }
     template <typename _T>
-    void SetVR(_T* DevicePointer, _T Value) {
+    static inline void SetVR(_T* DevicePointer, _T Value) {
         ThrowIfBad(cudaMemcpy(DevicePointer, &Value, sizeof(_T), cudaMemcpyHostToDevice));
     }
 }

--- a/crossassigns.h
+++ b/crossassigns.h
@@ -5,19 +5,13 @@
 
 namespace bcuda {
     template <typename _T>
-    _T GetVR(_T* DevicePointer);
+    _T GetVR(_T* DevicePointer) {
+        _T v;
+        ThrowIfBad(cudaMemcpy(&v, DevicePointer, sizeof(_T), cudaMemcpyDeviceToHost));
+        return v;
+    }
     template <typename _T>
-    void SetVR(_T* DevicePointer, _T Value);
-}
-
-template <typename _T>
-_T bcuda::GetVR(_T* DevicePointer) {
-    _T v;
-    ThrowIfBad(cudaMemcpy(&v, DevicePointer, sizeof(_T), cudaMemcpyDeviceToHost));
-    return v;
-}
-
-template <typename _T>
-void bcuda::SetVR(_T* DevicePointer, _T Value) {
-    ThrowIfBad(cudaMemcpy(DevicePointer, &Value, sizeof(_T), cudaMemcpyHostToDevice));
+    void SetVR(_T* DevicePointer, _T Value) {
+        ThrowIfBad(cudaMemcpy(DevicePointer, &Value, sizeof(_T), cudaMemcpyHostToDevice));
+    }
 }

--- a/details_dfieldbase.h
+++ b/details_dfieldbase.h
@@ -43,22 +43,22 @@ namespace bcuda {
             __host__ __device__ fields::FieldProxy<_T, _DimensionCount> F() const {
                 return fields::FieldProxy<_T, _DimensionCount>(this->Dimensions(), darrF);
             }
-            __host__ __device__ fields::FieldProxy<_T, _DimensionCount> B() const {
+            __host__ __device__ inline fields::FieldProxy<_T, _DimensionCount> B() const {
                 return fields::FieldProxy<_T, _DimensionCount>(this->Dimensions(), darrB);
             }
-            __host__ __device__ fields::FieldProxyConst<_T, _DimensionCount> FConst() const {
+            __host__ __device__ inline fields::FieldProxyConst<_T, _DimensionCount> FConst() const {
                 return fields::FieldProxyConst<_T, _DimensionCount>(this->Dimensions(), darrF);
             }
-            __host__ __device__ fields::FieldProxyConst<_T, _DimensionCount> BConst() const {
+            __host__ __device__ inline fields::FieldProxyConst<_T, _DimensionCount> BConst() const {
                 return fields::FieldProxyConst<_T, _DimensionCount>(this->Dimensions(), darrB);
             }
-            __host__ __device__ _T* FData() const {
+            __host__ __device__ inline _T* FData() const {
                 return darrF;
             }
-            __host__ __device__ _T* BData() const {
+            __host__ __device__ inline _T* BData() const {
                 return darrB;
             }
-            __host__ __device__ void Reverse() {
+            __host__ __device__ inline void Reverse() {
                 std::swap(darrF, darrB);
             }
 #pragma endregion
@@ -179,7 +179,7 @@ namespace bcuda {
             }
 #endif
 
-            __host__ __device__ this_t Clone() const {
+            __host__ __device__ inline this_t Clone() const {
                 this_t clone(this->Dimensions());
                 clone.F().CpyAllIn<false>(FData());
                 return clone;

--- a/details_dfieldbase.h
+++ b/details_dfieldbase.h
@@ -9,7 +9,7 @@ namespace bcuda {
             using this_t = DFieldBase<_T, _DimensionCount>;
             using basedb_t = DimensionedBase<_DimensionCount>;
         public:
-            __host__ __device__ __forceinline DFieldBase(const typename this_t::vector_t& Dimensions)
+            __host__ __device__ inline DFieldBase(const typename this_t::vector_t& Dimensions)
                 : basedb_t(Dimensions) {
                 if (!this->Length(0)) {
                     darrF = 0;
@@ -26,16 +26,16 @@ namespace bcuda {
             }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __host__ __device__ __forceinline DFieldBase(_Ts... Dimensions)
+            __host__ __device__ inline DFieldBase(_Ts... Dimensions)
                 : DFieldBase(typename this_t::vector_t(Dimensions...)) { }
-            __host__ __device__ __forceinline DFieldBase(const typename this_t::vector_t& Dimensions, _T* ArrF, _T* ArrB)
+            __host__ __device__ inline DFieldBase(const typename this_t::vector_t& Dimensions, _T* ArrF, _T* ArrB)
                 : basedb_t(Dimensions), darrF(ArrF), darrB(ArrB) { }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __host__ __device__ __forceinline DFieldBase(_Ts... Dimensions, _T* ArrF, _T* ArrB)
+            __host__ __device__ inline DFieldBase(_Ts... Dimensions, _T* ArrF, _T* ArrB)
                 : DFieldBase(typename this_t::vector_t(Dimensions...), ArrF, ArrB) { }
 
-            __host__ __device__ __forceinline size_t SizeOnGPU() const {
+            __host__ __device__ inline size_t SizeOnGPU() const {
                 return basedb_t::ValueCount() * sizeof(_T);
             }
 
@@ -63,7 +63,7 @@ namespace bcuda {
             }
 #pragma endregion
 
-            __host__ __device__ __forceinline void Dispose() {
+            __host__ __device__ inline void Dispose() {
 #ifdef __CUDA_ARCH__
                 free(darrF);
                 free(darrB);
@@ -75,106 +75,106 @@ namespace bcuda {
 
 #pragma region CpyAll
             template <bool _CopyFromHost>
-            __host__ __forceinline void CpyAllIn(const _T* All) const {
+            __host__ inline void CpyAllIn(const _T* All) const {
                 B().CpyAllIn<_CopyFromHost>(All);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyAllIn(const _T* All) const {
+            __device__ inline void CpyAllIn(const _T* All) const {
                 B().CpyAllIn(All);
             }
 #endif
             template <bool _CopyToHost>
-            __host__ __forceinline _T* CpyAllOut() const {
+            __host__ inline _T* CpyAllOut() const {
                 return F().CpyAllOut<_CopyToHost>();
             }
 #ifdef __CUDACC__
-            __device__ __forceinline _T* CpyAllOut() const {
+            __device__ inline _T* CpyAllOut() const {
                 return F().CpyAllOut();
             }
 #endif
             template <bool _CopyToHost>
-            __host__ __device__ __forceinline void CpyAllOut(_T* All) const {
+            __host__ __device__ inline void CpyAllOut(_T* All) const {
                 F().CpyAllOut<_CopyToHost>(All);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyAllOut(_T* All) const {
+            __device__ inline void CpyAllOut(_T* All) const {
                 F().CpyAllOut(All);
             }
 #endif
 #pragma endregion
 
 #pragma region CpyVal
-            __host__ __device__ __forceinline void CpyValIn(uint64_t Idx, const _T& Val) const {
+            __host__ __device__ inline void CpyValIn(uint64_t Idx, const _T& Val) const {
                 B().CpyValIn(Idx, Val);
             }
-            __host__ __device__ __forceinline void CpyValIn(const typename this_t::vector_t& Coords, const _T& Val) const {
+            __host__ __device__ inline void CpyValIn(const typename this_t::vector_t& Coords, const _T& Val) const {
                 B().CpyValIn(Coords, Val);
             }
             template <bool _CopyFromHost>
-            __host__ __forceinline void CpyValIn(uint64_t Idx, const _T* Val) const {
+            __host__ inline void CpyValIn(uint64_t Idx, const _T* Val) const {
                 B().CpyValIn<_CopyFromHost>(Idx, Val);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyValIn(uint64_t Idx, const _T* Val) {
+            __device__ inline void CpyValIn(uint64_t Idx, const _T* Val) {
                 B().CpyValIn(Idx, Val);
             }
 #endif
             template <bool _CopyFromHost>
-            __host__ __forceinline void CpyValIn(const typename this_t::vector_t& Coords, const _T* Val) const {
+            __host__ inline void CpyValIn(const typename this_t::vector_t& Coords, const _T* Val) const {
                 B().CpyValIn<_CopyFromHost>(Coords, Val);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyValIn(const typename this_t::vector_t& Coords, const _T* Val) const {
+            __device__ inline void CpyValIn(const typename this_t::vector_t& Coords, const _T* Val) const {
                 B().CpyValIn(Coords, Val);
             }
 #endif
-            __host__ __device__ __forceinline void CpyValOut(uint64_t Idx, _T& Val) const {
+            __host__ __device__ inline void CpyValOut(uint64_t Idx, _T& Val) const {
                 F().CpyValOut(Idx, Val);
             }
-            __host__ __device__ __forceinline void CpyValOut(const typename this_t::vector_t& Coords, _T& Val) const {
+            __host__ __device__ inline void CpyValOut(const typename this_t::vector_t& Coords, _T& Val) const {
                 F().CpyValOut(Coords, Val);
             }
             template <bool _CopyToHost>
-            __host__ __forceinline void CpyValOut(uint64_t Idx, _T* Val) const {
+            __host__ inline void CpyValOut(uint64_t Idx, _T* Val) const {
                 F().CpyValOut<_CopyToHost>(Idx, Val);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyValOut(uint64_t Idx, _T* Val) const {
+            __device__ inline void CpyValOut(uint64_t Idx, _T* Val) const {
                 F().CpyValOut(Idx, Val);
             }
 #endif
             template <bool _CopyToHost>
-            __host__ __forceinline void CpyValOut(const typename this_t::vector_t& Coords, _T* Val) const {
+            __host__ inline void CpyValOut(const typename this_t::vector_t& Coords, _T* Val) const {
                 F().CpyValOut<_CopyToHost>(Coords, Val);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyValOut(const typename this_t::vector_t& Coords, _T* Val) const {
+            __device__ inline void CpyValOut(const typename this_t::vector_t& Coords, _T* Val) const {
                 F().CpyValOut(Coords, Val);
             }
 #endif
-            __host__ __device__ __forceinline _T CpyValOut(uint64_t Idx) const {
+            __host__ __device__ inline _T CpyValOut(uint64_t Idx) const {
                 F().CpyValOut(Idx);
             }
-            __host__ __device__ __forceinline _T CpyValOut(const typename this_t::vector_t& Coords) const {
+            __host__ __device__ inline _T CpyValOut(const typename this_t::vector_t& Coords) const {
                 F().CpyValOut(Coords);
             }
 #pragma endregion
 
             template <bool _InputOnHost>
-            __host__ __forceinline void CopyBlockIn(const _T* Input, const typename this_t::vector_t& InputDimensions, const typename this_t::vector_t& RangeDimensions, const typename this_t::vector_t& RangeInInputsCoordinates, const typename this_t::vector_t& RangeInOutputsCoordinates) const {
+            __host__ inline void CopyBlockIn(const _T* Input, const typename this_t::vector_t& InputDimensions, const typename this_t::vector_t& RangeDimensions, const typename this_t::vector_t& RangeInInputsCoordinates, const typename this_t::vector_t& RangeInOutputsCoordinates) const {
                 B().CopyBlockIn<_InputOnHost>(Input, InputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CopyBlockIn(const _T* Input, const typename this_t::vector_t& InputDimensions, const typename this_t::vector_t& RangeDimensions, const typename this_t::vector_t& RangeInInputsCoordinates, const typename this_t::vector_t& RangeInOutputsCoordinates) const {
+            __device__ inline void CopyBlockIn(const _T* Input, const typename this_t::vector_t& InputDimensions, const typename this_t::vector_t& RangeDimensions, const typename this_t::vector_t& RangeInInputsCoordinates, const typename this_t::vector_t& RangeInOutputsCoordinates) const {
                 B().CopyBlockIn(Input, InputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #endif
             template <bool _OutputOnHost>
-            __host__ __forceinline void CopyBlockOut(_T* Output, const typename this_t::vector_t& OutputDimensions, const typename this_t::vector_t& RangeDimensions, const typename this_t::vector_t& RangeInInputsCoordinates, const typename this_t::vector_t& RangeInOutputsCoordinates) const {
+            __host__ inline void CopyBlockOut(_T* Output, const typename this_t::vector_t& OutputDimensions, const typename this_t::vector_t& RangeDimensions, const typename this_t::vector_t& RangeInInputsCoordinates, const typename this_t::vector_t& RangeInOutputsCoordinates) const {
                 F().CopyBlockOut<_OutputOnHost>(Output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CopyBlockOut(_T* Output, const typename this_t::vector_t& OutputDimensions, const typename this_t::vector_t& RangeDimensions, const typename this_t::vector_t& RangeInInputsCoordinates, const typename this_t::vector_t& RangeInOutputsCoordinates) const {
+            __device__ inline void CopyBlockOut(_T* Output, const typename this_t::vector_t& OutputDimensions, const typename this_t::vector_t& RangeDimensions, const typename this_t::vector_t& RangeInInputsCoordinates, const typename this_t::vector_t& RangeInOutputsCoordinates) const {
                 F().CopyBlockOut(Output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #endif
@@ -185,19 +185,19 @@ namespace bcuda {
                 return clone;
             }
 
-            __forceinline size_t SerializedSize() const requires BSerializer::Serializable<_T> {
+            inline size_t SerializedSize() const requires BSerializer::Serializable<_T> {
                 F().SerializedSize();
             }
-            __forceinline void Serialize(void*& Data) const requires BSerializer::Serializable<_T> {
+            inline void Serialize(void*& Data) const requires BSerializer::Serializable<_T> {
                 F().Serialize(Data);
             }
-            static __forceinline this_t Deserialize(const void*& Data) requires BSerializer::Serializable<_T> {
+            static inline this_t Deserialize(const void*& Data) requires BSerializer::Serializable<_T> {
                 FieldBase<_T, _DimensionCount> field = FieldBase<_T, _DimensionCount>::Deserialize(Data);
                 this_t value(field.Dimensions());
                 value.F().CpyAllIn<false>(field.Data());
                 return value;
             }
-            static __forceinline void Deserialize(const void*& Data, void* Value) requires BSerializer::Serializable<_T> {
+            static inline void Deserialize(const void*& Data, void* Value) requires BSerializer::Serializable<_T> {
                 new (Value) this_t(Deserialize(Data));
             }
         private:

--- a/details_fieldbase.h
+++ b/details_fieldbase.h
@@ -22,449 +22,246 @@ namespace bcuda {
             using basedb_t = DimensionedBase<_DimensionCount>;
         public:
 #pragma region Constructors
-            __host__ __device__ __forceinline FieldBase(const typename this_t::vector_t& Dimensions);
+            __host__ __device__ inline FieldBase(const typename this_t::vector_t& Dimensions)
+                : basedb_t(Dimensions) {
+                if (!(this->Length(0))) {
+                    darr = 0;
+                    return;
+                }
+#ifdef __CUDA_ARCH__
+                darr = (_T*)malloc(SizeOnGPU());
+#else
+                ThrowIfBad(cudaMalloc(&darr, SizeOnGPU()));
+#endif
+            }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __host__ __device__ __forceinline FieldBase(_Ts... Dimensions)
+            __host__ __device__ inline FieldBase(_Ts... Dimensions)
                 : FieldBase(typename this_t::vector_t(Dimensions...)) { }
-            __host__ __device__ __forceinline FieldBase(const typename this_t::vector_t& Dimensions, _T* Arr)
+            __host__ __device__ inline FieldBase(const typename this_t::vector_t& Dimensions, _T* Arr)
                 : basedb_t(Dimensions), darr(Arr) { }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __host__ __device__ __forceinline FieldBase(_Ts... Dimensions, _T* Arr)
+            __host__ __device__ inline FieldBase(_Ts... Dimensions, _T* Arr)
                 : FieldBase(typename this_t::vector_t(Dimensions...), Arr) { }
 #pragma endregion
 
-            __host__ __device__ __forceinline size_t SizeOnGPU() const {
+            __host__ __device__ inline size_t SizeOnGPU() const {
                 return sizeof(_T) * basedb_t::ValueCount();
             }
 
 #pragma region RefConversion
-            __host__ __device__ __forceinline _T* IdxToPtr(uint64_t Idx) const;
-            __device__ __forceinline _T& IdxToRef(uint64_t Idx) const;
-            __host__ __forceinline thrust::device_reference<_T> IdxToDRef(uint64_t Idx) const;
-            __host__ __device__ __forceinline _T* CoordsToPtr(const typename this_t::vector_t& Coords) const;
+            __host__ __device__ inline _T* IdxToPtr(uint64_t Idx) const {
+                return darr + Idx;
+            }
+            __host__ __device__ inline _T* CoordsToPtr(const typename this_t::vector_t& Coords) const {
+                return IdxToPtr(this->CoordsToIdx(Coords));
+            }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __host__ __device__ __forceinline _T* CoordsToPtr(_Ts... Coords) const {
+            __host__ __device__ inline _T* CoordsToPtr(_Ts... Coords) const {
                 return CoordsToPtr(typename this_t::vector_t(Coords...));
             }
-            __host__ __device__ __forceinline _T& CoordsToRef(const typename this_t::vector_t& Coords) const;
-            __host__ __device__ __forceinline thrust::device_reference<_T> CoordsToDRef(const typename this_t::vector_t& Coords) const;
-            template <std::convertible_to<uint32_t>... _Ts>
-                requires (sizeof...(_Ts) == _DimensionCount)
-            __device__ __forceinline _T& CoordsToRef(_Ts... Coords) const {
-                return CoordsToRef(typename this_t::vector_t(Coords...));
+            __host__ __device__ inline uint64_t PtrToIdx(const _T* Ptr) const {
+                return Ptr - darr;
             }
-            template <std::convertible_to<uint32_t>... _Ts>
-                requires (sizeof...(_Ts) == _DimensionCount)
-            __host__ __forceinline thrust::device_reference<_T> CoordsToDRef(_Ts... Coords) const {
-                return CoordsToRef(typename this_t::vector_t(Coords...));
+            __host__ __device__ inline typename this_t::vector_t PtrToCoords(const _T* Ptr) const {
+                return this->IdxToCoords(PtrToIdx(Ptr));
             }
-            __host__ __device__ __forceinline uint64_t PtrToIdx(const _T* Ptr) const;
-            __host__ __device__ __forceinline this_t::vector_t PtrToCoords(const _T* Ptr) const;
-            __device__ __forceinline _T& PtrToRef(const _T* Ptr) const;
-            __host__ __forceinline thrust::device_reference<_T> PtrToDRef(const _T* Ptr) const;
-            __device__ __forceinline _T& PtrToRef(const _T* Ptr);
-            __host__ __forceinline thrust::device_reference<_T> PtrToDRef(const _T* Ptr);
-            __host__ __forceinline uint64_t DRefToIdx(thrust::device_reference<_T> Ref) const;
-            __host__ __forceinline uint64_t DRefToIdx(thrust::device_reference<const _T> Ref) const;
-#ifdef __CUDACC__
-            __device__ __forceinline uint64_t RefToIdx(const _T& Ref) const;
-#endif
-            __host__ __forceinline typename this_t::vector_t DRefToCoords(thrust::device_reference<_T> Ref) const;
-            __host__ __forceinline typename this_t::vector_t DRefToCoords(thrust::device_reference<const _T> Ref) const;
-#ifdef __CUDACC__
-            __device__ __forceinline typename this_t::vector_t RefToCoords(const _T& Ref) const;
-#endif
-            __host__ __forceinline _T* DRefToPtr(thrust::device_reference<_T> Ref) const;
-            __host__ __forceinline _T* DRefToPtr(thrust::device_reference<const _T> Ref) const;
-#ifdef __CUDACC__
-            __device__ __forceinline _T* RefToPtr(const _T& Ref) const;
-#endif
 #pragma endregion
 
 #pragma region OperatorInvoke
-            __device__ __forceinline _T& operator()(uint64_t Idx) const;
-            __device__ __forceinline _T& operator()(const typename this_t::vector_t& Coords) const;
+            __device__ inline _T& operator()(uint64_t Idx) const {
+                return *IdxToPtr(Idx);
+            }
+            __device__ inline _T& operator()(const typename this_t::vector_t& Coords) const {
+                return *CoordsToPtr(Coords);
+            }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __device__ __forceinline _T& operator()(_Ts... Coords) const {
-                return CoordsToRef(typename this_t::vector_t(Coords...));
+            __device__ inline _T& operator()(_Ts... Coords) const {
+                return *CoordsToPtr(typename this_t::vector_t(Coords...));
             }
 #pragma endregion
 
 #pragma region CpyAll
             template <bool _CopyFromHost>
-            __host__ __forceinline void CpyAllIn(const _T* All) const;
+            __host__ inline void CpyAllIn(const _T* All) const {
+                ThrowIfBad(cudaMemcpy(darr, All, SizeOnGPU(), _CopyFromHost ? cudaMemcpyHostToDevice : cudaMemcpyDeviceToDevice));
+            }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyAllIn(const _T* All) const;
+            __device__ inline void CpyAllIn(const _T* All) const {
+                memcpy(darr, All, SizeOnGPU());
+            }
 #endif
             template <bool _CopyToHost>
-            __host__ __forceinline _T* CpyAllOut() const;
+            __host__ inline _T* CpyAllOut() const {
+                _T* all;
+                if constexpr (_CopyToHost) ThrowIfBad(cudaMalloc(&all, SizeOnGPU()));
+                else malloc(all);
+
+                CpyAllOut<_CopyToHost>(all);
+
+                return all;
+            }
 #ifdef __CUDACC__
-            __device__ __forceinline _T* CpyAllOut() const;
+            __device__ inline _T* CpyAllOut() const {
+                _T* all = malloc(SizeOnGPU());
+
+                CpyAllOut(all);
+
+                return all;
+            }
 #endif
             template <bool _CopyToHost>
-            __host__ __device__ __forceinline void CpyAllOut(_T* All) const;
+            __host__ __device__ inline void CpyAllOut(_T* All) const {
+                ThrowIfBad(cudaMemcpy(All, darr, SizeOnGPU(), _CopyToHost ? cudaMemcpyDeviceToHost : cudaMemcpyDeviceToDevice));
+            }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyAllOut(_T* All) const;
+            __device__ inline void CpyAllOut(_T* All) const {
+                memcpy(All, darr, SizeOnGPU());
+            }
 #endif
 #pragma endregion
 
 #pragma region CpyVal
-            __host__ __device__ __forceinline void CpyValIn(uint64_t Idx, const _T& Val) const;
-            __host__ __device__ __forceinline void CpyValIn(const typename this_t::vector_t& Coords, const _T& Val) const;
+            __host__ __device__ inline void CpyValIn(uint64_t Idx, const _T& Val) const {
+#ifdef __CUDA_ARCH__
+                memcpy(IdxToPtr(Idx), &Val, sizeof(_T));
+#else
+                ThrowIfBad(cudaMemcpy(IdxToPtr(Idx), &Val, sizeof(_T), cudaMemcpyHostToDevice));
+#endif
+            }
+            __host__ __device__ inline void CpyValIn(const typename this_t::vector_t& Coords, const _T& Val) const {
+#ifdef __CUDA_ARCH__
+                memcpy(CoordsToPtr(Coords), &Val, sizeof(_T));
+#else
+                ThrowIfBad(cudaMemcpy(CoordsToPtr(Coords), &Val, sizeof(_T), cudaMemcpyHostToDevice));
+#endif
+            }
             template <bool _CopyFromHost>
-            __host__ __forceinline void CpyValIn(uint64_t Idx, const _T* Val) const;
+            __host__ inline void CpyValIn(uint64_t Idx, const _T* Val) const {
+                ThrowIfBad(cudaMemcpy(IdxToPtr(Idx), Val, sizeof(_T), _CopyFromHost ? cudaMemcpyHostToDevice : cudaMemcpyDeviceToDevice));
+            }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyValIn(uint64_t Idx, const _T* Val) const;
+            __device__ inline void CpyValIn(uint64_t Idx, const _T* Val) const {
+                memcpy(IdxToPtr(Idx), Val, sizeof(_T));
+            }
 #endif
             template <bool _CopyFromHost>
-            __host__ __forceinline void CpyValIn(const typename this_t::vector_t& Coords, const _T* Val) const;
+            __host__ inline void CpyValIn(const typename this_t::vector_t& Coords, const _T* Val) const {
+                ThrowIfBad(cudaMemcpy(CoordsToPtr(Coords), Val, sizeof(_T), _CopyFromHost ? cudaMemcpyHostToDevice : cudaMemcpyDeviceToDevice));
+            }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyValIn(const typename this_t::vector_t& Coords, const _T* Val) const;
+            __device__ inline void CpyValIn(const typename this_t::vector_t& Coords, const _T* Val) const {
+                memcpy(CoordsToPtr(Coords), &Val, sizeof(_T));
+            }
 #endif
-            __host__ __device__ __forceinline void CpyValOut(uint64_t Idx, _T& Val) const;
-            __host__ __device__ __forceinline void CpyValOut(const typename this_t::vector_t& Coords, _T& Val) const;
+            __host__ __device__ inline void CpyValOut(uint64_t Idx, _T& Val) const {
+#ifdef __CUDA_ARCH__
+                memcpy(&Val, IdxToPtr(Idx), sizeof(_T));
+#else
+                ThrowIfBad(cudaMemcpy(&Val, IdxToPtr(Idx), sizeof(_T), cudaMemcpyDeviceToHost));
+#endif
+            }
+            __host__ __device__ inline void CpyValOut(const typename this_t::vector_t& Coords, _T& Val) const {
+#ifdef __CUDA_ARCH__
+                memcpy(&Val, CoordsToPtr(Coords), sizeof(_T));
+#else
+                ThrowIfBad(cudaMemcpy(&Val, CoordsToPtr(Coords), sizeof(_T), cudaMemcpyDeviceToHost));
+#endif
+            }
             template <bool _CopyToHost>
-            __host__ __forceinline void CpyValOut(uint64_t Idx, _T* Val) const;
+            __host__ inline void CpyValOut(uint64_t Idx, _T* Val) const {
+                ThrowIfBad(cudaMemcpy(Val, IdxToPtr(Idx), sizeof(_T), _CopyToHost ? cudaMemcpyDeviceToHost : cudaMemcpyDeviceToDevice));
+            }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyValOut(uint64_t Idx, _T* Val) const;
+            __device__ inline void CpyValOut(uint64_t Idx, _T* Val) const {
+                memcpy(Val, IdxToPtr(Idx), sizeof(_T));
+            }
 #endif
             template <bool _CopyToHost>
-            __host__ __forceinline void CpyValOut(const typename this_t::vector_t& Coords, _T* Val) const;
+            __host__ inline void CpyValOut(const typename this_t::vector_t& Coords, _T* Val) const {
+                ThrowIfBad(cudaMemcpy(Val, CoordsToPtr(Coords), sizeof(_T), _CopyToHost ? cudaMemcpyDeviceToHost : cudaMemcpyDeviceToDevice));
+            }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyValOut(const typename this_t::vector_t& Coords, _T* Val) const;
+            __device__ inline void CpyValOut(const typename this_t::vector_t& Coords, _T* Val) const {
+                memcpy(Val, CoordsToPtr(Coords), sizeof(_T));
+            }
 #endif
-            __host__ __device__ __forceinline _T CpyValOut(uint64_t Idx) const;
-            __host__ __device__ __forceinline _T CpyValOut(const typename this_t::vector_t& Coords) const;
+            __host__ __device__ inline _T CpyValOut(uint64_t Idx) const {
+                _T val;
+                CpyValOut(Idx, val);
+                return val;
+            }
+            __host__ __device__ inline _T CpyValOut(const typename this_t::vector_t& Coords) const {
+                _T val;
+                CpyValOut(Coords, val);
+                return val;
+            }
 #pragma endregion
 
-            __host__ __device__ __forceinline void Dispose();
+            __host__ __device__ inline void Dispose() {
+#ifdef __CUDA_ARCH__
+                free(darr);
+#else
+                ThrowIfBad(cudaFree(darr));
+#endif
+            }
 
-            __host__ __device__ __forceinline _T* Data() const;
+            __host__ __device__ inline _T* Data() const {
+                return darr;
+            }
 
             template <bool _InputOnHost>
-            __host__ __forceinline void CopyBlockIn(const _T* Input, const typename this_t::vector_t& InputDimensions, const typename this_t::vector_t& RangeDimensions, const typename this_t::vector_t& RangeInInputsCoordinates, const typename this_t::vector_t& RangeInOutputsCoordinates) const;
+            __host__ inline void CopyBlockIn(const _T* Input, const typename this_t::vector_t& InputDimensions, const typename this_t::vector_t& RangeDimensions, const typename this_t::vector_t& RangeInInputsCoordinates, const typename this_t::vector_t& RangeInOutputsCoordinates) const {
+                CopyBlock<_T, _DimensionCount, _InputOnHost, false, true>(Input, darr, InputDimensions, this->Dimensions(), RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
+            }
 #ifdef __CUDACC__
-            __device__ __forceinline void CopyBlockIn(const _T* Input, const typename this_t::vector_t& InputDimensions, const typename this_t::vector_t& RangeDimensions, const typename this_t::vector_t& RangeInInputsCoordinates, const typename this_t::vector_t& RangeInOutputsCoordinates) const;
+            __device__ inline void CopyBlockIn(const _T* Input, const typename this_t::vector_t& InputDimensions, const typename this_t::vector_t& RangeDimensions, const typename this_t::vector_t& RangeInInputsCoordinates, const typename this_t::vector_t& RangeInOutputsCoordinates) const {
+                CopyBlock<_T, _DimensionCount, true>(Input, darr, InputDimensions, this->Dimensions(), RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
+            }
 #endif
             template <bool _OutputOnHost>
-            __host__ __forceinline void CopyBlockOut(_T* Output, const typename this_t::vector_t& OutputDimensions, const typename this_t::vector_t& RangeDimensions, const typename this_t::vector_t& RangeInInputsCoordinates, const typename this_t::vector_t& RangeInOutputsCoordinates) const;
+            __host__ inline void CopyBlockOut(_T* Output, const typename this_t::vector_t& OutputDimensions, const typename this_t::vector_t& RangeDimensions, const typename this_t::vector_t& RangeInInputsCoordinates, const typename this_t::vector_t& RangeInOutputsCoordinates) const {
+                CopyBlock<_T, _DimensionCount, false, _OutputOnHost, true>(darr, Output, this->Dimensions(), OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
+            }
 #ifdef __CUDACC__
-            __device__ __forceinline void CopyBlockOut(_T* Output, const typename this_t::vector_t& OutputDimensions, const typename this_t::vector_t& RangeDimensions, const typename this_t::vector_t& RangeInInputsCoordinates, const typename this_t::vector_t& RangeInOutputsCoordinates) const;
+            __device__ inline void CopyBlockOut(_T* Output, const typename this_t::vector_t& OutputDimensions, const typename this_t::vector_t& RangeDimensions, const typename this_t::vector_t& RangeInInputsCoordinates, const typename this_t::vector_t& RangeInOutputsCoordinates) const {
+                CopyBlock<_T, _DimensionCount, true>(darr, Output, this->Dimensions(), OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
+            }
 #endif
             
-            __host__ __device__ this_t Clone() const;
+            __host__ __device__ inline this_t Clone() const {
+                return FieldBase<_T, _DimensionCount>(this->Dimensions(), darr);
+            }
 
-            __forceinline size_t SerializedSize() const requires BSerializer::Serializable<_T>;
-            __forceinline void Serialize(void*& Data) const requires BSerializer::Serializable<_T>;
-            static __forceinline this_t Deserialize(const void*& Data) requires BSerializer::Serializable<_T>;
-            static __forceinline void Deserialize(const void*& Data, void* Value) requires BSerializer::Serializable<_T>;
+            inline size_t SerializedSize() const requires BSerializer::Serializable<_T> {
+                size_t t = sizeof(uint32_t) * _DimensionCount;
+                size_t l = this->ValueCount();
+                for (size_t i = 0; i < l; ++i)
+                    t += BSerializer::SerializedSize(CpyValOut(i));
+                return t;
+            }
+            inline void Serialize(void*& Data) const requires BSerializer::Serializable<_T> {
+                BSerializer::Serialize<typename this_t::vector_t>(Data, this->Dimensions());
+                size_t l = this->ValueCount();
+                for (size_t i = 0; i < l; ++i)
+                    BSerializer::Serialize(Data, CpyValOut(i));
+            }
+            static inline this_t Deserialize(const void*& Data) requires BSerializer::Serializable<_T> {
+                typename this_t::vector_t dimensions = BSerializer::Deserialize<typename this_t::vector_t>(Data);
+                FieldBase<_T, _DimensionCount> field(dimensions);
+                size_t l = field.ValueCount();
+                for (size_t i = 0; i < l; ++i)
+                    field.CpyValIn(i, BSerializer::Deserialize<_T>(Data));
+                return field;
+            }
+            static inline void Deserialize(const void*& Data, void* Value) requires BSerializer::Serializable<_T> requires BSerializer::Serializable<_T> {
+                new (Value) FieldBase<_T, _DimensionCount>(Deserialize(Data));
+            }
         private:
             _T* darr;
         };
     }
-}
-
-template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline bcuda::details::FieldBase<_T, _DimensionCount>::FieldBase(const typename this_t::vector_t& Dimensions)
-    : basedb_t(Dimensions) {
-    if (!(this->Length(0))) {
-        darr = 0;
-        return;
-    }
-#ifdef __CUDA_ARCH__
-    darr = (_T*)malloc(SizeOnGPU());
-#else
-    ThrowIfBad(cudaMalloc(&darr, SizeOnGPU()));
-#endif
-}
-template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline _T* bcuda::details::FieldBase<_T, _DimensionCount>::IdxToPtr(uint64_t Idx) const {
-    return darr + Idx;
-}
-template <typename _T, size_t _DimensionCount>
-__device__ __forceinline _T& bcuda::details::FieldBase<_T, _DimensionCount>::IdxToRef(uint64_t Idx) const {
-    return darr[Idx];
-}
-template <typename _T, size_t _DimensionCount>
-__host__ __forceinline thrust::device_reference<_T> bcuda::details::FieldBase<_T, _DimensionCount>::IdxToDRef(uint64_t Idx) const {
-    return *thrust::device_ptr<_T>(darr + Idx);
-}
-template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline _T* bcuda::details::FieldBase<_T, _DimensionCount>::CoordsToPtr(const typename this_t::vector_t& Coords) const {
-    return IdxToPtr(this->CoordsToIdx(Coords));
-}
-template <typename _T, size_t _DimensionCount>
-__device__ __forceinline _T& bcuda::details::FieldBase<_T, _DimensionCount>::CoordsToRef(const typename this_t::vector_t& Coords) const {
-    return IdxToRef(this->CoordsToIdx(Coords));
-}
-template <typename _T, size_t _DimensionCount>
-__host__ __forceinline thrust::device_reference<_T> bcuda::details::FieldBase<_T, _DimensionCount>::CoordsToDRef(const typename this_t::vector_t& Coords) const {
-    return IdxToDRef(this->CoordsToIdx(Coords));
-}
-template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline uint64_t bcuda::details::FieldBase<_T, _DimensionCount>::PtrToIdx(const _T* Ptr) const {
-    return Ptr - darr;
-}
-template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline auto bcuda::details::FieldBase<_T, _DimensionCount>::PtrToCoords(const _T* Ptr) const -> typename this_t::vector_t {
-    return this->IdxToCoords(PtrToIdx(Ptr));
-}
-template <typename _T, size_t _DimensionCount>
-__device__ __forceinline _T& bcuda::details::FieldBase<_T, _DimensionCount>::PtrToRef(const _T* Ptr) const {
-    return *Ptr;
-}
-template <typename _T, size_t _DimensionCount>
-__host__ __forceinline thrust::device_reference<_T> bcuda::details::FieldBase<_T, _DimensionCount>::PtrToDRef(const _T* Ptr) const {
-    return *thrust::device_ptr<_T>(Ptr);
-}
-template <typename _T, size_t _DimensionCount>
-__host__ __forceinline uint64_t bcuda::details::FieldBase<_T, _DimensionCount>::DRefToIdx(thrust::device_reference<const _T> Ref) const {
-    return PtrToIdx(RefToPtr(Ref));
-}
-template <typename _T, size_t _DimensionCount>
-__host__ __forceinline uint64_t bcuda::details::FieldBase<_T, _DimensionCount>::DRefToIdx(thrust::device_reference<_T> Ref) const {
-    return PtrToIdx(RefToPtr(Ref));
-}
-#ifdef __CUDACC__
-template <typename _T, size_t _DimensionCount>
-__device__ __forceinline uint64_t bcuda::details::FieldBase<_T, _DimensionCount>::RefToIdx(const _T& Ref) const {
-    return PtrToIdx(RefToPtr(Ref));
-}
-#endif
-template <typename _T, size_t _DimensionCount>
-__host__ __forceinline auto bcuda::details::FieldBase<_T, _DimensionCount>::DRefToCoords(thrust::device_reference<_T> Ref) const -> typename this_t::vector_t {
-    return PtrToCoords(RefToPtr(Ref));
-}
-template <typename _T, size_t _DimensionCount>
-__host__ __forceinline auto bcuda::details::FieldBase<_T, _DimensionCount>::DRefToCoords(thrust::device_reference<const _T> Ref) const -> typename this_t::vector_t {
-    return PtrToCoords(RefToPtr(Ref));
-}
-#ifdef __CUDACC__
-template <typename _T, size_t _DimensionCount>
-__device__ __forceinline auto bcuda::details::FieldBase<_T, _DimensionCount>::RefToCoords(const _T& Ref) const -> typename this_t::vector_t {
-    return PtrToCoords(RefToPtr(Ref));
-}
-#endif
-template <typename _T, size_t _DimensionCount>
-__host__ __forceinline _T* bcuda::details::FieldBase<_T, _DimensionCount>::DRefToPtr(thrust::device_reference<_T> Ref) const {
-    return (&Ref).get();
-}
-template <typename _T, size_t _DimensionCount>
-__host__ __forceinline _T* bcuda::details::FieldBase<_T, _DimensionCount>::DRefToPtr(thrust::device_reference<const _T> Ref) const {
-    return (&Ref).get();
-}
-#ifdef __CUDACC__
-template <typename _T, size_t _DimensionCount>
-__device__ __forceinline _T* bcuda::details::FieldBase<_T, _DimensionCount>::RefToPtr(const _T& Ref) const {
-    return const_cast<_T*>(&Ref);
-}
-#endif
-template <typename _T, size_t _DimensionCount>
-__device__ __forceinline _T& bcuda::details::FieldBase<_T, _DimensionCount>::operator()(uint64_t Idx) const {
-    return IdxToRef(Idx);
-}
-template <typename _T, size_t _DimensionCount>
-__device__ __forceinline _T& bcuda::details::FieldBase<_T, _DimensionCount>::operator()(const typename this_t::vector_t& Coords) const {
-    return CoordsToRef(Coords);
-}
-template <typename _T, size_t _DimensionCount>
-template <bool _CopyFromHost>
-__host__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyAllIn(const _T* All) const {
-    cudaMemcpy(darr, All, SizeOnGPU(), _CopyFromHost ? cudaMemcpyHostToDevice : cudaMemcpyDeviceToDevice);
-}
-#ifdef __CUDACC__
-template <typename _T, size_t _DimensionCount>
-__device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyAllIn(const _T* All) const {
-    memcpy(darr, All, SizeOnGPU());
-}
-#endif
-template <typename _T, size_t _DimensionCount>
-template <bool _CopyToHost>
-__host__ __forceinline _T* bcuda::details::FieldBase<_T, _DimensionCount>::CpyAllOut() const {
-    _T* all;
-    if constexpr (_CopyToHost) cudaMalloc(&all, SizeOnGPU());
-    else malloc(all);
-
-    CpyAllOut<_CopyToHost>(all);
-
-    return all;
-}
-#ifdef __CUDACC__
-template <typename _T, size_t _DimensionCount>
-__device__ __forceinline _T* bcuda::details::FieldBase<_T, _DimensionCount>::CpyAllOut() const {
-    _T* all = malloc(SizeOnGPU());
-
-    CpyAllOut(all);
-
-    return all;
-}
-#endif
-template <typename _T, size_t _DimensionCount>
-template <bool _CopyToHost>
-__host__ __device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyAllOut(_T* All) const {
-    cudaMemcpy(All, darr, SizeOnGPU(), _CopyToHost ? cudaMemcpyDeviceToHost : cudaMemcpyDeviceToDevice);
-}
-#ifdef __CUDACC__
-template <typename _T, size_t _DimensionCount>
-__device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyAllOut(_T* All) const {
-    memcpy(All, darr, SizeOnGPU());
-}
-#endif
-template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValIn(uint64_t Idx, const _T& Val) const {
-#ifdef __CUDA_ARCH__
-    memcpy(IdxToPtr(Idx), &Val, sizeof(_T));
-#else
-    cudaMemcpy(IdxToPtr(Idx), &Val, sizeof(_T), cudaMemcpyHostToDevice);
-#endif
-}
-template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValIn(const typename this_t::vector_t& Coords, const _T& Val) const {
-#ifdef __CUDA_ARCH__
-    memcpy(CoordsToPtr(Coords), &Val, sizeof(_T));
-#else
-    cudaMemcpy(CoordsToPtr(Coords), &Val, sizeof(_T), cudaMemcpyHostToDevice);
-#endif
-}
-template <typename _T, size_t _DimensionCount>
-template <bool _CopyFromHost>
-__host__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValIn(uint64_t Idx, const _T* Val) const {
-    cudaMemcpy(IdxToPtr(Idx), Val, sizeof(_T), _CopyFromHost ? cudaMemcpyHostToDevice : cudaMemcpyDeviceToDevice);
-}
-#ifdef __CUDACC__
-template <typename _T, size_t _DimensionCount>
-__device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValIn(uint64_t Idx, const _T* Val) const {
-    memcpy(IdxToPtr(Idx), Val, sizeof(_T));
-}
-#endif
-template <typename _T, size_t _DimensionCount>
-template <bool _CopyFromHost>
-__host__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValIn(const typename this_t::vector_t& Coords, const _T* Val) const {
-    cudaMemcpy(CoordsToPtr(Coords), Val, sizeof(_T), _CopyFromHost ? cudaMemcpyHostToDevice : cudaMemcpyDeviceToDevice);
-}
-#ifdef __CUDACC__
-template <typename _T, size_t _DimensionCount>
-__device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValIn(const typename this_t::vector_t& Coords, const _T* Val) const {
-    memcpy(CoordsToPtr(Coords), &Val, sizeof(_T));
-}
-#endif
-template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(uint64_t Idx, _T& Val) const {
-#ifdef __CUDA_ARCH__
-    memcpy(&Val, IdxToPtr(Idx), sizeof(_T));
-#else
-    cudaMemcpy(&Val, IdxToPtr(Idx), sizeof(_T), cudaMemcpyDeviceToHost);
-#endif
-}
-template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(const typename this_t::vector_t& Coords, _T& Val) const {
-#ifdef __CUDA_ARCH__
-    memcpy(&Val, CoordsToPtr(Coords), sizeof(_T));
-#else
-    cudaMemcpy(&Val, CoordsToPtr(Coords), sizeof(_T), cudaMemcpyDeviceToHost);
-#endif
-}
-template <typename _T, size_t _DimensionCount>
-template <bool _CopyToHost>
-__host__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(uint64_t Idx, _T* Val) const {
-    cudaMemcpy(Val, IdxToPtr(Idx), sizeof(_T), _CopyToHost ? cudaMemcpyDeviceToHost : cudaMemcpyDeviceToDevice);
-}
-#ifdef __CUDACC__
-template <typename _T, size_t _DimensionCount>
-__device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(uint64_t Idx, _T* Val) const {
-    memcpy(Val, IdxToPtr(Idx), sizeof(_T));
-}
-#endif
-template <typename _T, size_t _DimensionCount>
-template <bool _CopyToHost>
-__host__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(const typename this_t::vector_t& Coords, _T* Val) const {
-    cudaMemcpy(Val, CoordsToPtr(Coords), sizeof(_T), _CopyToHost ? cudaMemcpyDeviceToHost : cudaMemcpyDeviceToDevice);
-}
-#ifdef __CUDACC__
-template <typename _T, size_t _DimensionCount>
-__device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(const typename this_t::vector_t& Coords, _T* Val) const {
-    memcpy(Val, CoordsToPtr(Coords), sizeof(_T));
-}
-#endif
-template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline _T bcuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(uint64_t Idx) const {
-    _T val;
-    CpyValOut(Idx, val);
-    return val;
-}
-template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline _T bcuda::details::FieldBase<_T, _DimensionCount>::CpyValOut(const typename this_t::vector_t& Coords) const {
-    _T val;
-    CpyValOut(Coords, val);
-    return val;
-}
-template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::Dispose() {
-#ifdef __CUDA_ARCH__
-    free(darr);
-#else
-    ThrowIfBad(cudaFree(darr));
-#endif
-}
-template <typename _T, size_t _DimensionCount>
-__host__ __device__ __forceinline _T* bcuda::details::FieldBase<_T, _DimensionCount>::Data() const {
-    return darr;
-}
-template <typename _T, size_t _DimensionCount>
-template <bool _InputOnHost>
-__host__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CopyBlockIn(const _T* Input, const typename this_t::vector_t& InputDimensions, const typename this_t::vector_t& RangeDimensions, const typename this_t::vector_t& RangeInInputsCoordinates, const typename this_t::vector_t& RangeInOutputsCoordinates) const {
-    CopyBlock<_T, _DimensionCount, _InputOnHost, false, true>(Input, darr, InputDimensions, this->Dimensions(), RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
-}
-#ifdef __CUDACC__
-template <typename _T, size_t _DimensionCount>
-__device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CopyBlockIn(const _T* Input, const typename this_t::vector_t& InputDimensions, const typename this_t::vector_t& RangeDimensions, const typename this_t::vector_t& RangeInInputsCoordinates, const typename this_t::vector_t& RangeInOutputsCoordinates) const {
-    CopyBlock<_T, _DimensionCount, true>(Input, darr, InputDimensions, this->Dimensions(), RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
-}
-#endif
-template <typename _T, size_t _DimensionCount>
-template <bool _OutputOnHost>
-__host__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CopyBlockOut(_T* Output, const typename this_t::vector_t& OutputDimensions, const typename this_t::vector_t& RangeDimensions, const typename this_t::vector_t& RangeInInputsCoordinates, const typename this_t::vector_t& RangeInOutputsCoordinates) const {
-    CopyBlock<_T, _DimensionCount, false, _OutputOnHost, true>(darr, Output, this->Dimensions(), OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
-}
-#ifdef __CUDACC__
-template <typename _T, size_t _DimensionCount>
-__device__ __forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::CopyBlockOut(_T* Output, const typename this_t::vector_t& OutputDimensions, const typename this_t::vector_t& RangeDimensions, const typename this_t::vector_t& RangeInInputsCoordinates, const typename this_t::vector_t& RangeInOutputsCoordinates) const {
-    CopyBlock<_T, _DimensionCount, true>(darr, Output, this->Dimensions(), OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
-}
-#endif
-template <typename _T, size_t _DimensionCount>
-__host__ __device__ auto bcuda::details::FieldBase<_T, _DimensionCount>::Clone() const -> this_t {
-    return FieldBase<_T, _DimensionCount>(this->Dimensions(), darr);
-}
-template <typename _T, size_t _DimensionCount>
-__forceinline size_t bcuda::details::FieldBase<_T, _DimensionCount>::SerializedSize() const requires BSerializer::Serializable<_T> {
-    size_t t = sizeof(uint32_t) * _DimensionCount;
-    size_t l = this->ValueCount();
-    for (size_t i = 0; i < l; ++i)
-        t += BSerializer::SerializedSize(CpyValOut(i));
-    return t;
-}
-template <typename _T, size_t _DimensionCount>
-__forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::Serialize(void*& Data) const requires BSerializer::Serializable<_T> {
-    BSerializer::Serialize<typename this_t::vector_t>(Data, this->Dimensions());
-    size_t l = this->ValueCount();
-    for (size_t i = 0; i < l; ++i)
-        BSerializer::Serialize(Data, CpyValOut(i));
-}
-template <typename _T, size_t _DimensionCount>
-__forceinline auto bcuda::details::FieldBase<_T, _DimensionCount>::Deserialize(const void*& Data) -> this_t requires BSerializer::Serializable<_T> {
-    typename this_t::vector_t dimensions = BSerializer::Deserialize<typename this_t::vector_t>(Data);
-    FieldBase<_T, _DimensionCount> field(dimensions);
-    size_t l = field.ValueCount();
-    for (size_t i = 0; i < l; ++i)
-        field.CpyValIn(i, BSerializer::Deserialize<_T>(Data));
-    return field;
-}
-template <typename _T, size_t _DimensionCount>
-__forceinline void bcuda::details::FieldBase<_T, _DimensionCount>::Deserialize(const void*& Data, void* Value) requires BSerializer::Serializable<_T> {
-    new (Value) FieldBase<_T, _DimensionCount>(Deserialize(Data));
 }

--- a/details_fillwith.cu
+++ b/details_fillwith.cu
@@ -7,6 +7,10 @@ __global__ void fillWithKernel(void* Array, void* Value, size_t ValueSize) {
     memcpy((uint8_t*)Array + blockIdx.x * ValueSize, Value, ValueSize);
 }
 
-__forceinline void bcuda::details::FillWith(void* Array, size_t ArrayElementCount, void* Value, size_t ValueSize) {
-    fillWithKernel<<<ArrayElementCount, 1>>>(Array, Value, ValueSize);
+namespace bcuda {
+    namespace details {
+        __forceinline void FillWith(void* Array, size_t ArrayElementCount, void* Value, size_t ValueSize) {
+            fillWithKernel<<<ArrayElementCount, 1>>>(Array, Value, ValueSize);
+        }
+    }
 }

--- a/details_fillwith.cu
+++ b/details_fillwith.cu
@@ -9,7 +9,7 @@ __global__ void fillWithKernel(void* Array, void* Value, size_t ValueSize) {
 
 namespace bcuda {
     namespace details {
-        __forceinline void FillWith(void* Array, size_t ArrayElementCount, void* Value, size_t ValueSize) {
+        inline void FillWith(void* Array, size_t ArrayElementCount, void* Value, size_t ValueSize) {
             fillWithKernel<<<ArrayElementCount, 1>>>(Array, Value, ValueSize);
         }
     }

--- a/details_fillwith.h
+++ b/details_fillwith.h
@@ -8,7 +8,7 @@ namespace bcuda {
         void FillWith(void* Array, size_t ArrayElementCount, void* Value, size_t ValueSize);
     }
     template <typename _T>
-    void FillWith(_T* Array, size_t Length, _T Value) {
+    static inline void FillWith(_T* Array, size_t Length, _T Value) {
         void* cValue;
         ThrowIfBad(cudaMalloc(&cValue, sizeof(_T)));
         ThrowIfBad(cudaMemcpy(cValue, &Value, sizeof(_T), cudaMemcpyHostToDevice));

--- a/details_getintbin.h
+++ b/details_getintbin.h
@@ -7,7 +7,7 @@
 namespace bcuda {
     namespace details {
         template <std::integral _T, std::uniform_random_bit_generator _TRNG>
-        __host__ static __forceinline _T GetIntBin(_TRNG& RNG) {
+        __host__ static inline _T GetIntBin(_TRNG& RNG) {
             if constexpr (sizeof(_T) >= 4) {
                 std::uniform_int_distribution<std::make_unsigned_t<_T>> dis(0);
                 return (_T)dis(RNG);
@@ -19,7 +19,7 @@ namespace bcuda {
         }
 #ifdef __CUDACC__
         template <std::integral _T, KernelCurandState _TRNG>
-        __device__ static __forceinline _T GetIntBin(_TRNG& RNG) {
+        __device__ static inline _T GetIntBin(_TRNG& RNG) {
             if constexpr (sizeof(_T) == 8) {
                 return ((_T)curand(RNG) << 32) | (_T)curand(RNG);
             }

--- a/details_mfieldbase.h
+++ b/details_mfieldbase.h
@@ -114,15 +114,15 @@ namespace bcuda {
 
 #pragma region ProxyAccess
             template <size_t _Idx>
-            __host__ __device__ fields::FieldProxy<element_t<_Idx>, _DimensionCount> F() const {
+            __host__ __device__ inline fields::FieldProxy<element_t<_Idx>, _DimensionCount> F() const {
                 return fields::FieldProxy<element_t<_Idx>, _DimensionCount>(this->Dimensions(), (element_t<_Idx>*)darrs[_Idx]);
             }
             template <size_t _Idx>
-            __host__ __device__ fields::FieldProxyConst<element_t<_Idx>, _DimensionCount> FConst() const {
+            __host__ __device__ inline fields::FieldProxyConst<element_t<_Idx>, _DimensionCount> FConst() const {
                 return fields::FieldProxyConst<element_t<_Idx>, _DimensionCount>(this->Dimensions(), (element_t<_Idx>*)darrs[_Idx]);
             }
             template <size_t _Idx>
-            __host__ __device__ element_t<_Idx>* FData() const {
+            __host__ __device__ inline element_t<_Idx>* FData() const {
                 return (element_t<_Idx>*)darrs[_Idx];
             }
 #pragma endregion
@@ -136,7 +136,7 @@ namespace bcuda {
 #endif
             }
 
-            __host__ __device__ this_t Clone() const {
+            __host__ __device__ inline this_t Clone() const {
                 this_t clone(this->Dimensions());
                 RunFunctionsOverTypeWrapper<MFieldBase_Clone, 0, _Ts...>::template RunFunctionsOverType(&clone.darrs, (void**)&darrs, basedb_t::ValueCount());
                 return clone;

--- a/details_mfieldbase.h
+++ b/details_mfieldbase.h
@@ -83,7 +83,7 @@ namespace bcuda {
             template <size_t _Idx>
             using element_t = std::tuple_element_t<_Idx, tuple_t>;
 
-            __host__ __device__ __forceinline MFieldBase(const typename this_t::vector_t& Dimensions)
+            __host__ __device__ inline MFieldBase(const typename this_t::vector_t& Dimensions)
                 : basedb_t(Dimensions) {
                 if (!this->Length(0)) {
                     for (size_t i = 0; i < sizeof...(_Ts); ++i)
@@ -92,23 +92,23 @@ namespace bcuda {
                 }
                 RunFunctionsOverTypeWrapper<MFieldBase_MallocMem, 0, _Ts...>::template RunFunctionsOverType((void**)&darrs, basedb_t::ValueCount());
             }
-            __host__ __device__ __forceinline MFieldBase(const typename this_t::vector_t& Dimensions, void* const* Arrays)
+            __host__ __device__ inline MFieldBase(const typename this_t::vector_t& Dimensions, void* const* Arrays)
                 : basedb_t(Dimensions) {
                 for (size_t i = 0; i < sizeof...(_Ts); ++i)
                     darrs[i] = Arrays[i];
             }
 
-            __host__ __device__ __forceinline size_t EachValueCount() const {
+            __host__ __device__ inline size_t EachValueCount() const {
                 return basedb_t::ValueCount();
             }
             template <size_t _Idx>
-            __host__ __device__ __forceinline size_t EachSizeOnGPU() const {
+            __host__ __device__ inline size_t EachSizeOnGPU() const {
                 return EachValueCount() * sizeof(element_t<_Idx>);
             }
-            __host__ __device__ __forceinline size_t TotalValueCount() const {
+            __host__ __device__ inline size_t TotalValueCount() const {
                 return EachValueCount() * sizeof...(_Ts);
             }
-            __host__ __device__ __forceinline size_t TotalSizeOnGPU() const {
+            __host__ __device__ inline size_t TotalSizeOnGPU() const {
                 return EachValueCount() * (sizeof(_Ts) + ...);
             }
 
@@ -127,7 +127,7 @@ namespace bcuda {
             }
 #pragma endregion
 
-            __host__ __device__ __forceinline void Dispose() {
+            __host__ __device__ inline void Dispose() {
                 for (size_t i = 0; i < sizeof...(_Ts); ++i)
 #ifdef __CUDA_ARCH__
                     free(darrs[i]);
@@ -142,24 +142,24 @@ namespace bcuda {
                 return clone;
             }
 
-            __forceinline size_t SerializedSize() const requires (BSerializer::Serializable<_Ts> && ...) {
+            inline size_t SerializedSize() const requires (BSerializer::Serializable<_Ts> && ...) {
                 size_t t = sizeof(typename this_t::vector_t);
                 RunFunctionsOverTypeWrapper<MFieldBase_SerializedSize_Wrapper<_DimensionCount>::template MFieldBase_SerializedSize, 0, _Ts...>::template RunFunctionsOverType((void**)&darrs, basedb_t::ValueCount(), basedb_t::Dimensions(), t);
             }
-            __forceinline void Serialize(void*& Data) const requires (BSerializer::Serializable<_Ts> && ...) {
+            inline void Serialize(void*& Data) const requires (BSerializer::Serializable<_Ts> && ...) {
                 BSerializer::Serialize(Data, basedb_t::Dimensions());
                 RunFunctionsOverTypeWrapper<MFieldBase_Serialize_Wrapper<_DimensionCount>::template MFieldBase_Serialize, 0, _Ts...>::template RunFunctionOverType((void**)&darrs, basedb_t::ValueCount(), basedb_t::Dimensions(), Data);
             }
-            static __forceinline this_t Deserialize(const void*& Data) requires (BSerializer::Serializable<_Ts> && ...) {
+            static inline this_t Deserialize(const void*& Data) requires (BSerializer::Serializable<_Ts> && ...) {
                 typename this_t::vector_t dims = BSerializer::Deserialize<typename this_t::vector_t>(Data);
                 this_t value(dims);
                 RunFunctionsOverTypeWrapper<MFieldBase_Deserialize_Wrapper<_DimensionCount>::template MFieldBase_Deserialize, 0, _Ts...>::template RunFunctionOverType((void**)&value.darrs, basedb_t::ValueCount(), basedb_t::Dimensions(), Data);
                 return value;
             }
-            static __forceinline void Deserialize(const void*& Data, void* Value) requires (BSerializer::Serializable<_Ts> && ...) {
+            static inline void Deserialize(const void*& Data, void* Value) requires (BSerializer::Serializable<_Ts> && ...) {
                 new (Value) this_t(Deserialize(Data));
             }
-            __host__ __device__ __forceinline void* const* FieldDataArray() const {
+            __host__ __device__ inline void* const* FieldDataArray() const {
                 return darrs;
             }
         private:

--- a/dimensionedbase.h
+++ b/dimensionedbase.h
@@ -12,7 +12,7 @@ namespace bcuda {
     protected:
         using vector_t = FixedVector<uint32_t, _DimensionCount>;
     public:
-        __host__ __device__ __forceinline DimensionedBase(vector_t Dimensions) {
+        __host__ __device__ inline DimensionedBase(vector_t Dimensions) {
             for (size_t i = 0; i < _DimensionCount; ++i)
                 if (!Dimensions[i]) {
                     dims = vector_t();
@@ -22,49 +22,49 @@ namespace bcuda {
         }
         template <std::convertible_to<uint32_t>... _Ts>
             requires (sizeof...(_Ts) == _DimensionCount)
-        __host__ __device__ __forceinline DimensionedBase(_Ts... Dimensions)
+        __host__ __device__ inline DimensionedBase(_Ts... Dimensions)
             : DimensionedBase(vector_t(Dimensions...)) { }
 
-        __host__ __device__ __forceinline uint32_t LengthX() const requires (_DimensionCount <= 4) {
+        __host__ __device__ inline uint32_t LengthX() const requires (_DimensionCount <= 4) {
             return dims.x;
         }
-        __host__ __device__ __forceinline uint32_t LengthY() const requires (_DimensionCount >= 2 && _DimensionCount <= 4) {
+        __host__ __device__ inline uint32_t LengthY() const requires (_DimensionCount >= 2 && _DimensionCount <= 4) {
             return dims.y;
         }
-        __host__ __device__ __forceinline uint32_t LengthZ() const requires (_DimensionCount >= 3 && _DimensionCount <= 4) {
+        __host__ __device__ inline uint32_t LengthZ() const requires (_DimensionCount >= 3 && _DimensionCount <= 4) {
             return dims.z;
         }
-        __host__ __device__ __forceinline uint32_t LengthW() const requires (_DimensionCount == 4) {
+        __host__ __device__ inline uint32_t LengthW() const requires (_DimensionCount == 4) {
             return dims.w;
         }
 
-        __host__ __device__ __forceinline uint32_t Length(size_t Idx) const {
+        __host__ __device__ inline uint32_t Length(size_t Idx) const {
             return dims[Idx];
         }
-        __host__ __device__ __forceinline vector_t Dimensions() const {
+        __host__ __device__ inline vector_t Dimensions() const {
             return dims;
         }
-        __host__ __device__ __forceinline dim3 DimensionsD() const requires (_DimensionCount <= 3) {
+        __host__ __device__ inline dim3 DimensionsD() const requires (_DimensionCount <= 3) {
             if constexpr (_DimensionCount == 1) return dim3(dims.x);
             else if constexpr (_DimensionCount == 2) return dim3(dims.x, dims.y);
             else return dim3(dims.x, dims.y, dims.z);
         }
-        __host__ __device__ __forceinline size_t ValueCount() const {
+        __host__ __device__ inline size_t ValueCount() const {
             size_t s = 1;
             for (size_t i = 0; i < _DimensionCount; ++i)
                 s *= dims[i];
             return s;
         }
 
-        __host__ __device__ __forceinline vector_t IdxToCoords(uint64_t Index) const {
+        __host__ __device__ inline vector_t IdxToCoords(uint64_t Index) const {
             return bcuda::IndexToCoordinates<uint64_t, uint32_t, _DimensionCount, true>(Dimensions(), Idx);
         }
-        __host__ __device__ __forceinline uint64_t CoordsToIdx(vector_t Coords) const {
+        __host__ __device__ inline uint64_t CoordsToIdx(vector_t Coords) const {
             return bcuda::CoordinatesToIndex<uint64_t, uint32_t, _DimensionCount, true>(Dimensions(), Coords);
         }
         template <std::convertible_to<uint32_t>... _Ts>
             requires (sizeof...(_Ts) == _DimensionCount)
-        __host__ __device__ __forceinline uint64_t CoordsToIdx(_Ts... Coords) const {
+        __host__ __device__ inline uint64_t CoordsToIdx(_Ts... Coords) const {
             return CoordsToIdx(vector_t(Coords...));
         }
     private:

--- a/dimensionedbase.h
+++ b/dimensionedbase.h
@@ -12,26 +12,56 @@ namespace bcuda {
     protected:
         using vector_t = FixedVector<uint32_t, _DimensionCount>;
     public:
-        __host__ __device__ __forceinline DimensionedBase(vector_t Dimensions);
+        __host__ __device__ __forceinline DimensionedBase(vector_t Dimensions) {
+            for (size_t i = 0; i < _DimensionCount; ++i)
+                if (!Dimensions[i]) {
+                    dims = vector_t();
+                    return;
+                }
+            dims = Dimensions;
+        }
         template <std::convertible_to<uint32_t>... _Ts>
             requires (sizeof...(_Ts) == _DimensionCount)
         __host__ __device__ __forceinline DimensionedBase(_Ts... Dimensions)
             : DimensionedBase(vector_t(Dimensions...)) { }
 
-        __host__ __device__ __forceinline uint32_t LengthX() const requires (_DimensionCount <= 4);
-        __host__ __device__ __forceinline uint32_t LengthY() const requires (_DimensionCount >= 2 && _DimensionCount <= 4);
-        __host__ __device__ __forceinline uint32_t LengthZ() const requires (_DimensionCount >= 3 && _DimensionCount <= 4);
-        __host__ __device__ __forceinline uint32_t LengthW() const requires (_DimensionCount == 4);
+        __host__ __device__ __forceinline uint32_t LengthX() const requires (_DimensionCount <= 4) {
+            return dims.x;
+        }
+        __host__ __device__ __forceinline uint32_t LengthY() const requires (_DimensionCount >= 2 && _DimensionCount <= 4) {
+            return dims.y;
+        }
+        __host__ __device__ __forceinline uint32_t LengthZ() const requires (_DimensionCount >= 3 && _DimensionCount <= 4) {
+            return dims.z;
+        }
+        __host__ __device__ __forceinline uint32_t LengthW() const requires (_DimensionCount == 4) {
+            return dims.w;
+        }
 
         __host__ __device__ __forceinline uint32_t Length(size_t Idx) const {
             return dims[Idx];
         }
-        __host__ __device__ __forceinline vector_t Dimensions() const;
-        __host__ __device__ __forceinline dim3 DimensionsD() const requires (_DimensionCount <= 3);
-        __host__ __device__ __forceinline size_t ValueCount() const;
+        __host__ __device__ __forceinline vector_t Dimensions() const {
+            return dims;
+        }
+        __host__ __device__ __forceinline dim3 DimensionsD() const requires (_DimensionCount <= 3) {
+            if constexpr (_DimensionCount == 1) return dim3(dims.x);
+            else if constexpr (_DimensionCount == 2) return dim3(dims.x, dims.y);
+            else return dim3(dims.x, dims.y, dims.z);
+        }
+        __host__ __device__ __forceinline size_t ValueCount() const {
+            size_t s = 1;
+            for (size_t i = 0; i < _DimensionCount; ++i)
+                s *= dims[i];
+            return s;
+        }
 
-        __host__ __device__ __forceinline vector_t IdxToCoords(uint64_t Index) const;
-        __host__ __device__ __forceinline uint64_t CoordsToIdx(vector_t Coords) const;
+        __host__ __device__ __forceinline vector_t IdxToCoords(uint64_t Index) const {
+            return bcuda::IndexToCoordinates<uint64_t, uint32_t, _DimensionCount, true>(Dimensions(), Idx);
+        }
+        __host__ __device__ __forceinline uint64_t CoordsToIdx(vector_t Coords) const {
+            return bcuda::CoordinatesToIndex<uint64_t, uint32_t, _DimensionCount, true>(Dimensions(), Coords);
+        }
         template <std::convertible_to<uint32_t>... _Ts>
             requires (sizeof...(_Ts) == _DimensionCount)
         __host__ __device__ __forceinline uint64_t CoordsToIdx(_Ts... Coords) const {
@@ -40,55 +70,4 @@ namespace bcuda {
     private:
         vector_t dims;
     };
-}
-
-template <size_t _DimensionCount>
-bcuda::DimensionedBase<_DimensionCount>::DimensionedBase(vector_t Dimensions) {
-    for (size_t i = 0; i < _DimensionCount; ++i)
-        if (!Dimensions[i]) {
-            dims = vector_t();
-            return;
-        }
-    dims = Dimensions;
-}
-template <size_t _DimensionCount>
-__host__ __device__ __forceinline uint32_t bcuda::DimensionedBase<_DimensionCount>::LengthX() const requires (_DimensionCount <= 4) {
-    return dims.x;
-}
-template <size_t _DimensionCount>
-__host__ __device__ __forceinline uint32_t bcuda::DimensionedBase<_DimensionCount>::LengthY() const requires (_DimensionCount >= 2 && _DimensionCount <= 4) {
-    return dims.y;
-}
-template <size_t _DimensionCount>
-__host__ __device__ __forceinline uint32_t bcuda::DimensionedBase<_DimensionCount>::LengthZ() const requires (_DimensionCount >= 3 && _DimensionCount <= 4) {
-    return dims.z;
-}
-template <size_t _DimensionCount>
-__host__ __device__ __forceinline uint32_t bcuda::DimensionedBase<_DimensionCount>::LengthW() const requires (_DimensionCount == 4) {
-    return dims.w;
-}
-template <size_t _DimensionCount>
-__host__ __device__ __forceinline auto bcuda::DimensionedBase<_DimensionCount>::Dimensions() const -> vector_t {
-    return dims;
-}
-template <size_t _DimensionCount>
-__host__ __device__ __forceinline dim3 bcuda::DimensionedBase<_DimensionCount>::DimensionsD() const requires (_DimensionCount <= 3) {
-    if constexpr (_DimensionCount == 1) return dim3(dims.x);
-    else if constexpr (_DimensionCount == 2) return dim3(dims.x, dims.y);
-    else return dim3(dims.x, dims.y, dims.z);
-}
-template <size_t _DimensionCount>
-__host__ __device__ __forceinline size_t bcuda::DimensionedBase<_DimensionCount>::ValueCount() const {
-    size_t s = 1;
-    for (size_t i = 0; i < _DimensionCount; ++i)
-        s *= dims[i];
-    return s;
-}
-template <size_t _DimensionCount>
-__host__ __device__ __forceinline uint64_t bcuda::DimensionedBase<_DimensionCount>::CoordsToIdx(vector_t Coords) const {
-    return bcuda::CoordinatesToIndex<uint64_t, uint32_t, _DimensionCount, true>(Dimensions(), Coords);
-}
-template <size_t _DimensionCount>
-__host__ __device__ __forceinline auto bcuda::DimensionedBase<_DimensionCount>::IdxToCoords(uint64_t Idx) const -> vector_t {
-    return bcuda::IndexToCoordinates<uint64_t, uint32_t, _DimensionCount, true>(Dimensions(), Idx);
 }

--- a/errorhelp.h
+++ b/errorhelp.h
@@ -6,7 +6,7 @@
 namespace bcuda {
     template <typename _T>
         requires (std::is_enum_v<_T> || std::integral<_T>)
-    void ThrowIfBad(_T e) {
+    static inline void ThrowIfBad(_T e) {
         if (e) throw e;
     }
 }

--- a/exprs.h
+++ b/exprs.h
@@ -25,7 +25,7 @@ namespace bcuda {
 
             virtual _TOutput Calc(const varmap_t&) = 0;
 
-            std::any CalcToAny(const varmap_t& VarMap) override {
+            std::any CalcToAny(const varmap_t& VarMap) override final {
                 return Calc(VarMap);
             }
 

--- a/exprs.h
+++ b/exprs.h
@@ -756,7 +756,7 @@ namespace bcuda {
             };
 
             template <typename _TTupleI, typename _TTupleO, size_t _Idx = 0>
-            __forceinline void CalcTuple(const _TTupleI& InTuple, _TTupleO& OutTuple, const varmap_t& Map) {
+            inline void CalcTuple(const _TTupleI& InTuple, _TTupleO& OutTuple, const varmap_t& Map) {
                 if constexpr (_Idx >= std::tuple_size_v<_TTupleI>) return;
                 using type_t = std::tuple_element_t<_Idx, _TTupleO>;
                 new (&std::get<_Idx>(OutTuple)) type_t(std::get<_Idx>(InTuple)->Calc(Map));
@@ -764,14 +764,14 @@ namespace bcuda {
             }
 
             template <typename _TTuple, size_t _Idx = 0>
-            __forceinline void ConvertTupleToArray(const _TTuple& Tuple, ArrayV<ExprBase*>& Array) {
+            inline void ConvertTupleToArray(const _TTuple& Tuple, ArrayV<ExprBase*>& Array) {
                 if constexpr (_Idx >= std::tuple_size_v<_TTuple>) return;
                 Array[_Idx] = std::get<_Idx>(Tuple);
                 ConvertTupleToArray<_TTuple, _Idx + 1>(Tuple, Array);
             }
 
             template <typename _TTuple, size_t _Idx = 0>
-            __forceinline void CloneTuple(const _TTuple& TupleOld, _TTuple& TupleNew) {
+            inline void CloneTuple(const _TTuple& TupleOld, _TTuple& TupleNew) {
                 using type_t = std::tuple_element_t<_Idx, _TTuple>;
                 std::get<_Idx>(TupleNew) = type_t(std::get<_Idx>(TupleOld)->Clone());
             }

--- a/fields_dfield.h
+++ b/fields_dfield.h
@@ -29,49 +29,49 @@ namespace bcuda {
             using kernelFunc_t = details::dfieldIK_t<_T, _DimensionCount>;
 
 #pragma region Wrapper
-            __host__ __device__ __forceinline DField(const vector_t& Dimensions)
+            __host__ __device__ inline DField(const vector_t& Dimensions)
                 : basefb_t(Dimensions) { }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __host__ __device__ __forceinline DField(_Ts... Dimensions)
+            __host__ __device__ inline DField(_Ts... Dimensions)
                 : basefb_t(Dimensions...) { }
 
-            __host__ __device__ __forceinline uint32_t LengthX() const requires (_DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthX() const requires (_DimensionCount <= 4) {
                 return basedb_t::LengthX();
             }
-            __host__ __device__ __forceinline uint32_t LengthY() const requires (_DimensionCount >= 2 && _DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthY() const requires (_DimensionCount >= 2 && _DimensionCount <= 4) {
                 return basedb_t::LengthY();
             }
-            __host__ __device__ __forceinline uint32_t LengthZ() const requires (_DimensionCount >= 3 && _DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthZ() const requires (_DimensionCount >= 3 && _DimensionCount <= 4) {
                 return basedb_t::LengthZ();
             }
-            __host__ __device__ __forceinline uint32_t LengthW() const requires (_DimensionCount == 4) {
+            __host__ __device__ inline uint32_t LengthW() const requires (_DimensionCount == 4) {
                 return basedb_t::LengthW();
             }
-            __host__ __device__ __forceinline uint32_t Length(size_t Idx) const {
+            __host__ __device__ inline uint32_t Length(size_t Idx) const {
                 return basedb_t::Length(Idx);
             }
-            __host__ __device__ __forceinline vector_t Dimensions() const {
+            __host__ __device__ inline vector_t Dimensions() const {
                 return basedb_t::Dimensions();
             }
-            __host__ __device__ __forceinline dim3 DimensionsD() const {
+            __host__ __device__ inline dim3 DimensionsD() const {
                 return basedb_t::DimensionsD();
             }
-            __host__ __device__ __forceinline size_t ValueCount() const {
+            __host__ __device__ inline size_t ValueCount() const {
                 return basedb_t::ValueCount();
             }
-            __host__ __device__ __forceinline vector_t IdxToCoords(uint64_t Index) const {
+            __host__ __device__ inline vector_t IdxToCoords(uint64_t Index) const {
                 return basedb_t::IdxToCoords(Index);
             }
-            __host__ __device__ __forceinline uint64_t CoordsToIdx(vector_t Coords) const {
+            __host__ __device__ inline uint64_t CoordsToIdx(vector_t Coords) const {
                 return basedb_t::CoordsToIdx(Coords);
             }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __host__ __device__ __forceinline uint64_t CoordsToIdx(_Ts... Coords) const {
+            __host__ __device__ inline uint64_t CoordsToIdx(_Ts... Coords) const {
                 return basedb_t::CoordsToIdx(Coords...);
             }
-            __host__ __device__ __forceinline size_t SizeOnGPU() const {
+            __host__ __device__ inline size_t SizeOnGPU() const {
                 return basefb_t::SizeOnGPU();
             }
             __host__ __device__ fields::FieldProxy<_T, _DimensionCount> F() {
@@ -102,152 +102,152 @@ namespace bcuda {
                 basefb_t::Reverse();
             }
             template <bool _CopyFromHost>
-            __host__ __forceinline void CpyAllIn(const _T* All) {
+            __host__ inline void CpyAllIn(const _T* All) {
                 basefb_t::template CpyAllIn<_CopyFromHost>(All);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyAllIn(const _T* All) {
+            __device__ inline void CpyAllIn(const _T* All) {
                 basefb_t::CpyAllIn(All);
             }
 #endif
             template <bool _CopyToHost>
-            __host__ __forceinline _T* CpyAllOut() const {
+            __host__ inline _T* CpyAllOut() const {
                 return basefb_t::template CpyAllOut<_CopyToHost>();
             }
 #ifdef __CUDACC__
-            __device__ __forceinline _T* CpyAllOut() const {
+            __device__ inline _T* CpyAllOut() const {
                 return basefb_t::CpyAllOut();
             }
 #endif
             template <bool _CopyToHost>
-            __host__ __device__ __forceinline void CpyAllOut(_T* All) const {
+            __host__ __device__ inline void CpyAllOut(_T* All) const {
                 basefb_t::template CpyAllOut<_CopyToHost>(All);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyAllOut(_T* All) const {
+            __device__ inline void CpyAllOut(_T* All) const {
                 basefb_t::CpyAllOut(All);
             }
 #endif
-            __host__ __device__ __forceinline void CpyValIn(uint64_t Idx, const _T& Val) {
+            __host__ __device__ inline void CpyValIn(uint64_t Idx, const _T& Val) {
                 basefb_t::CpyValIn(Idx, Val);
             }
-            __host__ __device__ __forceinline void CpyValIn(const vector_t& Coords, const _T& Val) {
+            __host__ __device__ inline void CpyValIn(const vector_t& Coords, const _T& Val) {
                 basefb_t::CpyValIn(Coords, Val);
             }
             template <bool _CopyFromHost>
-            __host__ __forceinline void CpyValIn(uint64_t Idx, const _T* Val) {
+            __host__ inline void CpyValIn(uint64_t Idx, const _T* Val) {
                 basefb_t::template CpyValIn<_CopyFromHost>(Idx, Val);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyValIn(uint64_t Idx, const _T* Val) {
+            __device__ inline void CpyValIn(uint64_t Idx, const _T* Val) {
                 basefb_t::CpyValIn(Idx, Val);
             }
 #endif
             template <bool _CopyFromHost>
-            __host__ __forceinline void CpyValIn(const vector_t& Coords, const _T* Val) {
+            __host__ inline void CpyValIn(const vector_t& Coords, const _T* Val) {
                 basefb_t::template CpyValIn<_CopyFromHost>(Coords, Val);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyValIn(const vector_t& Coords, const _T* Val) {
+            __device__ inline void CpyValIn(const vector_t& Coords, const _T* Val) {
                 basefb_t::CpyValIn(Coords, Val);
             }
 #endif
-            __host__ __device__ __forceinline void CpyValOut(uint64_t Idx, _T& Val) const {
+            __host__ __device__ inline void CpyValOut(uint64_t Idx, _T& Val) const {
                 basefb_t::CpyValOut(Idx, Val);
             }
-            __host__ __device__ __forceinline void CpyValOut(const vector_t& Coords, _T& Val) const {
+            __host__ __device__ inline void CpyValOut(const vector_t& Coords, _T& Val) const {
                 basefb_t::CpyValOut(Coords, Val);
             }
             template <bool _CopyToHost>
-            __host__ __forceinline void CpyValOut(uint64_t Idx, _T* Val) const {
+            __host__ inline void CpyValOut(uint64_t Idx, _T* Val) const {
                 basefb_t::template CpyValOut<_CopyToHost>(Idx, Val);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyValOut(uint64_t Idx, _T* Val) const {
+            __device__ inline void CpyValOut(uint64_t Idx, _T* Val) const {
                 basefb_t::CpyValOut(Idx, Val);
             }
 #endif
             template <bool _CopyToHost>
-            __host__ __forceinline void CpyValOut(const vector_t& Coords, _T* Val) const {
+            __host__ inline void CpyValOut(const vector_t& Coords, _T* Val) const {
                 basefb_t::template CpyValOut<_CopyToHost>(Coords, Val);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyValOut(const vector_t& Coords, _T* Val) const {
+            __device__ inline void CpyValOut(const vector_t& Coords, _T* Val) const {
                 basefb_t::CpyValOut(Coords, Val);
             }
 #endif
-            __host__ __device__ __forceinline _T CpyValOut(uint64_t Idx) const {
+            __host__ __device__ inline _T CpyValOut(uint64_t Idx) const {
                 return basefb_t::CpyValOut(Idx);
             }
-            __host__ __device__ __forceinline _T CpyValOut(const vector_t& Coords) const {
+            __host__ __device__ inline _T CpyValOut(const vector_t& Coords) const {
                 return basefb_t::CpyValOut(Coords);
             }
             template <bool _InputOnHost>
-            __host__ __forceinline void CopyBlockIn(const _T* Input, const vector_t& InputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) {
+            __host__ inline void CopyBlockIn(const _T* Input, const vector_t& InputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) {
                 basefb_t::template CopyBlockIn<_InputOnHost>(Input, InputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CopyBlockIn(const _T* Input, const vector_t& InputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) {
+            __device__ inline void CopyBlockIn(const _T* Input, const vector_t& InputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) {
                 basefb_t::CopyBlockIn(Input, InputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #endif
             template <bool _OutputOnHost>
-            __host__ __forceinline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
+            __host__ inline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
                 basefb_t::template CopyBlockOut<_OutputOnHost>(Output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
+            __device__ inline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
                 basefb_t::CopyBlockOut(Output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #endif
-            __forceinline size_t SerializedSize() const requires BSerializer::Serializable<_T> {
+            inline size_t SerializedSize() const requires BSerializer::Serializable<_T> {
                 return basefb_t::SerializedSize();
             }
-            __forceinline void Serialize(void*& Data) const requires BSerializer::Serializable<_T> {
+            inline void Serialize(void*& Data) const requires BSerializer::Serializable<_T> {
                 basefb_t::Serialize(Data);
             }
 #pragma endregion
 
-            static __forceinline this_t Deserialize(const void*& Data) requires BSerializer::Serializable<_T> {
+            static inline this_t Deserialize(const void*& Data) requires BSerializer::Serializable<_T> {
                 return *(this_t*)&basefb_t::Deserialize(Data);
             }
-            static __forceinline void Deserialize(const void*& Data, void* Value) requires BSerializer::Serializable<_T> {
+            static inline void Deserialize(const void*& Data, void* Value) requires BSerializer::Serializable<_T> {
                 basefb_t::Deserialize(Data, Value);
             }
 
-            __host__ __device__ __forceinline DField(vector_t Dimensions, _T* All)
+            __host__ __device__ inline DField(vector_t Dimensions, _T* All)
                 : DField(Dimensions) {
                 CpyAllIn(All);
             }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __host__ __device__ __forceinline DField(_Ts... Dimensions, _T* All)
+            __host__ __device__ inline DField(_Ts... Dimensions, _T* All)
                 : DField(vector_t(Dimensions...), All) { }
 
-            __host__ __device__ __forceinline DField(const this_t& Other)
+            __host__ __device__ inline DField(const this_t& Other)
                 : DField(Other.Dimensions(), Other.FData()) { }
-            __host__ __device__ __forceinline DField(this_t&& Other)
+            __host__ __device__ inline DField(this_t&& Other)
                 : basefb_t(Other.Dimensions(), Other.FData(), Other.BData()) {
                 new (&Other) basefb_t(this->Dimensions(), 0, 0);
             }
-            __host__ __device__ __forceinline ~DField() {
+            __host__ __device__ inline ~DField() {
                 basefb_t::Dispose();
             }
-            __host__ __device__ __forceinline this_t& operator=(const this_t& Other) {
+            __host__ __device__ inline this_t& operator=(const this_t& Other) {
                 this->~DField();
                 new (this) DField(Other);
                 return *this;
             }
-            __host__ __device__ __forceinline this_t& operator=(this_t&& Other) {
+            __host__ __device__ inline this_t& operator=(this_t&& Other) {
                 this->~DField();
                 new (this) DField(Other);
                 return *this;
             }
 
-            __host__ __device__ __forceinline DFieldProxy<_T, _DimensionCount> MakeProxy() {
+            __host__ __device__ inline DFieldProxy<_T, _DimensionCount> MakeProxy() {
                 return DFieldProxy<_T, _DimensionCount>(*this);
             }
-            __host__ __device__ __forceinline DFieldProxyConst<_T, _DimensionCount> MakeProxy() const {
+            __host__ __device__ inline DFieldProxyConst<_T, _DimensionCount> MakeProxy() const {
                 return DFieldProxyConst<_T, _DimensionCount>(*this);
             }
         };
@@ -263,43 +263,43 @@ namespace bcuda {
             __host__ __device__ DFieldProxy(const vector_t& Dimensions, _T* ArrF, _T* ArrB)
                 : basefb_t(Dimensions, ArrF, ArrB) { }
 
-            __host__ __device__ __forceinline uint32_t LengthX() const requires (_DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthX() const requires (_DimensionCount <= 4) {
                 return basedb_t::LengthX();
             }
-            __host__ __device__ __forceinline uint32_t LengthY() const requires (_DimensionCount >= 2 && _DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthY() const requires (_DimensionCount >= 2 && _DimensionCount <= 4) {
                 return basedb_t::LengthY();
             }
-            __host__ __device__ __forceinline uint32_t LengthZ() const requires (_DimensionCount >= 3 && _DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthZ() const requires (_DimensionCount >= 3 && _DimensionCount <= 4) {
                 return basedb_t::LengthZ();
             }
-            __host__ __device__ __forceinline uint32_t LengthW() const requires (_DimensionCount == 4) {
+            __host__ __device__ inline uint32_t LengthW() const requires (_DimensionCount == 4) {
                 return basedb_t::LengthW();
             }
-            __host__ __device__ __forceinline uint32_t Length(size_t Idx) const {
+            __host__ __device__ inline uint32_t Length(size_t Idx) const {
                 return basedb_t::Length(Idx);
             }
-            __host__ __device__ __forceinline vector_t Dimensions() const {
+            __host__ __device__ inline vector_t Dimensions() const {
                 return basedb_t::Dimensions();
             }
-            __host__ __device__ __forceinline dim3 DimensionsD() const {
+            __host__ __device__ inline dim3 DimensionsD() const {
                 return basedb_t::DimensionsD();
             }
-            __host__ __device__ __forceinline size_t ValueCount() const {
+            __host__ __device__ inline size_t ValueCount() const {
                 return basedb_t::ValueCount();
             }
-            __host__ __device__ __forceinline vector_t IdxToCoords(uint64_t Index) const {
+            __host__ __device__ inline vector_t IdxToCoords(uint64_t Index) const {
                 return basedb_t::IdxToCoords(Index);
             }
-            __host__ __device__ __forceinline uint64_t CoordsToIdx(vector_t Coords) const {
+            __host__ __device__ inline uint64_t CoordsToIdx(vector_t Coords) const {
                 return basedb_t::CoordsToIdx(Coords);
             }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __host__ __device__ __forceinline uint64_t CoordsToIdx(_Ts... Coords) const {
+            __host__ __device__ inline uint64_t CoordsToIdx(_Ts... Coords) const {
                 return basedb_t::CoordsToIdx(Coords...);
             }
 
-            __host__ __device__ __forceinline size_t SizeOnGPU() const {
+            __host__ __device__ inline size_t SizeOnGPU() const {
                 return basefb_t::SizeOnGPU();
             }
             __host__ __device__ fields::FieldProxy<_T, _DimensionCount> F() const {
@@ -321,113 +321,113 @@ namespace bcuda {
                 return basefb_t::BData();
             }
             template <bool _CopyFromHost>
-            __host__ __forceinline void CpyAllIn(const _T* All) const {
+            __host__ inline void CpyAllIn(const _T* All) const {
                 basefb_t::template CpyAllIn<_CopyFromHost>(All);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyAllIn(const _T* All) const {
+            __device__ inline void CpyAllIn(const _T* All) const {
                 basefb_t::CpyAllIn(All);
             }
 #endif
             template <bool _CopyToHost>
-            __host__ __forceinline _T* CpyAllOut() const {
+            __host__ inline _T* CpyAllOut() const {
                 return basefb_t::template CpyAllOut<_CopyToHost>();
             }
 #ifdef __CUDACC__
-            __device__ __forceinline _T* CpyAllOut() const {
+            __device__ inline _T* CpyAllOut() const {
                 return basefb_t::CpyAllOut();
             }
 #endif
             template <bool _CopyToHost>
-            __host__ __device__ __forceinline void CpyAllOut(_T* All) const {
+            __host__ __device__ inline void CpyAllOut(_T* All) const {
                 basefb_t::template CpyAllOut<_CopyToHost>(All);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyAllOut(_T* All) const {
+            __device__ inline void CpyAllOut(_T* All) const {
                 basefb_t::CpyAllOut(All);
             }
 #endif
-            __host__ __device__ __forceinline void CpyValIn(uint64_t Idx, const _T& Val) const {
+            __host__ __device__ inline void CpyValIn(uint64_t Idx, const _T& Val) const {
                 basefb_t::CpyValIn(Idx, Val);
             }
-            __host__ __device__ __forceinline void CpyValIn(const vector_t& Coords, const _T& Val) const {
+            __host__ __device__ inline void CpyValIn(const vector_t& Coords, const _T& Val) const {
                 basefb_t::CpyValIn(Coords, Val);
             }
             template <bool _CopyFromHost>
-            __host__ __forceinline void CpyValIn(uint64_t Idx, const _T* Val) const {
+            __host__ inline void CpyValIn(uint64_t Idx, const _T* Val) const {
                 basefb_t::template CpyValIn<_CopyFromHost>(Idx, Val);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyValIn(uint64_t Idx, const _T* Val) const {
+            __device__ inline void CpyValIn(uint64_t Idx, const _T* Val) const {
                 basefb_t::CpyValIn(Idx, Val);
             }
 #endif
             template <bool _CopyFromHost>
-            __host__ __forceinline void CpyValIn(const vector_t& Coords, const _T* Val) const {
+            __host__ inline void CpyValIn(const vector_t& Coords, const _T* Val) const {
                 basefb_t::template CpyValIn<_CopyFromHost>(Coords, Val);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyValIn(const vector_t& Coords, const _T* Val) const {
+            __device__ inline void CpyValIn(const vector_t& Coords, const _T* Val) const {
                 basefb_t::CpyValIn(Coords, Val);
             }
 #endif
-            __host__ __device__ __forceinline void CpyValOut(uint64_t Idx, _T& Val) const {
+            __host__ __device__ inline void CpyValOut(uint64_t Idx, _T& Val) const {
                 basefb_t::CpyValOut(Idx, Val);
             }
-            __host__ __device__ __forceinline void CpyValOut(const vector_t& Coords, _T& Val) const {
+            __host__ __device__ inline void CpyValOut(const vector_t& Coords, _T& Val) const {
                 basefb_t::CpyValOut(Coords, Val);
             }
             template <bool _CopyToHost>
-            __host__ __forceinline void CpyValOut(uint64_t Idx, _T* Val) const {
+            __host__ inline void CpyValOut(uint64_t Idx, _T* Val) const {
                 basefb_t::template CpyValOut<_CopyToHost>(Idx, Val);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyValOut(uint64_t Idx, _T* Val) const {
+            __device__ inline void CpyValOut(uint64_t Idx, _T* Val) const {
                 basefb_t::CpyValOut(Idx, Val);
             }
 #endif
             template <bool _CopyToHost>
-            __host__ __forceinline void CpyValOut(const vector_t& Coords, _T* Val) const {
+            __host__ inline void CpyValOut(const vector_t& Coords, _T* Val) const {
                 basefb_t::template CpyValOut<_CopyToHost>(Coords, Val);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyValOut(const vector_t& Coords, _T* Val) const {
+            __device__ inline void CpyValOut(const vector_t& Coords, _T* Val) const {
                 basefb_t::CpyValOut(Coords, Val);
             }
 #endif
-            __host__ __device__ __forceinline _T CpyValOut(uint64_t Idx) const {
+            __host__ __device__ inline _T CpyValOut(uint64_t Idx) const {
                 return basefb_t::CpyValOut(Idx);
             }
-            __host__ __device__ __forceinline _T CpyValOut(const vector_t& Coords) const {
+            __host__ __device__ inline _T CpyValOut(const vector_t& Coords) const {
                 return basefb_t::CpyValOut(Coords);
             }
             template <bool _InputOnHost>
-            __host__ __forceinline void CopyBlockIn(const _T* Input, const vector_t& InputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
+            __host__ inline void CopyBlockIn(const _T* Input, const vector_t& InputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
                 basefb_t::template CopyBlockIn<_InputOnHost>(Input, InputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CopyBlockIn(const _T* Input, const vector_t& InputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
+            __device__ inline void CopyBlockIn(const _T* Input, const vector_t& InputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
                 basefb_t::CopyBlockIn(Input, InputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #endif
             template <bool _OutputOnHost>
-            __host__ __forceinline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
+            __host__ inline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
                 basefb_t::template CopyBlockOut<_OutputOnHost>(Output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
+            __device__ inline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
                 basefb_t::CopyBlockOut(Output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #endif
-            __forceinline size_t SerializedSize() const requires BSerializer::Serializable<_T> {
+            inline size_t SerializedSize() const requires BSerializer::Serializable<_T> {
                 return basefb_t::SerializedSize();
             }
-            __forceinline void Serialize(void*& Data) const requires BSerializer::Serializable<_T> {
+            inline void Serialize(void*& Data) const requires BSerializer::Serializable<_T> {
                 basefb_t::Serialize(Data);
             }
 #pragma endregion
 
-            __host__ __device__ __forceinline DField<_T, _DimensionCount> Clone() const {
+            __host__ __device__ inline DField<_T, _DimensionCount> Clone() const {
                 return *(DField<_T, _DimensionCount>*)&basefb_t::Clone();
             }
 
@@ -445,43 +445,43 @@ namespace bcuda {
             __host__ __device__ DFieldProxyConst(const vector_t& Dimensions, const _T* ArrF, const _T* ArrB)
                 : basefb_t(Dimensions, const_cast<_T*>(ArrF), const_cast<_T*>(ArrB)) { }
 
-            __host__ __device__ __forceinline uint32_t LengthX() const requires (_DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthX() const requires (_DimensionCount <= 4) {
                 return basedb_t::LengthX();
             }
-            __host__ __device__ __forceinline uint32_t LengthY() const requires (_DimensionCount >= 2 && _DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthY() const requires (_DimensionCount >= 2 && _DimensionCount <= 4) {
                 return basedb_t::LengthY();
             }
-            __host__ __device__ __forceinline uint32_t LengthZ() const requires (_DimensionCount >= 3 && _DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthZ() const requires (_DimensionCount >= 3 && _DimensionCount <= 4) {
                 return basedb_t::LengthZ();
             }
-            __host__ __device__ __forceinline uint32_t LengthW() const requires (_DimensionCount == 4) {
+            __host__ __device__ inline uint32_t LengthW() const requires (_DimensionCount == 4) {
                 return basedb_t::LengthW();
             }
-            __host__ __device__ __forceinline uint32_t Length(size_t Idx) const {
+            __host__ __device__ inline uint32_t Length(size_t Idx) const {
                 return basedb_t::Length(Idx);
             }
-            __host__ __device__ __forceinline vector_t Dimensions() const {
+            __host__ __device__ inline vector_t Dimensions() const {
                 return basedb_t::Dimensions();
             }
-            __host__ __device__ __forceinline dim3 DimensionsD() const {
+            __host__ __device__ inline dim3 DimensionsD() const {
                 return basedb_t::DimensionsD();
             }
-            __host__ __device__ __forceinline size_t ValueCount() const {
+            __host__ __device__ inline size_t ValueCount() const {
                 return basedb_t::ValueCount();
             }
-            __host__ __device__ __forceinline vector_t IdxToCoords(uint64_t Index) const {
+            __host__ __device__ inline vector_t IdxToCoords(uint64_t Index) const {
                 return basedb_t::IdxToCoords(Index);
             }
-            __host__ __device__ __forceinline uint64_t CoordsToIdx(vector_t Coords) const {
+            __host__ __device__ inline uint64_t CoordsToIdx(vector_t Coords) const {
                 return basedb_t::CoordsToIdx(Coords);
             }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __host__ __device__ __forceinline uint64_t CoordsToIdx(_Ts... Coords) const {
+            __host__ __device__ inline uint64_t CoordsToIdx(_Ts... Coords) const {
                 return basedb_t::CoordsToIdx(Coords...);
             }
 
-            __host__ __device__ __forceinline size_t SizeOnGPU() const {
+            __host__ __device__ inline size_t SizeOnGPU() const {
                 return basefb_t::SizeOnGPU();
             }
             __host__ __device__ fields::FieldProxyConst<_T, _DimensionCount> FConst() const {
@@ -497,71 +497,71 @@ namespace bcuda {
                 return basefb_t::BData();
             }
             template <bool _CopyToHost>
-            __host__ __forceinline _T* CpyAllOut() const {
+            __host__ inline _T* CpyAllOut() const {
                 return basefb_t::template CpyAllOut<_CopyToHost>();
             }
 #ifdef __CUDACC__
-            __device__ __forceinline _T* CpyAllOut() const {
+            __device__ inline _T* CpyAllOut() const {
                 return basefb_t::CpyAllOut();
             }
 #endif
             template <bool _CopyToHost>
-            __host__ __device__ __forceinline void CpyAllOut(_T* All) const {
+            __host__ __device__ inline void CpyAllOut(_T* All) const {
                 basefb_t::template CpyAllOut<_CopyToHost>(All);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyAllOut(_T* All) const {
+            __device__ inline void CpyAllOut(_T* All) const {
                 basefb_t::CpyAllOut(All);
             }
 #endif
-            __host__ __device__ __forceinline void CpyValOut(uint64_t Idx, _T& Val) const {
+            __host__ __device__ inline void CpyValOut(uint64_t Idx, _T& Val) const {
                 basefb_t::CpyValOut(Idx, Val);
             }
-            __host__ __device__ __forceinline void CpyValOut(const vector_t& Coords, _T& Val) const {
+            __host__ __device__ inline void CpyValOut(const vector_t& Coords, _T& Val) const {
                 basefb_t::CpyValOut(Coords, Val);
             }
             template <bool _CopyToHost>
-            __host__ __forceinline void CpyValOut(uint64_t Idx, _T* Val) const {
+            __host__ inline void CpyValOut(uint64_t Idx, _T* Val) const {
                 basefb_t::CpyValOut(Idx, Val);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyValOut(uint64_t Idx, _T* Val) const {
+            __device__ inline void CpyValOut(uint64_t Idx, _T* Val) const {
                 basefb_t::CpyValOut(Idx, Val);
             }
 #endif
             template <bool _CopyToHost>
-            __host__ __forceinline void CpyValOut(const vector_t& Coords, _T* Val) const {
+            __host__ inline void CpyValOut(const vector_t& Coords, _T* Val) const {
                 basefb_t::CpyValOut(Coords, Val);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyValOut(const vector_t& Coords, _T* Val) const {
+            __device__ inline void CpyValOut(const vector_t& Coords, _T* Val) const {
                 basefb_t::CpyValOut(Coords, Val);
             }
 #endif
-            __host__ __device__ __forceinline _T CpyValOut(uint64_t Idx) const {
+            __host__ __device__ inline _T CpyValOut(uint64_t Idx) const {
                 return basefb_t::CpyValOut(Idx);
             }
-            __host__ __device__ __forceinline _T CpyValOut(const vector_t& Coords) const {
+            __host__ __device__ inline _T CpyValOut(const vector_t& Coords) const {
                 return basefb_t::CpyValOut(Coords);
             }
             template <bool _OutputOnHost>
-            __host__ __forceinline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
+            __host__ inline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
                 basefb_t::template CopyBlockOut<_OutputOnHost>(Output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
+            __device__ inline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
                 basefb_t::CopyBlockOut(Output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #endif
-            __forceinline size_t SerializedSize() const requires BSerializer::Serializable<_T> {
+            inline size_t SerializedSize() const requires BSerializer::Serializable<_T> {
                 return basefb_t::SerializedSize();
             }
-            __forceinline void Serialize(void*& Data) const requires BSerializer::Serializable<_T> {
+            inline void Serialize(void*& Data) const requires BSerializer::Serializable<_T> {
                 basefb_t::Serialize(Data);
             }
 #pragma endregion
 
-            __host__ __device__ __forceinline DField<_T, _DimensionCount> Clone() const {
+            __host__ __device__ inline DField<_T, _DimensionCount> Clone() const {
                 return *(DField<_T, _DimensionCount>*)&basefb_t::Clone();
             }
 

--- a/fields_dfield.h
+++ b/fields_dfield.h
@@ -74,31 +74,31 @@ namespace bcuda {
             __host__ __device__ inline size_t SizeOnGPU() const {
                 return basefb_t::SizeOnGPU();
             }
-            __host__ __device__ fields::FieldProxy<_T, _DimensionCount> F() {
+            __host__ __device__ inline fields::FieldProxy<_T, _DimensionCount> F() {
                 return basefb_t::F();
             }
-            __host__ __device__ fields::FieldProxy<_T, _DimensionCount> B() {
+            __host__ __device__ inline fields::FieldProxy<_T, _DimensionCount> B() {
                 return basefb_t::B();
             }
-            __host__ __device__ fields::FieldProxyConst<_T, _DimensionCount> FConst() const {
+            __host__ __device__ inline fields::FieldProxyConst<_T, _DimensionCount> FConst() const {
                 return basefb_t::FConst();
             }
-            __host__ __device__ fields::FieldProxyConst<_T, _DimensionCount> BConst() const {
+            __host__ __device__ inline fields::FieldProxyConst<_T, _DimensionCount> BConst() const {
                 return basefb_t::BConst();
             }
-            __host__ __device__ _T* FData() {
+            __host__ __device__ inline _T* FData() {
                 return basefb_t::FData();
             }
-            __host__ __device__ _T* BData() {
+            __host__ __device__ inline _T* BData() {
                 return basefb_t::BData();
             }
-            __host__ __device__ const _T* FData() const {
+            __host__ __device__ inline const _T* FData() const {
                 return basefb_t::FData();
             }
-            __host__ __device__ const _T* BData() const {
+            __host__ __device__ inline const _T* BData() const {
                 return basefb_t::BData();
             }
-            __host__ __device__ void Reverse() {
+            __host__ __device__ inline void Reverse() {
                 basefb_t::Reverse();
             }
             template <bool _CopyFromHost>
@@ -260,7 +260,7 @@ namespace bcuda {
             using kernelFunc_t = details::dfieldIK_t<_T, _DimensionCount>;
 
 #pragma region Wrapper
-            __host__ __device__ DFieldProxy(const vector_t& Dimensions, _T* ArrF, _T* ArrB)
+            __host__ __device__ inline DFieldProxy(const vector_t& Dimensions, _T* ArrF, _T* ArrB)
                 : basefb_t(Dimensions, ArrF, ArrB) { }
 
             __host__ __device__ inline uint32_t LengthX() const requires (_DimensionCount <= 4) {
@@ -302,22 +302,22 @@ namespace bcuda {
             __host__ __device__ inline size_t SizeOnGPU() const {
                 return basefb_t::SizeOnGPU();
             }
-            __host__ __device__ fields::FieldProxy<_T, _DimensionCount> F() const {
+            __host__ __device__ inline fields::FieldProxy<_T, _DimensionCount> F() const {
                 return basefb_t::F();
             }
-            __host__ __device__ fields::FieldProxy<_T, _DimensionCount> B() const {
+            __host__ __device__ inline fields::FieldProxy<_T, _DimensionCount> B() const {
                 return basefb_t::B();
             }
-            __host__ __device__ fields::FieldProxyConst<_T, _DimensionCount> FConst() const {
+            __host__ __device__ inline fields::FieldProxyConst<_T, _DimensionCount> FConst() const {
                 return basefb_t::FConst();
             }
-            __host__ __device__ fields::FieldProxyConst<_T, _DimensionCount> BConst() const {
+            __host__ __device__ inline fields::FieldProxyConst<_T, _DimensionCount> BConst() const {
                 return basefb_t::BConst();
             }
-            __host__ __device__ _T* FData() const {
+            __host__ __device__ inline _T* FData() const {
                 return basefb_t::FData();
             }
-            __host__ __device__ _T* BData() const {
+            __host__ __device__ inline _T* BData() const {
                 return basefb_t::BData();
             }
             template <bool _CopyFromHost>
@@ -442,7 +442,7 @@ namespace bcuda {
             using vector_t = typename basefb_t::vector_t;
 
 #pragma region Wrapper
-            __host__ __device__ DFieldProxyConst(const vector_t& Dimensions, const _T* ArrF, const _T* ArrB)
+            __host__ __device__ inline DFieldProxyConst(const vector_t& Dimensions, const _T* ArrF, const _T* ArrB)
                 : basefb_t(Dimensions, const_cast<_T*>(ArrF), const_cast<_T*>(ArrB)) { }
 
             __host__ __device__ inline uint32_t LengthX() const requires (_DimensionCount <= 4) {
@@ -484,10 +484,10 @@ namespace bcuda {
             __host__ __device__ inline size_t SizeOnGPU() const {
                 return basefb_t::SizeOnGPU();
             }
-            __host__ __device__ fields::FieldProxyConst<_T, _DimensionCount> FConst() const {
+            __host__ __device__ inline fields::FieldProxyConst<_T, _DimensionCount> FConst() const {
                 return basefb_t::FConst();
             }
-            __host__ __device__ fields::FieldProxyConst<_T, _DimensionCount> BConst() const {
+            __host__ __device__ inline fields::FieldProxyConst<_T, _DimensionCount> BConst() const {
                 return basefb_t::BConst();
             }
             __host__ __device__ const _T* FData() const {
@@ -565,9 +565,9 @@ namespace bcuda {
                 return *(DField<_T, _DimensionCount>*)&basefb_t::Clone();
             }
 
-            __host__ __device__ DFieldProxyConst(const DField<_T, _DimensionCount>& Parent)
+            __host__ __device__ inline DFieldProxyConst(const DField<_T, _DimensionCount>& Parent)
                 : basefb_t(Parent.Dimensions(), Parent.FData(), Parent.BData()) { }
-            __host__ __device__ DFieldProxyConst(const DFieldProxy<_T, _DimensionCount>& Partner)
+            __host__ __device__ inline DFieldProxyConst(const DFieldProxy<_T, _DimensionCount>& Partner)
                 : basefb_t(Partner.Dimensions(), Partner.FData(), Partner.BData()) { }
         };
     }

--- a/fields_field.h
+++ b/fields_field.h
@@ -24,355 +24,355 @@ namespace bcuda {
             using vector_t = typename basedb_t::vector_t;
 
 #pragma region Wrapper
-            __host__ __device__ __forceinline Field(const vector_t& Dimensions)
+            __host__ __device__ inline Field(const vector_t& Dimensions)
                 : basefb_t(Dimensions) { }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __host__ __device__ __forceinline Field(_Ts... Dimensions)
+            __host__ __device__ inline Field(_Ts... Dimensions)
                 : basefb_t(vector_t(Dimensions...)) { }
 
-            __host__ __device__ __forceinline uint32_t LengthX() const requires (_DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthX() const requires (_DimensionCount <= 4) {
                 return basedb_t::LengthX();
             }
-            __host__ __device__ __forceinline uint32_t LengthY() const requires (_DimensionCount >= 2 && _DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthY() const requires (_DimensionCount >= 2 && _DimensionCount <= 4) {
                 return basedb_t::LengthY();
             }
-            __host__ __device__ __forceinline uint32_t LengthZ() const requires (_DimensionCount >= 3 && _DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthZ() const requires (_DimensionCount >= 3 && _DimensionCount <= 4) {
                 return basedb_t::LengthZ();
             }
-            __host__ __device__ __forceinline uint32_t LengthW() const requires (_DimensionCount == 4) {
+            __host__ __device__ inline uint32_t LengthW() const requires (_DimensionCount == 4) {
                 return basedb_t::LengthW();
             }
-            __host__ __device__ __forceinline uint32_t Length(size_t Idx) const {
+            __host__ __device__ inline uint32_t Length(size_t Idx) const {
                 return basedb_t::Length(Idx);
             }
-            __host__ __device__ __forceinline vector_t Dimensions() const {
+            __host__ __device__ inline vector_t Dimensions() const {
                 return basedb_t::Dimensions();
             }
-            __host__ __device__ __forceinline dim3 DimensionsD() const {
+            __host__ __device__ inline dim3 DimensionsD() const {
                 return basedb_t::DimensionsD();
             }
-            __host__ __device__ __forceinline size_t ValueCount() const {
+            __host__ __device__ inline size_t ValueCount() const {
                 return basedb_t::ValueCount();
             }
-            __host__ __device__ __forceinline vector_t IdxToCoords(uint64_t Index) const {
+            __host__ __device__ inline vector_t IdxToCoords(uint64_t Index) const {
                 return basedb_t::IdxToCoords(Index);
             }
-            __host__ __device__ __forceinline uint64_t CoordsToIdx(vector_t Coords) const {
+            __host__ __device__ inline uint64_t CoordsToIdx(vector_t Coords) const {
                 return basedb_t::CoordsToIdx(Coords);
             }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __host__ __device__ __forceinline uint64_t CoordsToIdx(_Ts... Coords) const {
+            __host__ __device__ inline uint64_t CoordsToIdx(_Ts... Coords) const {
                 return basedb_t::CoordsToIdx(vector_t(Coords...));
             }
 
-            __host__ __device__ __forceinline size_t SizeOnGPU() const {
+            __host__ __device__ inline size_t SizeOnGPU() const {
                 return basefb_t::SizeOnGPU();
             }
-            __host__ __device__ __forceinline _T* IdxToPtr(uint64_t Idx) {
+            __host__ __device__ inline _T* IdxToPtr(uint64_t Idx) {
                 return basefb_t::IdxToPtr(Idx);
             }
-            __device__ __forceinline _T& IdxToRef(uint64_t Idx) {
+            __device__ inline _T& IdxToRef(uint64_t Idx) {
                 return basefb_t::IdxToRef(Idx);
             }
-            __host__ __forceinline thrust::device_reference<_T> IdxToDRef(uint64_t Idx) {
+            __host__ inline thrust::device_reference<_T> IdxToDRef(uint64_t Idx) {
                 return basefb_t::IdxToDRef(Idx);
             }
-            __host__ __device__ __forceinline _T* CoordsToPtr(const vector_t& Coords) {
+            __host__ __device__ inline _T* CoordsToPtr(const vector_t& Coords) {
                 return basefb_t::CoordsToPtr(Coords);
             }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __host__ __device__ __forceinline _T* CoordsToPtr(_Ts... Coords) {
+            __host__ __device__ inline _T* CoordsToPtr(_Ts... Coords) {
                 return basefb_t::CoordsToPtr(vector_t(Coords...));
             }
-            __device__ __forceinline _T& CoordsToRef(const vector_t& Coords) {
+            __device__ inline _T& CoordsToRef(const vector_t& Coords) {
                 return basefb_t::CoordsToRef(Coords);
             }
-            __host__ __forceinline thrust::device_reference<_T> CoordsToDRef(const vector_t& Coords) {
+            __host__ inline thrust::device_reference<_T> CoordsToDRef(const vector_t& Coords) {
                 return basefb_t::CoordsToDRef(Coords);
             }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __device__ __forceinline _T& CoordsToRef(_Ts... Coords) {
+            __device__ inline _T& CoordsToRef(_Ts... Coords) {
                 return basefb_t::CoordsToRef(vector_t(Coords...));
             }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __host__ __forceinline thrust::device_reference<_T> CoordsToDRef(_Ts... Coords) {
+            __host__ inline thrust::device_reference<_T> CoordsToDRef(_Ts... Coords) {
                 return basefb_t::CoordsToDRef(vector_t(Coords...));
             }
-            __host__ __device__ __forceinline const _T* IdxToPtr(uint64_t Idx) const {
+            __host__ __device__ inline const _T* IdxToPtr(uint64_t Idx) const {
                 return basefb_t::IdxToPtr(Idx);
             }
-            __device__ __forceinline const _T& IdxToRef(uint64_t Idx) const {
+            __device__ inline const _T& IdxToRef(uint64_t Idx) const {
                 return basefb_t::IdxToRef(Idx);
             }
-            __host__ __forceinline thrust::device_reference<const _T> IdxToDRef(uint64_t Idx) const {
+            __host__ inline thrust::device_reference<const _T> IdxToDRef(uint64_t Idx) const {
                 return basefb_t::IdxToDRef(Idx);
             }
-            __host__ __device__ __forceinline const _T* CoordsToPtr(const vector_t& Coords) const {
+            __host__ __device__ inline const _T* CoordsToPtr(const vector_t& Coords) const {
                 return basefb_t::CoordsToPtr(Coords);
             }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __host__ __device__ __forceinline const _T* CoordsToPtr(_Ts... Coords) const {
+            __host__ __device__ inline const _T* CoordsToPtr(_Ts... Coords) const {
                 return basefb_t::CoordsToPtr(vector_t(Coords...));
             }
-            __device__ __forceinline const _T& CoordsToRef(const vector_t& Coords) const {
+            __device__ inline const _T& CoordsToRef(const vector_t& Coords) const {
                 return basefb_t::CoordsToRef(Coords);
             }
-            __host__ __forceinline thrust::device_reference<const _T> CoordsToDRef(const vector_t& Coords) const {
+            __host__ inline thrust::device_reference<const _T> CoordsToDRef(const vector_t& Coords) const {
                 return basefb_t::CoordsToDRef(Coords);
             }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __device__ __forceinline const _T& CoordsToRef(_Ts... Coords) const {
+            __device__ inline const _T& CoordsToRef(_Ts... Coords) const {
                 return basefb_t::CoordsToRef(vector_t(Coords...));
             }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __host__ __forceinline thrust::device_reference<const _T> CoordsToDRef(_Ts... Coords) const {
+            __host__ inline thrust::device_reference<const _T> CoordsToDRef(_Ts... Coords) const {
                 return basefb_t::CoordsToDRef(vector_t(Coords...));
             }
-            __host__ __device__ __forceinline uint64_t PtrToIdx(const _T* Ptr) const {
+            __host__ __device__ inline uint64_t PtrToIdx(const _T* Ptr) const {
                 return basefb_t::PtrToIdx(Ptr);
             }
-            __host__ __device__ __forceinline vector_t PtrToCoords(const _T* Ptr) const {
+            __host__ __device__ inline vector_t PtrToCoords(const _T* Ptr) const {
                 return basefb_t::PtrToCoords(Ptr);
             }
-            __device__ __forceinline const _T& PtrToRef(const _T* Ptr) const {
+            __device__ inline const _T& PtrToRef(const _T* Ptr) const {
                 return basefb_t::PtrToRef(Ptr);
             }
-            __host__ __forceinline thrust::device_reference<const _T> PtrToDRef(const _T* Ptr) const {
+            __host__ inline thrust::device_reference<const _T> PtrToDRef(const _T* Ptr) const {
                 return basefb_t::PtrToDRef(Ptr);
             }
-            __device__ __forceinline _T& PtrToRef(const _T* Ptr) {
+            __device__ inline _T& PtrToRef(const _T* Ptr) {
                 return basefb_t::PtrToRef(Ptr);
             }
-            __host__ __forceinline thrust::device_reference<_T> PtrToDRef(const _T* Ptr) {
+            __host__ inline thrust::device_reference<_T> PtrToDRef(const _T* Ptr) {
                 return basefb_t::PtrToDRef(Ptr);
             }
-            __host__ __forceinline uint64_t DRefToIdx(thrust::device_reference<_T> Ref) const {
+            __host__ inline uint64_t DRefToIdx(thrust::device_reference<_T> Ref) const {
                 return basefb_t::DRefToIdx(Ref);
             }
-            __host__ __forceinline uint64_t DRefToIdx(thrust::device_reference<const _T> Ref) const {
+            __host__ inline uint64_t DRefToIdx(thrust::device_reference<const _T> Ref) const {
                 return basefb_t::DRefToIdx(Ref);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline uint64_t RefToIdx(const _T& Ref) const {
+            __device__ inline uint64_t RefToIdx(const _T& Ref) const {
                 return basefb_t::RefToIdx(Ref);
             }
 #endif
-            __host__ __forceinline vector_t DRefToCoords(thrust::device_reference<_T> Ref) const {
+            __host__ inline vector_t DRefToCoords(thrust::device_reference<_T> Ref) const {
                 return basefb_t::DRefToCoords(Ref);
             }
-            __host__ __forceinline vector_t DRefToCoords(thrust::device_reference<const _T> Ref) const {
+            __host__ inline vector_t DRefToCoords(thrust::device_reference<const _T> Ref) const {
                 return basefb_t::DRefToCoords(Ref);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline vector_t RefToCoords(const _T& Ref) const {
+            __device__ inline vector_t RefToCoords(const _T& Ref) const {
                 return basefb_t::RefToCoords(Ref);
             }
 #endif
-            __host__ __forceinline const _T* DRefToPtr(thrust::device_reference<_T> Ref) const {
+            __host__ inline const _T* DRefToPtr(thrust::device_reference<_T> Ref) const {
                 return basefb_t::DRefToPtr(Ref);
             }
-            __host__ __forceinline const _T* DRefToPtr(thrust::device_reference<const _T> Ref) const {
-                return basefb_t::DRefToPtr(Ref);
-            }
-#ifdef __CUDACC__
-            __device__ __forceinline const  _T* RefToPtr(const _T& Ref) const {
-                return basefb_t::RefToPtr(Ref);
-            }
-#endif
-            __host__ __forceinline _T* DRefToPtr(thrust::device_reference<_T> Ref) {
-                return basefb_t::DRefToPtr(Ref);
-            }
-            __host__ __forceinline _T* DRefToPtr(thrust::device_reference<const _T> Ref) {
+            __host__ inline const _T* DRefToPtr(thrust::device_reference<const _T> Ref) const {
                 return basefb_t::DRefToPtr(Ref);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline _T* RefToPtr(const _T& Ref) {
+            __device__ inline const  _T* RefToPtr(const _T& Ref) const {
                 return basefb_t::RefToPtr(Ref);
             }
 #endif
-            __device__ __forceinline const _T& operator()(uint64_t Idx) const {
+            __host__ inline _T* DRefToPtr(thrust::device_reference<_T> Ref) {
+                return basefb_t::DRefToPtr(Ref);
+            }
+            __host__ inline _T* DRefToPtr(thrust::device_reference<const _T> Ref) {
+                return basefb_t::DRefToPtr(Ref);
+            }
+#ifdef __CUDACC__
+            __device__ inline _T* RefToPtr(const _T& Ref) {
+                return basefb_t::RefToPtr(Ref);
+            }
+#endif
+            __device__ inline const _T& operator()(uint64_t Idx) const {
                 return IdxToRef(Idx);
             }
-            __device__ __forceinline _T& operator()(uint64_t Idx) {
+            __device__ inline _T& operator()(uint64_t Idx) {
                 return IdxToRef(Idx);
             }
-            __device__ __forceinline const _T& operator()(const vector_t& Coords) const {
+            __device__ inline const _T& operator()(const vector_t& Coords) const {
                 return CoordsToRef(Coords);
             }
-            __device__ __forceinline _T& operator()(const vector_t& Coords) {
+            __device__ inline _T& operator()(const vector_t& Coords) {
                 return CoordsToRef(Coords);
             }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __device__ __forceinline const _T& operator()(_Ts... Coords) const {
+            __device__ inline const _T& operator()(_Ts... Coords) const {
                 return CoordsToRef(vector_t(Coords...));
             }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __device__ __forceinline _T& operator()(_Ts... Coords) {
+            __device__ inline _T& operator()(_Ts... Coords) {
                 return CoordsToRef(vector_t(Coords...));
             }
             template <bool _CopyFromHost>
-            __host__ __forceinline void CpyAllIn(const _T* All) {
+            __host__ inline void CpyAllIn(const _T* All) {
                 basefb_t::template CpyAllIn<_CopyFromHost>(All);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyAllIn(const _T* All) {
+            __device__ inline void CpyAllIn(const _T* All) {
                 basefb_t::CpyAllIn(All);
             }
 #endif
             template <bool _CopyToHost>
-            __host__ __forceinline _T* CpyAllOut() const {
+            __host__ inline _T* CpyAllOut() const {
                 return basefb_t::template CpyAllOut<_CopyToHost>();
             }
 #ifdef __CUDACC__
-            __device__ __forceinline _T* CpyAllOut() const {
+            __device__ inline _T* CpyAllOut() const {
                 return basefb_t::CpyAllOut();
             }
 #endif
             template <bool _CopyToHost>
-            __host__ __device__ __forceinline void CpyAllOut(_T* All) const {
+            __host__ __device__ inline void CpyAllOut(_T* All) const {
                 basefb_t::template CpyAllOut<_CopyToHost>(All);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyAllOut(_T* All) const {
+            __device__ inline void CpyAllOut(_T* All) const {
                 basefb_t::CpyAllOut(All);
             }
 #endif
-            __host__ __device__ __forceinline void CpyValIn(uint64_t Idx, const _T& Val) {
+            __host__ __device__ inline void CpyValIn(uint64_t Idx, const _T& Val) {
                 basefb_t::CpyValIn(Idx, Val);
             }
-            __host__ __device__ __forceinline void CpyValIn(const vector_t& Coords, const _T& Val) {
+            __host__ __device__ inline void CpyValIn(const vector_t& Coords, const _T& Val) {
                 basefb_t::CpyValIn(Coords, Val);
             }
             template <bool _CopyFromHost>
-            __host__ __forceinline void CpyValIn(uint64_t Idx, const _T* Val) {
+            __host__ inline void CpyValIn(uint64_t Idx, const _T* Val) {
                 basefb_t::template CpyValIn<_CopyFromHost>(Idx, Val);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyValIn(uint64_t Idx, const _T* Val) {
+            __device__ inline void CpyValIn(uint64_t Idx, const _T* Val) {
                 basefb_t::CpyValIn(Idx, Val);
             }
 #endif
             template <bool _CopyFromHost>
-            __host__ __forceinline void CpyValIn(const vector_t& Coords, const _T* Val) {
+            __host__ inline void CpyValIn(const vector_t& Coords, const _T* Val) {
                 basefb_t::template CpyValIn<_CopyFromHost>(Coords, Val);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyValIn(const vector_t& Coords, const _T* Val) {
+            __device__ inline void CpyValIn(const vector_t& Coords, const _T* Val) {
                 basefb_t::CpyValIn(Coords, Val);
             }
 #endif
-            __host__ __device__ __forceinline void CpyValOut(uint64_t Idx, _T& Val) const {
+            __host__ __device__ inline void CpyValOut(uint64_t Idx, _T& Val) const {
                 basefb_t::CpyValOut(Idx, Val);
             }
-            __host__ __device__ __forceinline void CpyValOut(const vector_t& Coords, _T& Val) const {
+            __host__ __device__ inline void CpyValOut(const vector_t& Coords, _T& Val) const {
                 basefb_t::CpyValOut(Coords, Val);
             }
             template <bool _CopyToHost>
-            __host__ __forceinline void CpyValOut(uint64_t Idx, _T* Val) const {
+            __host__ inline void CpyValOut(uint64_t Idx, _T* Val) const {
                 basefb_t::template CpyValOut<_CopyToHost>(Idx, Val);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyValOut(uint64_t Idx, _T* Val) const {
+            __device__ inline void CpyValOut(uint64_t Idx, _T* Val) const {
                 basefb_t::CpyValOut(Idx, Val);
             }
 #endif
             template <bool _CopyToHost>
-            __host__ __forceinline void CpyValOut(const vector_t& Coords, _T* Val) const {
+            __host__ inline void CpyValOut(const vector_t& Coords, _T* Val) const {
                 basefb_t::template CpyValOut<_CopyToHost>(Coords, Val);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyValOut(const vector_t& Coords, _T* Val) const {
+            __device__ inline void CpyValOut(const vector_t& Coords, _T* Val) const {
                 basefb_t::CpyValOut(Coords, Val);
             }
 #endif
-            __host__ __device__ __forceinline _T CpyValOut(uint64_t Idx) const {
+            __host__ __device__ inline _T CpyValOut(uint64_t Idx) const {
                 return basefb_t::CpyValOut(Idx);
             }
-            __host__ __device__ __forceinline _T CpyValOut(const vector_t& Coords) const {
+            __host__ __device__ inline _T CpyValOut(const vector_t& Coords) const {
                 return basefb_t::CpyValOut(Coords);
             }
-            __host__ __device__ __forceinline _T* Data() {
+            __host__ __device__ inline _T* Data() {
                 return basefb_t::Data();
             }
-            __host__ __device__ __forceinline const _T* Data() const {
+            __host__ __device__ inline const _T* Data() const {
                 return basefb_t::Data();
             }
             template <bool _InputOnHost>
-            __host__ __forceinline void CopyBlockIn(const _T* Input, const vector_t& InputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) {
+            __host__ inline void CopyBlockIn(const _T* Input, const vector_t& InputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) {
                 basefb_t::template CopyBlockIn<_InputOnHost>(Input, InputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CopyBlockIn(const _T* Input, const vector_t& InputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) {
+            __device__ inline void CopyBlockIn(const _T* Input, const vector_t& InputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) {
                 basefb_t::CopyBlockIn(Input, InputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #endif
             template <bool _OutputOnHost>
-            __host__ __forceinline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
+            __host__ inline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
                 basefb_t::template CopyBlockOut<_OutputOnHost>(Output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
+            __device__ inline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
                 basefb_t::CopyBlockOut(Output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #endif
-            __forceinline size_t SerializedSize() const requires BSerializer::Serializable<_T> {
+            inline size_t SerializedSize() const requires BSerializer::Serializable<_T> {
                 return basefb_t::SerializedSize();
             }
-            __forceinline void Serialize(void*& Data) const requires BSerializer::Serializable<_T> {
+            inline void Serialize(void*& Data) const requires BSerializer::Serializable<_T> {
                 basefb_t::Serialize(Data);
             }
 #pragma endregion
 
-            __host__ __device__ __forceinline Field(const vector_t& Dimensions, const _T* All)
+            __host__ __device__ inline Field(const vector_t& Dimensions, const _T* All)
                 : basefb_t(Dimensions) {
                 CpyAllIn(All);
             }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __host__ __device__ __forceinline Field(_Ts... Dimensions, const _T* All)
+            __host__ __device__ inline Field(_Ts... Dimensions, const _T* All)
                 : Field(vector_t(Dimensions...), All) { }
 
-            static __forceinline this_t Deserialize(const void*& Data) requires BSerializer::Serializable<_T> {
+            static inline this_t Deserialize(const void*& Data) requires BSerializer::Serializable<_T> {
                 return *(this_t*)&basefb_t::Deserialize(Data);
             }
-            static __forceinline this_t Deserialize(const void*& Data, void* Value) requires BSerializer::Serializable<_T> {
+            static inline this_t Deserialize(const void*& Data, void* Value) requires BSerializer::Serializable<_T> {
                 basefb_t::Deserialize(Data, Value);
             }
 
-            __host__ __device__ __forceinline Field(const this_t& Other)
+            __host__ __device__ inline Field(const this_t& Other)
                 : Field(Other.Dimensions(), Other.Data()) { }
-            __host__ __device__ __forceinline Field(this_t&& Other)
+            __host__ __device__ inline Field(this_t&& Other)
                 : basefb_t(Other.Dimensions(), Other.Data()) {
                 new (&Other) basefb_t(this->Dimensions(), 0);
             }
-            __host__ __device__ __forceinline ~Field() {
+            __host__ __device__ inline ~Field() {
                 basefb_t::Dispose();
             }
-            __host__ __device__ __forceinline this_t& operator=(const this_t& Other) {
+            __host__ __device__ inline this_t& operator=(const this_t& Other) {
                 this->~Field();
                 new (this) Field(Other);
                 return *this;
             }
-            __host__ __device__ __forceinline this_t& operator=(this_t&& Other) {
+            __host__ __device__ inline this_t& operator=(this_t&& Other) {
                 this->~Field();
                 new (this) Field(Other);
                 return *this;
             }
 
-            __host__ __device__ __forceinline FieldProxy<_T, _DimensionCount> MakeProxy() {
+            __host__ __device__ inline FieldProxy<_T, _DimensionCount> MakeProxy() {
                 return FieldProxy<_T, _DimensionCount>(*this);
             }
-            __host__ __device__ __forceinline FieldProxyConst<_T, _DimensionCount> MakeConstProxy() const {
+            __host__ __device__ inline FieldProxyConst<_T, _DimensionCount> MakeConstProxy() const {
                 return FieldProxyConst<_T, _DimensionCount>(*this);
             }
         };
@@ -385,259 +385,259 @@ namespace bcuda {
             using vector_t = typename basedb_t::vector_t;
 
 #pragma region Wrapper
-            __host__ __device__ __forceinline FieldProxy(const vector_t& Dimensions, _T* All)
+            __host__ __device__ inline FieldProxy(const vector_t& Dimensions, _T* All)
                 : basefb_t(Dimensions, All) { }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __host__ __device__ __forceinline FieldProxy(_Ts... Dimensions, _T* All)
+            __host__ __device__ inline FieldProxy(_Ts... Dimensions, _T* All)
                 : basefb_t(vector_t(Dimensions...), All) { }
 
-            __host__ __device__ __forceinline uint32_t LengthX() const requires (_DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthX() const requires (_DimensionCount <= 4) {
                 return basedb_t::LengthX();
             }
-            __host__ __device__ __forceinline uint32_t LengthY() const requires (_DimensionCount >= 2 && _DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthY() const requires (_DimensionCount >= 2 && _DimensionCount <= 4) {
                 return basedb_t::LengthY();
             }
-            __host__ __device__ __forceinline uint32_t LengthZ() const requires (_DimensionCount >= 3 && _DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthZ() const requires (_DimensionCount >= 3 && _DimensionCount <= 4) {
                 return basedb_t::LengthZ();
             }
-            __host__ __device__ __forceinline uint32_t LengthW() const requires (_DimensionCount == 4) {
+            __host__ __device__ inline uint32_t LengthW() const requires (_DimensionCount == 4) {
                 return basedb_t::LengthW();
             }
-            __host__ __device__ __forceinline uint32_t Length(size_t Idx) const {
+            __host__ __device__ inline uint32_t Length(size_t Idx) const {
                 return basedb_t::Length(Idx);
             }
-            __host__ __device__ __forceinline vector_t Dimensions() const {
+            __host__ __device__ inline vector_t Dimensions() const {
                 return basedb_t::Dimensions();
             }
-            __host__ __device__ __forceinline dim3 DimensionsD() const {
+            __host__ __device__ inline dim3 DimensionsD() const {
                 return basedb_t::DimensionsD();
             }
-            __host__ __device__ __forceinline size_t ValueCount() const {
+            __host__ __device__ inline size_t ValueCount() const {
                 return basedb_t::ValueCount();
             }
-            __host__ __device__ __forceinline vector_t IdxToCoords(uint64_t Index) const {
+            __host__ __device__ inline vector_t IdxToCoords(uint64_t Index) const {
                 return basedb_t::IdxToCoords(Index);
             }
-            __host__ __device__ __forceinline uint64_t CoordsToIdx(vector_t Coords) const {
+            __host__ __device__ inline uint64_t CoordsToIdx(vector_t Coords) const {
                 return basedb_t::CoordsToIdx(Coords);
             }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __host__ __device__ __forceinline uint64_t CoordsToIdx(_Ts... Coords) const {
+            __host__ __device__ inline uint64_t CoordsToIdx(_Ts... Coords) const {
                 return basedb_t::CoordsToIdx(vector_t(Coords...));
             }
 
-            __host__ __device__ __forceinline size_t SizeOnGPU() const {
+            __host__ __device__ inline size_t SizeOnGPU() const {
                 return basefb_t::SizeOnGPU();
             }
-            __host__ __device__ __forceinline _T* IdxToPtr(uint64_t Idx) const {
+            __host__ __device__ inline _T* IdxToPtr(uint64_t Idx) const {
                 return basefb_t::IdxToPtr(Idx);
             }
-            __device__ __forceinline _T& IdxToRef(uint64_t Idx) const {
+            __device__ inline _T& IdxToRef(uint64_t Idx) const {
                 return basefb_t::IdxToRef(Idx);
             }
-            __host__ __forceinline thrust::device_reference<_T> IdxToDRef(uint64_t Idx) const {
+            __host__ inline thrust::device_reference<_T> IdxToDRef(uint64_t Idx) const {
                 return basefb_t::IdxToDRef(Idx);
             }
-            __host__ __device__ __forceinline _T* CoordsToPtr(const vector_t& Coords) const {
+            __host__ __device__ inline _T* CoordsToPtr(const vector_t& Coords) const {
                 return basefb_t::CoordsToPtr(Coords);
             }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __host__ __device__ __forceinline _T* CoordsToPtr(_Ts... Coords) const {
+            __host__ __device__ inline _T* CoordsToPtr(_Ts... Coords) const {
                 return basefb_t::CoordsToPtr(vector_t(Coords...));
             }
-            __device__ __forceinline _T& CoordsToRef(const vector_t& Coords) const {
+            __device__ inline _T& CoordsToRef(const vector_t& Coords) const {
                 return basefb_t::CoordsToRef(Coords);
             }
-            __host__ __forceinline thrust::device_reference<_T> CoordsToDRef(const vector_t& Coords) const {
+            __host__ inline thrust::device_reference<_T> CoordsToDRef(const vector_t& Coords) const {
                 return basefb_t::CoordsToDRef(Coords);
             }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __device__ __forceinline _T& CoordsToRef(_Ts... Coords) const {
+            __device__ inline _T& CoordsToRef(_Ts... Coords) const {
                 return basefb_t::CoordsToRef(vector_t(Coords...));
             }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __host__ __forceinline thrust::device_reference<_T> CoordsToDRef(_Ts... Coords) const {
+            __host__ inline thrust::device_reference<_T> CoordsToDRef(_Ts... Coords) const {
                 return basefb_t::CoordsToDRef(vector_t(Coords...));
             }
-            __host__ __device__ __forceinline uint64_t PtrToIdx(const _T* Ptr) const {
+            __host__ __device__ inline uint64_t PtrToIdx(const _T* Ptr) const {
                 return basefb_t::PtrToIdx(Ptr);
             }
-            __host__ __device__ __forceinline vector_t PtrToCoords(const _T* Ptr) const {
+            __host__ __device__ inline vector_t PtrToCoords(const _T* Ptr) const {
                 return basefb_t::PtrToCoords(Ptr);
             }
-            __device__ __forceinline _T& PtrToRef(const _T* Ptr) const {
+            __device__ inline _T& PtrToRef(const _T* Ptr) const {
                 return basefb_t::PtrToRef(Ptr);
             }
-            __host__ __forceinline thrust::device_reference<_T> PtrToDRef(const _T* Ptr) const {
+            __host__ inline thrust::device_reference<_T> PtrToDRef(const _T* Ptr) const {
                 return basefb_t::PtrToDRef(Ptr);
             }
-            __host__ __forceinline uint64_t DRefToIdx(thrust::device_reference<_T> Ref) const {
+            __host__ inline uint64_t DRefToIdx(thrust::device_reference<_T> Ref) const {
                 return basefb_t::DRefToIdx(Ref);
             }
-            __host__ __forceinline uint64_t DRefToIdx(thrust::device_reference<const _T> Ref) const {
+            __host__ inline uint64_t DRefToIdx(thrust::device_reference<const _T> Ref) const {
                 return basefb_t::DRefToIdx(Ref);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline uint64_t RefToIdx(const _T& Ref) const {
+            __device__ inline uint64_t RefToIdx(const _T& Ref) const {
                 return basefb_t::RefToIdx(Ref);
             }
 #endif
-            __host__ __forceinline vector_t DRefToCoords(thrust::device_reference<_T> Ref) const {
+            __host__ inline vector_t DRefToCoords(thrust::device_reference<_T> Ref) const {
                 return basefb_t::DRefToCoords(Ref);
             }
-            __host__ __forceinline vector_t DRefToCoords(thrust::device_reference<const _T> Ref) const {
+            __host__ inline vector_t DRefToCoords(thrust::device_reference<const _T> Ref) const {
                 return basefb_t::DRefToCoords(Ref);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline vector_t RefToCoords(const _T& Ref) const {
+            __device__ inline vector_t RefToCoords(const _T& Ref) const {
                 return basefb_t::RefToCoords(Ref);
             }
 #endif
-            __host__ __forceinline _T* DRefToPtr(thrust::device_reference<_T> Ref) const {
+            __host__ inline _T* DRefToPtr(thrust::device_reference<_T> Ref) const {
                 return basefb_t::DRefToPtr(Ref);
             }
-            __host__ __forceinline _T* DRefToPtr(thrust::device_reference<const _T> Ref) const {
+            __host__ inline _T* DRefToPtr(thrust::device_reference<const _T> Ref) const {
                 return basefb_t::DRefToPtr(Ref);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline _T* RefToPtr(const _T& Ref) const {
+            __device__ inline _T* RefToPtr(const _T& Ref) const {
                 return basefb_t::RefToPtr(Ref);
             }
 #endif
-            __device__ __forceinline _T& operator()(uint64_t Idx) const {
+            __device__ inline _T& operator()(uint64_t Idx) const {
                 return IdxToRef(Idx);
             }
-            __device__ __forceinline _T& operator()(const vector_t& Coords) const {
+            __device__ inline _T& operator()(const vector_t& Coords) const {
                 return CoordsToRef(Coords);
             }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __device__ __forceinline _T& operator()(_Ts... Coords) const {
+            __device__ inline _T& operator()(_Ts... Coords) const {
                 return CoordsToRef(vector_t(Coords...));
             }
             template <bool _CopyFromHost>
-            __host__ __forceinline void CpyAllIn(const _T* All) const {
+            __host__ inline void CpyAllIn(const _T* All) const {
                 basefb_t::template CpyAllIn<_CopyFromHost>(All);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyAllIn(const _T* All) const {
+            __device__ inline void CpyAllIn(const _T* All) const {
                 basefb_t::CpyAllIn(All);
             }
 #endif
             template <bool _CopyToHost>
-            __host__ __forceinline _T* CpyAllOut() const {
+            __host__ inline _T* CpyAllOut() const {
                 return basefb_t::template CpyAllOut<_CopyToHost>();
             }
 #ifdef __CUDACC__
-            __device__ __forceinline _T* CpyAllOut() const {
+            __device__ inline _T* CpyAllOut() const {
                 return basefb_t::CpyAllOut();
             }
 #endif
             template <bool _CopyToHost>
-            __host__ __device__ __forceinline void CpyAllOut(_T* All) const {
+            __host__ __device__ inline void CpyAllOut(_T* All) const {
                 basefb_t::template CpyAllOut<_CopyToHost>(All);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyAllOut(_T* All) const {
+            __device__ inline void CpyAllOut(_T* All) const {
                 basefb_t::CpyAllOut(All);
             }
 #endif
-            __host__ __device__ __forceinline void CpyValIn(uint64_t Idx, const _T& Val) const {
+            __host__ __device__ inline void CpyValIn(uint64_t Idx, const _T& Val) const {
                 basefb_t::CpyValIn(Idx, Val);
             }
-            __host__ __device__ __forceinline void CpyValIn(const vector_t& Coords, const _T& Val) const {
+            __host__ __device__ inline void CpyValIn(const vector_t& Coords, const _T& Val) const {
                 basefb_t::CpyValIn(Coords, Val);
             }
             template <bool _CopyFromHost>
-            __host__ __forceinline void CpyValIn(uint64_t Idx, const _T* Val) const {
+            __host__ inline void CpyValIn(uint64_t Idx, const _T* Val) const {
                 basefb_t::template CpyValIn<_CopyFromHost>(Idx, Val);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyValIn(uint64_t Idx, const _T* Val) const {
+            __device__ inline void CpyValIn(uint64_t Idx, const _T* Val) const {
                 basefb_t::CpyValIn(Idx, Val);
             }
 #endif
             template <bool _CopyFromHost>
-            __host__ __forceinline void CpyValIn(const vector_t& Coords, const _T* Val) const {
+            __host__ inline void CpyValIn(const vector_t& Coords, const _T* Val) const {
                 basefb_t::template CpyValIn<_CopyFromHost>(Coords, Val);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyValIn(const vector_t& Coords, const _T* Val) const {
+            __device__ inline void CpyValIn(const vector_t& Coords, const _T* Val) const {
                 basefb_t::CpyValIn(Coords, Val);
             }
 #endif
-            __host__ __device__ __forceinline void CpyValOut(uint64_t Idx, _T& Val) const {
+            __host__ __device__ inline void CpyValOut(uint64_t Idx, _T& Val) const {
                 basefb_t::CpyValOut(Idx, Val);
             }
-            __host__ __device__ __forceinline void CpyValOut(const vector_t& Coords, _T& Val) const {
+            __host__ __device__ inline void CpyValOut(const vector_t& Coords, _T& Val) const {
                 basefb_t::CpyValOut(Coords, Val);
             }
             template <bool _CopyToHost>
-            __host__ __forceinline void CpyValOut(uint64_t Idx, _T* Val) const {
+            __host__ inline void CpyValOut(uint64_t Idx, _T* Val) const {
                 basefb_t::template CpyValOut<_CopyToHost>(Idx, Val);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyValOut(uint64_t Idx, _T* Val) const {
+            __device__ inline void CpyValOut(uint64_t Idx, _T* Val) const {
                 basefb_t::CpyValOut(Idx, Val);
             }
 #endif
             template <bool _CopyToHost>
-            __host__ __forceinline void CpyValOut(const vector_t& Coords, _T* Val) const {
+            __host__ inline void CpyValOut(const vector_t& Coords, _T* Val) const {
                 basefb_t::CpyValOut(Coords, Val);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyValOut(const vector_t& Coords, _T* Val) const {
+            __device__ inline void CpyValOut(const vector_t& Coords, _T* Val) const {
                 basefb_t::CpyValOut(Coords, Val);
             }
 #endif
-            __host__ __device__ __forceinline _T CpyValOut(uint64_t Idx) const {
+            __host__ __device__ inline _T CpyValOut(uint64_t Idx) const {
                 return basefb_t::CpyValOut(Idx);
             }
-            __host__ __device__ __forceinline _T CpyValOut(const vector_t& Coords) const {
+            __host__ __device__ inline _T CpyValOut(const vector_t& Coords) const {
                 return basefb_t::CpyValOut(Coords);
             }
-            __host__ __device__ __forceinline _T* Data() const {
+            __host__ __device__ inline _T* Data() const {
                 return basefb_t::Data();
             }
             template <bool _InputOnHost>
-            __host__ __forceinline void CopyBlockIn(const _T* Input, const vector_t& InputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
+            __host__ inline void CopyBlockIn(const _T* Input, const vector_t& InputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
                 basefb_t::template CopyBlockIn<_InputOnHost>(Input, InputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CopyBlockIn(const _T* Input, const vector_t& InputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
+            __device__ inline void CopyBlockIn(const _T* Input, const vector_t& InputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
                 basefb_t::CopyBlockIn(Input, InputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #endif
             template <bool _OutputOnHost>
-            __host__ __forceinline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
+            __host__ inline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
                 basefb_t::template CopyBlockOut<_OutputOnHost>(Output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
+            __device__ inline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
                 basefb_t::CopyBlockOut(Output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #endif
-            __forceinline size_t SerializedSize() const requires BSerializer::Serializable<_T> {
+            inline size_t SerializedSize() const requires BSerializer::Serializable<_T> {
                 return basefb_t::SerializedSize();
             }
-            __forceinline void Serialize(void*& Data) const requires BSerializer::Serializable<_T> {
+            inline void Serialize(void*& Data) const requires BSerializer::Serializable<_T> {
                 basefb_t::Serialize(Data);
             }
 #pragma endregion
 
-            __host__ __device__ __forceinline Field<_T, _DimensionCount> Clone() const {
+            __host__ __device__ inline Field<_T, _DimensionCount> Clone() const {
                 return *(Field<_T, _DimensionCount>*)basefb_t::Clone();
             }
 
             __host__ __device__ FieldProxy(Field<_T, _DimensionCount>& Parent)
                 : FieldProxy(Parent.Dimensions(), Parent.Data()) { }
 
-            __host__ __device__ __forceinline FieldProxyConst<_T, _DimensionCount> MakeConstProxy() const {
+            __host__ __device__ inline FieldProxyConst<_T, _DimensionCount> MakeConstProxy() const {
                 return FieldProxyConst<_T, _DimensionCount>(*this);
             }
         };
@@ -650,210 +650,210 @@ namespace bcuda {
             using vector_t = typename basedb_t::vector_t;
 
 #pragma region Wrapper
-            __host__ __device__ __forceinline FieldProxyConst(const vector_t& Dimensions, const _T* All)
+            __host__ __device__ inline FieldProxyConst(const vector_t& Dimensions, const _T* All)
                 : basefb_t(Dimensions, const_cast<_T*>(All)) { }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __host__ __device__ __forceinline FieldProxyConst(_Ts... Dimensions, const _T* All)
+            __host__ __device__ inline FieldProxyConst(_Ts... Dimensions, const _T* All)
                 : basefb_t(vector_t(Dimensions...), const_cast<_T*>(All)) { }
 
-            __host__ __device__ __forceinline uint32_t LengthX() const requires (_DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthX() const requires (_DimensionCount <= 4) {
                 return basedb_t::LengthX();
             }
-            __host__ __device__ __forceinline uint32_t LengthY() const requires (_DimensionCount >= 2 && _DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthY() const requires (_DimensionCount >= 2 && _DimensionCount <= 4) {
                 return basedb_t::LengthY();
             }
-            __host__ __device__ __forceinline uint32_t LengthZ() const requires (_DimensionCount >= 3 && _DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthZ() const requires (_DimensionCount >= 3 && _DimensionCount <= 4) {
                 return basedb_t::LengthZ();
             }
-            __host__ __device__ __forceinline uint32_t LengthW() const requires (_DimensionCount == 4) {
+            __host__ __device__ inline uint32_t LengthW() const requires (_DimensionCount == 4) {
                 return basedb_t::LengthW();
             }
-            __host__ __device__ __forceinline uint32_t Length(size_t Idx) const {
+            __host__ __device__ inline uint32_t Length(size_t Idx) const {
                 return basedb_t::Length(Idx);
             }
-            __host__ __device__ __forceinline vector_t Dimensions() const {
+            __host__ __device__ inline vector_t Dimensions() const {
                 return basedb_t::Dimensions();
             }
-            __host__ __device__ __forceinline dim3 DimensionsD() const {
+            __host__ __device__ inline dim3 DimensionsD() const {
                 return basedb_t::DimensionsD();
             }
-            __host__ __device__ __forceinline size_t ValueCount() const {
+            __host__ __device__ inline size_t ValueCount() const {
                 return basedb_t::ValueCount();
             }
-            __host__ __device__ __forceinline vector_t IdxToCoords(uint64_t Index) const {
+            __host__ __device__ inline vector_t IdxToCoords(uint64_t Index) const {
                 return basedb_t::IdxToCoords(Index);
             }
-            __host__ __device__ __forceinline uint64_t CoordsToIdx(vector_t Coords) const {
+            __host__ __device__ inline uint64_t CoordsToIdx(vector_t Coords) const {
                 return basedb_t::CoordsToIdx(Coords);
             }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __host__ __device__ __forceinline uint64_t CoordsToIdx(_Ts... Coords) const {
+            __host__ __device__ inline uint64_t CoordsToIdx(_Ts... Coords) const {
                 return basedb_t::CoordsToIdx(vector_t(Coords...));
             }
 
-            __host__ __device__ __forceinline size_t SizeOnGPU() const {
+            __host__ __device__ inline size_t SizeOnGPU() const {
                 return basefb_t::SizeOnGPU();
             }
-            __host__ __device__ __forceinline const _T* IdxToPtr(uint64_t Idx) const {
+            __host__ __device__ inline const _T* IdxToPtr(uint64_t Idx) const {
                 return basefb_t::IdxToPtr(Idx);
             }
-            __device__ __forceinline const _T& IdxToRef(uint64_t Idx) const {
+            __device__ inline const _T& IdxToRef(uint64_t Idx) const {
                 return basefb_t::IdxToRef(Idx);
             }
-            __host__ __forceinline thrust::device_reference<const _T> IdxToDRef(uint64_t Idx) const {
+            __host__ inline thrust::device_reference<const _T> IdxToDRef(uint64_t Idx) const {
                 return basefb_t::IdxToDRef(Idx);
             }
-            __host__ __device__ __forceinline const _T* CoordsToPtr(const vector_t& Coords) const {
+            __host__ __device__ inline const _T* CoordsToPtr(const vector_t& Coords) const {
                 return basefb_t::CoordsToPtr(Coords);
             }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __host__ __device__ __forceinline const _T* CoordsToPtr(_Ts... Coords) const {
+            __host__ __device__ inline const _T* CoordsToPtr(_Ts... Coords) const {
                 return basefb_t::CoordsToPtr(vector_t(Coords...));
             }
-            __device__ __forceinline const _T& CoordsToRef(const vector_t& Coords) const {
+            __device__ inline const _T& CoordsToRef(const vector_t& Coords) const {
                 return basefb_t::CoordsToRef(Coords);
             }
-            __host__ __forceinline thrust::device_reference<const _T> CoordsToDRef(const vector_t& Coords) const {
+            __host__ inline thrust::device_reference<const _T> CoordsToDRef(const vector_t& Coords) const {
                 return basefb_t::CoordsToDRef(Coords);
             }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __device__ __forceinline const _T& CoordsToRef(_Ts... Coords) const {
+            __device__ inline const _T& CoordsToRef(_Ts... Coords) const {
                 return basefb_t::CoordsToRef(vector_t(Coords...));
             }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __host__ __forceinline thrust::device_reference<const _T> CoordsToDRef(_Ts... Coords) const {
+            __host__ inline thrust::device_reference<const _T> CoordsToDRef(_Ts... Coords) const {
                 return basefb_t::CoordsToDRef(vector_t(Coords...));
             }
-            __host__ __device__ __forceinline uint64_t PtrToIdx(const _T* Ptr) const {
+            __host__ __device__ inline uint64_t PtrToIdx(const _T* Ptr) const {
                 return basefb_t::PtrToIdx(Ptr);
             }
-            __host__ __device__ __forceinline vector_t PtrToCoords(const _T* Ptr) const {
+            __host__ __device__ inline vector_t PtrToCoords(const _T* Ptr) const {
                 return basefb_t::PtrToCoords(Ptr);
             }
-            __device__ __forceinline const _T& PtrToRef(const _T* Ptr) const {
+            __device__ inline const _T& PtrToRef(const _T* Ptr) const {
                 return basefb_t::PtrToRef(Ptr);
             }
-            __host__ __forceinline thrust::device_reference<const _T> PtrToDRef(const _T* Ptr) const {
+            __host__ inline thrust::device_reference<const _T> PtrToDRef(const _T* Ptr) const {
                 return basefb_t::PtrToDRef(Ptr);
             }
-            __host__ __forceinline uint64_t DRefToIdx(thrust::device_reference<_T> Ref) const {
+            __host__ inline uint64_t DRefToIdx(thrust::device_reference<_T> Ref) const {
                 return basefb_t::DRefToIdx(Ref);
             }
-            __host__ __forceinline uint64_t DRefToIdx(thrust::device_reference<const _T> Ref) const {
+            __host__ inline uint64_t DRefToIdx(thrust::device_reference<const _T> Ref) const {
                 return basefb_t::DRefToIdx(Ref);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline uint64_t RefToIdx(const _T& Ref) const {
+            __device__ inline uint64_t RefToIdx(const _T& Ref) const {
                 return basefb_t::RefToIdx(Ref);
             }
 #endif
-            __host__ __forceinline vector_t DRefToCoords(thrust::device_reference<_T> Ref) const {
+            __host__ inline vector_t DRefToCoords(thrust::device_reference<_T> Ref) const {
                 return basefb_t::DRefToCoords(Ref);
             }
-            __host__ __forceinline vector_t DRefToCoords(thrust::device_reference<const _T> Ref) const {
+            __host__ inline vector_t DRefToCoords(thrust::device_reference<const _T> Ref) const {
                 return basefb_t::DRefToCoords(Ref);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline vector_t RefToCoords(const _T& Ref) const {
+            __device__ inline vector_t RefToCoords(const _T& Ref) const {
                 return basefb_t::RefToCoords(Ref);
             }
 #endif
-            __host__ __forceinline const _T* DRefToPtr(thrust::device_reference<_T> Ref) const {
+            __host__ inline const _T* DRefToPtr(thrust::device_reference<_T> Ref) const {
                 return basefb_t::DRefToPtr(Ref);
             }
-            __host__ __forceinline const _T* DRefToPtr(thrust::device_reference<const _T> Ref) const {
+            __host__ inline const _T* DRefToPtr(thrust::device_reference<const _T> Ref) const {
                 return basefb_t::DRefToPtr(Ref);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline const  _T* RefToPtr(const _T& Ref) const {
+            __device__ inline const  _T* RefToPtr(const _T& Ref) const {
                 return basefb_t::RefToPtr(Ref);
             }
 #endif
-            __device__ __forceinline const _T& operator()(uint64_t Idx) const {
+            __device__ inline const _T& operator()(uint64_t Idx) const {
                 return IdxToRef(Idx);
             }
-            __device__ __forceinline const _T& operator()(const vector_t& Coords) const {
+            __device__ inline const _T& operator()(const vector_t& Coords) const {
                 return CoordsToRef(Coords);
             }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __device__ __forceinline const _T& operator()(_Ts... Coords) const {
+            __device__ inline const _T& operator()(_Ts... Coords) const {
                 return CoordsToRef(vector_t(Coords...));
             }
             template <bool _CopyToHost>
-            __host__ __forceinline _T* CpyAllOut() const {
+            __host__ inline _T* CpyAllOut() const {
                 return basefb_t::template CpyAllOut<_CopyToHost>();
             }
 #ifdef __CUDACC__
-            __device__ __forceinline _T* CpyAllOut() const {
+            __device__ inline _T* CpyAllOut() const {
                 return basefb_t::CpyAllOut();
             }
 #endif
             template <bool _CopyToHost>
-            __host__ __device__ __forceinline void CpyAllOut(_T* All) const {
+            __host__ __device__ inline void CpyAllOut(_T* All) const {
                 basefb_t::template CpyAllOut<_CopyToHost>(All);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyAllOut(_T* All) const {
+            __device__ inline void CpyAllOut(_T* All) const {
                 basefb_t::CpyAllOut(All);
             }
 #endif
-            __host__ __device__ __forceinline void CpyValOut(uint64_t Idx, _T& Val) const {
+            __host__ __device__ inline void CpyValOut(uint64_t Idx, _T& Val) const {
                 basefb_t::CpyValOut(Idx, Val);
             }
-            __host__ __device__ __forceinline void CpyValOut(const vector_t& Coords, _T& Val) const {
+            __host__ __device__ inline void CpyValOut(const vector_t& Coords, _T& Val) const {
                 basefb_t::CpyValOut(Coords, Val);
             }
             template <bool _CopyToHost>
-            __host__ __forceinline void CpyValOut(uint64_t Idx, _T* Val) const {
+            __host__ inline void CpyValOut(uint64_t Idx, _T* Val) const {
                 basefb_t::template CpyValOut<_CopyToHost>(Idx, Val);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyValOut(uint64_t Idx, _T* Val) const {
+            __device__ inline void CpyValOut(uint64_t Idx, _T* Val) const {
                 basefb_t::CpyValOut(Idx, Val);
             }
 #endif
             template <bool _CopyToHost>
-            __host__ __forceinline void CpyValOut(const vector_t& Coords, _T* Val) const {
+            __host__ inline void CpyValOut(const vector_t& Coords, _T* Val) const {
                 basefb_t::template CpyValOut<_CopyToHost>(Coords, Val);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CpyValOut(const vector_t& Coords, _T* Val) const {
+            __device__ inline void CpyValOut(const vector_t& Coords, _T* Val) const {
                 basefb_t::CpyValOut(Coords, Val);
             }
 #endif
-            __host__ __device__ __forceinline _T CpyValOut(uint64_t Idx) const {
+            __host__ __device__ inline _T CpyValOut(uint64_t Idx) const {
                 return basefb_t::CpyValOut(Idx);
             }
-            __host__ __device__ __forceinline _T CpyValOut(const vector_t& Coords) const {
+            __host__ __device__ inline _T CpyValOut(const vector_t& Coords) const {
                 return basefb_t::CpyValOut(Coords);
             }
-            __host__ __device__ __forceinline const _T* Data() const {
+            __host__ __device__ inline const _T* Data() const {
                 return basefb_t::Data();
             }
             template <bool _OutputOnHost>
-            __host__ __forceinline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
+            __host__ inline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
                 basefb_t::template CopyBlockOut<_OutputOnHost>(Output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #ifdef __CUDACC__
-            __device__ __forceinline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
+            __device__ inline void CopyBlockOut(_T* Output, const vector_t& OutputDimensions, const vector_t& RangeDimensions, const vector_t& RangeInInputsCoordinates, const vector_t& RangeInOutputsCoordinates) const {
                 basefb_t::CopyBlockOut(Output, OutputDimensions, RangeDimensions, RangeInInputsCoordinates, RangeInOutputsCoordinates);
             }
 #endif
-            __forceinline size_t SerializedSize() const requires BSerializer::Serializable<_T> {
+            inline size_t SerializedSize() const requires BSerializer::Serializable<_T> {
                 return basefb_t::SerializedSize();
             }
-            __forceinline void Serialize(void*& Data) const requires BSerializer::Serializable<_T> {
+            inline void Serialize(void*& Data) const requires BSerializer::Serializable<_T> {
                 basefb_t::Serialize(Data);
             }
 #pragma endregion
 
-            __host__ __device__ __forceinline Field<_T, _DimensionCount> Clone() const {
+            __host__ __device__ inline Field<_T, _DimensionCount> Clone() const {
                 return *(Field<_T, _DimensionCount>*)basefb_t::Clone();
             }
 

--- a/fields_field.h
+++ b/fields_field.h
@@ -857,9 +857,9 @@ namespace bcuda {
                 return *(Field<_T, _DimensionCount>*)basefb_t::Clone();
             }
 
-            __host__ __device__ FieldProxyConst(const Field<_T, _DimensionCount>& Parent)
+            __host__ __device__ inline FieldProxyConst(const Field<_T, _DimensionCount>& Parent)
                 : basefb_t(Parent.Dimensions(), Parent.Data()) { }
-            __host__ __device__ FieldProxyConst(const FieldProxy<_T, _DimensionCount>& Partner)
+            __host__ __device__ inline FieldProxyConst(const FieldProxy<_T, _DimensionCount>& Partner)
                 : basefb_t(Partner.Dimensions(), Partner.Data()) { }
         };
     }

--- a/fields_instance.h
+++ b/fields_instance.h
@@ -36,124 +36,108 @@ namespace bcuda {
         using fieldInstance_assignInput_t = void(*)(_TFieldValue& FieldValue, const _TInput& InputValue);
 
         template <typename _T, size_t _DimensionCount, fieldInstance_createField_t<_T, _DimensionCount> _CreateField>
-        void* FieldInstance_Construct(void* Object, void* Settings);
+        void* FieldInstance_Construct(void* Object, void* Settings) {
+            FieldInstance_Construct_Settings settings = *(FieldInstance_Construct_Settings*)Settings;
+            rand::AnyRNG<uint32_t>& rng = settings.rng;
+
+            details::FieldInstance_CurrentInstance<_T, _DimensionCount>* p_rv = new details::FieldInstance_CurrentInstance<_T, _DimensionCount>{ _CreateField(settings.createField_sharedData), ArrayV<uint32_3>(settings.inputCount), ArrayV<uint32_3>(settings.outputCount), Object, settings.objectRunner_sharedData, rng };
+            details::FieldInstance_CurrentInstance<_T, _DimensionCount>& rv = *p_rv;
+            ArrayV<size_t>& il = rv.inputs;
+            ArrayV<size_t>& ol = rv.outputs;
+
+            std::uniform_int_distribution<uint32_t> dis(0, f.ValueCount());
+
+            for (uint32_t i = 0; i < settings.inputCount; ++i) {
+            ContinueInputs:
+                size_t thisIdx = dis(rng);
+                for (uint32_t j = 0; j < i; ++j)
+                    if (il[j] == thisIdx)
+                        goto ContinueInputs;
+                il[i] = thisIdx;
+            }
+            for (uint32_t i = 0; i < settings.outputCount; ++i) {
+            ContinueOutputs:
+                size_t thisIdx = dis(rng);
+                for (uint32_t j = 0; j < i; ++j)
+                    if (ol[j] == thisIdx)
+                        goto ContinueOutputs;
+                ol[i] = thisIdx;
+            }
+
+            return p_rv;
+        }
         template <typename _T, size_t _DimensionCount, fieldInstance_objectRunner_t<_T, _DimensionCount> _ObjectRunner>
-        _T* FieldInstance_Iterate(void* CurrentInstance, _T* Inputs);
+        _T* FieldInstance_Iterate(void* CurrentInstance, _T* Inputs) {
+            details::FieldInstance_CurrentInstance<_T, _DimensionCount>& c = *(details::FieldInstance_CurrentInstance<_T, _DimensionCount>*)CurrentInstance;
+            DField<_T, _DimensionCount>& df = c.dfield;
+            ArrayV<size_t>& il = c.inputs;
+            ArrayV<size_t>& ol = c.outputs;
+
+            if (Inputs) {
+                FieldProxy<_T, _DimensionCount> f = df.F();
+                for (size_t i = 0; i < il.size; ++i) {
+                    f.CpyValIn(il[i], Inputs[i]);
+                }
+            }
+            _ObjectRunner(c.obj, df.MakeProxy(), c.objectRunner_sharedData);
+            df.Reverse();
+            _T* opts = new _T[ol.size];
+            {
+                FieldProxy<_T, _DimensionCount> f = df.F();
+                for (size_t i = 0; i < ol.size; ++i) {
+                    opts[i] = f.CpyValOut(ol[i]);
+                }
+            }
+            return opts;
+        }
         template <typename _T, size_t _DimensionCount>
-        void FieldInstance_Destruct(void* CurrentInstance);
+        void FieldInstance_Destruct(void* CurrentInstance) {
+            delete (details::FieldInstance_CurrentInstance<_T, _DimensionCount>*)CurrentInstance;
+        }
         template <typename _T, size_t _DimensionCount, fieldInstance_createField_t<_T, _DimensionCount> _CreateField, fieldInstance_objectRunner_t<_T, _DimensionCount> _ObjectRunner>
-        ai::evol::eval::output::InstanceFunctions<_T*, _T*> FieldInstance();
+        ai::evol::eval::output::InstanceFunctions<_T*, _T*> FieldInstance() {
+            ai::evol::eval::output::InstanceFunctions<_T*, _T*> ifs;
+            ifs.constructInstance = FieldInstance_Construct<_T, _DimensionCount, _CreateField>;
+            ifs.iterateInstance = FieldInstance_Iterate<_T, _DimensionCount, _ObjectRunner>;
+            ifs.destructInstance = FieldInstance_Destruct<_T, _DimensionCount>;
+            return ifs;
+        }
 
         template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
-        _TOutput* FieldInstance_Iterate(void* CurrentInstance, _TInput* Inputs);
+        _TOutput* FieldInstance_Iterate(void* CurrentInstance, _TInput* Inputs) {
+            details::FieldInstance_CurrentInstance<_TFieldValue, _DimensionCount> c = *(details::FieldInstance_CurrentInstance<_TFieldValue, _DimensionCount>*)CurrentInstance;
+            DField<_TFieldValue, _DimensionCount>& df = c.dfield;
+            ArrayV<size_t>& il = c.inputs;
+            ArrayV<size_t>& ol = c.outputs;
+
+            if (Inputs) {
+                FieldProxy<_TFieldValue, _DimensionCount> f = df.F();
+                for (size_t i = 0; i < il.size; ++i) {
+                    size_t idx = il[i];
+                    _TFieldValue fieldValue = f.CpyValOut(idx);
+                    _AssignInput(fieldValue, Inputs[i]);
+                    f.CpyValIn(idx, fieldValue);
+                }
+            }
+            _ObjectRunner(c.obj, df.MakeProxy(), c.objectRunner_sharedData);
+            df.Reverse();
+            _TOutput* opts = new _TOutput[ol.size];
+            {
+                FieldProxy<_TFieldValue, _DimensionCount> f = df.F();
+                for (size_t i = 0; i < ol.size; ++i) {
+                    _TFieldValue fieldValue = f.CpyValOut(ol[i]);
+                    opts[i] = _GetOutput(fieldValue);
+                }
+            }
+            return opts;
+        }
         template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, fieldInstance_createField_t<_TFieldValue, _DimensionCount> _CreateField, fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
-        ai::evol::eval::output::InstanceFunctions<_TInput*, _TOutput*> FieldInstance();
-    }
-}
-
-template <typename _T, size_t _DimensionCount, bcuda::fields::fieldInstance_createField_t<_T, _DimensionCount> _CreateField>
-void* bcuda::fields::FieldInstance_Construct(void* Object, void* Settings) {
-    FieldInstance_Construct_Settings settings = *(FieldInstance_Construct_Settings*)Settings;
-    rand::AnyRNG<uint32_t>& rng = settings.rng;
-
-    details::FieldInstance_CurrentInstance<_T, _DimensionCount>* p_rv = new details::FieldInstance_CurrentInstance<_T, _DimensionCount>{ _CreateField(settings.createField_sharedData), ArrayV<uint32_3>(settings.inputCount), ArrayV<uint32_3>(settings.outputCount), Object, settings.objectRunner_sharedData, rng };
-    details::FieldInstance_CurrentInstance<_T, _DimensionCount>& rv = *p_rv;
-    ArrayV<size_t>& il = rv.inputs;
-    ArrayV<size_t>& ol = rv.outputs;
-
-    std::uniform_int_distribution<uint32_t> dis(0, f.ValueCount());
-
-    for (uint32_t i = 0; i < settings.inputCount; ++i) {
-    ContinueInputs:
-        size_t thisIdx = dis(rng);
-        for (uint32_t j = 0; j < i; ++j)
-            if (il[j] == thisIdx)
-                goto ContinueInputs;
-        il[i] = thisIdx;
-    }
-    for (uint32_t i = 0; i < settings.outputCount; ++i) {
-    ContinueOutputs:
-        size_t thisIdx = dis(rng);
-        for (uint32_t j = 0; j < i; ++j)
-            if (ol[j] == thisIdx)
-                goto ContinueOutputs;
-        ol[i] = thisIdx;
-    }
-
-    return p_rv;
-};
-template <typename _T, size_t _DimensionCount, bcuda::fields::fieldInstance_objectRunner_t<_T, _DimensionCount> _ObjectRunner>
-_T* bcuda::fields::FieldInstance_Iterate(void* CurrentInstance, _T* Inputs) {
-    details::FieldInstance_CurrentInstance<_T, _DimensionCount>& c = *(details::FieldInstance_CurrentInstance<_T, _DimensionCount>*)CurrentInstance;
-    DField<_T, _DimensionCount>& df = c.dfield;
-    ArrayV<size_t>& il = c.inputs;
-    ArrayV<size_t>& ol = c.outputs;
-
-    if (Inputs) {
-        FieldProxy<_T, _DimensionCount> f = df.F();
-        for (size_t i = 0; i < il.size; ++i) {
-            f.CpyValIn(il[i], Inputs[i]);
+        ai::evol::eval::output::InstanceFunctions<_TInput*, _TOutput*> FieldInstance() {
+            ai::evol::eval::output::InstanceFunctions<_TInput*, _TOutput*> ifs;
+            ifs.constructInstance = FieldInstance_Construct<_TFieldValue, _DimensionCount, _CreateField>;
+            ifs.iterateInstance = FieldInstance_Iterate<_TFieldValue, _DimensionCount, _TInput, _TOutput, _AssignInput, _GetOutput, _ObjectRunner>;
+            ifs.destructInstance = FieldInstance_Destruct<_TFieldValue, _DimensionCount>;
+            return ifs;
         }
     }
-    _ObjectRunner(c.obj, df.MakeProxy(), c.objectRunner_sharedData);
-    df.Reverse();
-    _T* opts = new _T[ol.size];
-    {
-        FieldProxy<_T, _DimensionCount> f = df.F();
-        for (size_t i = 0; i < ol.size; ++i) {
-            opts[i] = f.CpyValOut(ol[i]);
-        }
-    }
-    return opts;
-};
-template <typename _T, size_t _DimensionCount>
-void bcuda::fields::FieldInstance_Destruct(void* CurrentInstance) {
-    delete (details::FieldInstance_CurrentInstance<_T, _DimensionCount>*)CurrentInstance;
-};
-
-template <typename _T, size_t _DimensionCount, bcuda::fields::fieldInstance_createField_t<_T, _DimensionCount> _CreateField, bcuda::fields::fieldInstance_objectRunner_t<_T, _DimensionCount> _ObjectRunner>
-bcuda::ai::evol::eval::output::InstanceFunctions<_T*, _T*> bcuda::fields::FieldInstance() {
-    ai::evol::eval::output::InstanceFunctions<_T*, _T*> ifs;
-    ifs.constructInstance = FieldInstance_Construct<_T, _DimensionCount, _CreateField>;
-    ifs.iterateInstance = FieldInstance_Iterate<_T, _DimensionCount, _ObjectRunner>;
-    ifs.destructInstance = FieldInstance_Destruct<_T, _DimensionCount>;
-    return ifs;
-}
-
-template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, bcuda::fields::fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, bcuda::fields::fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, bcuda::fields::fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
-_TOutput* bcuda::fields::FieldInstance_Iterate(void* CurrentInstance, _TInput* Inputs) {
-    details::FieldInstance_CurrentInstance<_TFieldValue, _DimensionCount> c = *(details::FieldInstance_CurrentInstance<_TFieldValue, _DimensionCount>*)CurrentInstance;
-    DField<_TFieldValue, _DimensionCount>& df = c.dfield;
-    ArrayV<size_t>& il = c.inputs;
-    ArrayV<size_t>& ol = c.outputs;
-
-    if (Inputs) {
-        FieldProxy<_TFieldValue, _DimensionCount> f = df.F();
-        for (size_t i = 0; i < il.size; ++i) {
-            size_t idx = il[i];
-            _TFieldValue fieldValue = f.CpyValOut(idx);
-            _AssignInput(fieldValue, Inputs[i]);
-            f.CpyValIn(idx, fieldValue);
-        }
-    }
-    _ObjectRunner(c.obj, df.MakeProxy(), c.objectRunner_sharedData);
-    df.Reverse();
-    _TOutput* opts = new _TOutput[ol.size];
-    {
-        FieldProxy<_TFieldValue, _DimensionCount> f = df.F();
-        for (size_t i = 0; i < ol.size; ++i) {
-            _TFieldValue fieldValue = f.CpyValOut(ol[i]);
-            opts[i] = _GetOutput(fieldValue);
-        }
-    }
-    return opts;
-}
-
-template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, bcuda::fields::fieldInstance_createField_t<_TFieldValue, _DimensionCount> _CreateField, bcuda::fields::fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, bcuda::fields::fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, bcuda::fields::fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
-bcuda::ai::evol::eval::output::InstanceFunctions<_TInput*, _TOutput*> bcuda::fields::FieldInstance() {
-    ai::evol::eval::output::InstanceFunctions<_TInput*, _TOutput*> ifs;
-    ifs.constructInstance = FieldInstance_Construct<_TFieldValue, _DimensionCount, _CreateField>;
-    ifs.iterateInstance = FieldInstance_Iterate<_TFieldValue, _DimensionCount, _TInput, _TOutput, _AssignInput, _GetOutput, _ObjectRunner>;
-    ifs.destructInstance = FieldInstance_Destruct<_TFieldValue, _DimensionCount>;
-    return ifs;
 }

--- a/fields_instance.h
+++ b/fields_instance.h
@@ -36,7 +36,7 @@ namespace bcuda {
         using fieldInstance_assignInput_t = void(*)(_TFieldValue& FieldValue, const _TInput& InputValue);
 
         template <typename _T, size_t _DimensionCount, fieldInstance_createField_t<_T, _DimensionCount> _CreateField>
-        void* FieldInstance_Construct(void* Object, void* Settings) {
+        static inline void* FieldInstance_Construct(void* Object, void* Settings) {
             FieldInstance_Construct_Settings settings = *(FieldInstance_Construct_Settings*)Settings;
             rand::AnyRNG<uint32_t>& rng = settings.rng;
 
@@ -67,7 +67,7 @@ namespace bcuda {
             return p_rv;
         }
         template <typename _T, size_t _DimensionCount, fieldInstance_objectRunner_t<_T, _DimensionCount> _ObjectRunner>
-        _T* FieldInstance_Iterate(void* CurrentInstance, _T* Inputs) {
+        static inline _T* FieldInstance_Iterate(void* CurrentInstance, _T* Inputs) {
             details::FieldInstance_CurrentInstance<_T, _DimensionCount>& c = *(details::FieldInstance_CurrentInstance<_T, _DimensionCount>*)CurrentInstance;
             DField<_T, _DimensionCount>& df = c.dfield;
             ArrayV<size_t>& il = c.inputs;
@@ -91,11 +91,11 @@ namespace bcuda {
             return opts;
         }
         template <typename _T, size_t _DimensionCount>
-        void FieldInstance_Destruct(void* CurrentInstance) {
+        static inline void FieldInstance_Destruct(void* CurrentInstance) {
             delete (details::FieldInstance_CurrentInstance<_T, _DimensionCount>*)CurrentInstance;
         }
         template <typename _T, size_t _DimensionCount, fieldInstance_createField_t<_T, _DimensionCount> _CreateField, fieldInstance_objectRunner_t<_T, _DimensionCount> _ObjectRunner>
-        ai::evol::eval::output::InstanceFunctions<_T*, _T*> FieldInstance() {
+        static inline ai::evol::eval::output::InstanceFunctions<_T*, _T*> FieldInstance() {
             ai::evol::eval::output::InstanceFunctions<_T*, _T*> ifs;
             ifs.constructInstance = FieldInstance_Construct<_T, _DimensionCount, _CreateField>;
             ifs.iterateInstance = FieldInstance_Iterate<_T, _DimensionCount, _ObjectRunner>;
@@ -104,7 +104,7 @@ namespace bcuda {
         }
 
         template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
-        _TOutput* FieldInstance_Iterate(void* CurrentInstance, _TInput* Inputs) {
+        static inline _TOutput* FieldInstance_Iterate(void* CurrentInstance, _TInput* Inputs) {
             details::FieldInstance_CurrentInstance<_TFieldValue, _DimensionCount> c = *(details::FieldInstance_CurrentInstance<_TFieldValue, _DimensionCount>*)CurrentInstance;
             DField<_TFieldValue, _DimensionCount>& df = c.dfield;
             ArrayV<size_t>& il = c.inputs;
@@ -132,7 +132,7 @@ namespace bcuda {
             return opts;
         }
         template <typename _TFieldValue, size_t _DimensionCount, typename _TInput, typename _TOutput, fieldInstance_createField_t<_TFieldValue, _DimensionCount> _CreateField, fieldInstance_assignInput_t<_TFieldValue, _TInput> _AssignInput, fieldInstance_getOutput_t<_TFieldValue, _TOutput> _GetOutput, fieldInstance_objectRunner_t<_TFieldValue, _DimensionCount> _ObjectRunner>
-        ai::evol::eval::output::InstanceFunctions<_TInput*, _TOutput*> FieldInstance() {
+        static inline ai::evol::eval::output::InstanceFunctions<_TInput*, _TOutput*> FieldInstance() {
             ai::evol::eval::output::InstanceFunctions<_TInput*, _TOutput*> ifs;
             ifs.constructInstance = FieldInstance_Construct<_TFieldValue, _DimensionCount, _CreateField>;
             ifs.iterateInstance = FieldInstance_Iterate<_TFieldValue, _DimensionCount, _TInput, _TOutput, _AssignInput, _GetOutput, _ObjectRunner>;

--- a/fields_mdfield.h
+++ b/fields_mdfield.h
@@ -66,58 +66,58 @@ namespace bcuda {
             using publicPrivateKernelFunc_t = details::mdfppik_t<_DimensionCount, std::tuple<_Ts...>, std::integer_sequence<bool, _Publics...>>;
 
 #pragma region Wrapper
-            __host__ __device__ __forceinline MDField(const vector_t& Dimensions)
+            __host__ __device__ inline MDField(const vector_t& Dimensions)
                 : fields(Dimensions) { }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __host__ __device__ __forceinline MDField(_Ts... Dimensions)
+            __host__ __device__ inline MDField(_Ts... Dimensions)
                 : fields(vector_t(Dimensions...)) { }
 
-            __host__ __device__ __forceinline uint32_t LengthX() const requires (_DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthX() const requires (_DimensionCount <= 4) {
                 return fields.LengthX();
             }
-            __host__ __device__ __forceinline uint32_t LengthY() const requires (_DimensionCount >= 2 && _DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthY() const requires (_DimensionCount >= 2 && _DimensionCount <= 4) {
                 return fields.LengthY();
             }
-            __host__ __device__ __forceinline uint32_t LengthZ() const requires (_DimensionCount >= 3 && _DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthZ() const requires (_DimensionCount >= 3 && _DimensionCount <= 4) {
                 return fields.LengthZ();
             }
-            __host__ __device__ __forceinline uint32_t LengthW() const requires (_DimensionCount == 4) {
+            __host__ __device__ inline uint32_t LengthW() const requires (_DimensionCount == 4) {
                 return fields.LengthW();
             }
-            __host__ __device__ __forceinline uint32_t Length(size_t Idx) const {
+            __host__ __device__ inline uint32_t Length(size_t Idx) const {
                 return fields.Length(Idx);
             }
-            __host__ __device__ __forceinline vector_t Dimensions() const {
+            __host__ __device__ inline vector_t Dimensions() const {
                 return fields.Dimensions();
             }
-            __host__ __device__ __forceinline dim3 DimensionsD() const {
+            __host__ __device__ inline dim3 DimensionsD() const {
                 return fields.DimensionsD();
             }
-            __host__ __device__ __forceinline vector_t IdxToCoords(uint64_t Index) const {
+            __host__ __device__ inline vector_t IdxToCoords(uint64_t Index) const {
                 return fields.IdxToCoords(Index);
             }
-            __host__ __device__ __forceinline uint64_t CoordsToIdx(vector_t Coords) const {
+            __host__ __device__ inline uint64_t CoordsToIdx(vector_t Coords) const {
                 return fields.CoordsToIdx(Coords);
             }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __host__ __device__ __forceinline uint64_t CoordsToIdx(_Ts... Coords) const {
+            __host__ __device__ inline uint64_t CoordsToIdx(_Ts... Coords) const {
                 return fields.CoordsToIdx(Coords...);
             }
 
-            __host__ __device__ __forceinline size_t EachValueCount() const {
+            __host__ __device__ inline size_t EachValueCount() const {
                 return fields.EachValueCount();
             }
             template <size_t _Idx>
                 requires (_Idx < sizeof...(_Ts))
-            __host__ __device__ __forceinline size_t EachSizeOnGPU() const {
+            __host__ __device__ inline size_t EachSizeOnGPU() const {
                 return fields.EachSizeOnGPU<_Idx>();
             }
-            __host__ __device__ __forceinline size_t TotalValueCount() const {
+            __host__ __device__ inline size_t TotalValueCount() const {
                 return fields.TotalValueCount();
             }
-            __host__ __device__ __forceinline size_t TotalSizeOnGPU() const {
+            __host__ __device__ inline size_t TotalSizeOnGPU() const {
                 return fields.TotalSizeOnGPU();
             }
             template <bool _Front, size_t _Idx>
@@ -154,34 +154,34 @@ namespace bcuda {
                 constexpr size_t tIdx = _Front ? _Idx : sizeof...(_Ts) + _Idx;
                 return fields.FData<tIdx>();
             }
-            __forceinline size_t SerializedSize() const requires (BSerializer::Serializable<_Ts> && ...) {
+            inline size_t SerializedSize() const requires (BSerializer::Serializable<_Ts> && ...) {
                 return fields.SerializedSize();
             }
-            __forceinline void Serialize(void*& Data) const requires (BSerializer::Serializable<_Ts> && ...) {
+            inline void Serialize(void*& Data) const requires (BSerializer::Serializable<_Ts> && ...) {
                 fields.Serialize(Data);
             }
 #pragma endregion
 
-            static __forceinline this_t Deserialize(const void*& Data) requires (BSerializer::Serializable<_Ts> && ...) {
+            static inline this_t Deserialize(const void*& Data) requires (BSerializer::Serializable<_Ts> && ...) {
                 return *(this_t*)&details::MFieldBase<_DimensionCount, _Ts..., _Ts...>(Data);
             }
-            static __forceinline void Deserialize(const void*& Data, void* Value) requires (BSerializer::Serializable<_Ts> && ...) {
+            static inline void Deserialize(const void*& Data, void* Value) requires (BSerializer::Serializable<_Ts> && ...) {
                 details::MFieldBase<_DimensionCount, _Ts..., _Ts...>(Data, Value);
             }
 
-            __forceinline MDField(const this_t&) = default;
-            __forceinline MDField(this_t&&) = default;
-            __forceinline this_t& operator=(const this_t&) = default;
-            __forceinline this_t& operator=(this_t&&) = default;
+            inline MDField(const this_t&) = default;
+            inline MDField(this_t&&) = default;
+            inline this_t& operator=(const this_t&) = default;
+            inline this_t& operator=(this_t&&) = default;
 
-            __host__ __device__ __forceinline MDFieldProxy<_DimensionCount, _Ts...> MakeProxy() {
+            __host__ __device__ inline MDFieldProxy<_DimensionCount, _Ts...> MakeProxy() {
                 return MDFieldProxy<_DimensionCount, _Ts...>(*this);
             }
-            __host__ __device__ __forceinline MDFieldProxyConst<_DimensionCount, _Ts...> MakeProxyConst() const {
+            __host__ __device__ inline MDFieldProxyConst<_DimensionCount, _Ts...> MakeProxyConst() const {
                 return MDFieldProxyConst<_DimensionCount, _Ts...>(*this);
             }
 
-            __host__ __device__ __forceinline void Reverse() {
+            __host__ __device__ inline void Reverse() {
                 void* const* oldArrs = ((details::MFieldBase<_DimensionCount, _Ts..., _Ts...>*)&fields)->FieldDataArray();
                 void* arrs[sizeof...(_Ts) << 1];
 
@@ -211,51 +211,51 @@ namespace bcuda {
             using publicPrivateKernelFunc_t = details::mdfppik_t<_DimensionCount, std::tuple<_Ts...>, std::integer_sequence<bool, _Publics...>>;
 
 #pragma region Wrapper
-            __host__ __device__ __forceinline uint32_t LengthX() const requires (_DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthX() const requires (_DimensionCount <= 4) {
                 return fields.LengthX();
             }
-            __host__ __device__ __forceinline uint32_t LengthY() const requires (_DimensionCount >= 2 && _DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthY() const requires (_DimensionCount >= 2 && _DimensionCount <= 4) {
                 return fields.LengthY();
             }
-            __host__ __device__ __forceinline uint32_t LengthZ() const requires (_DimensionCount >= 3 && _DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthZ() const requires (_DimensionCount >= 3 && _DimensionCount <= 4) {
                 return fields.LengthZ();
             }
-            __host__ __device__ __forceinline uint32_t LengthW() const requires (_DimensionCount == 4) {
+            __host__ __device__ inline uint32_t LengthW() const requires (_DimensionCount == 4) {
                 return fields.LengthW();
             }
-            __host__ __device__ __forceinline uint32_t Length(size_t Idx) const {
+            __host__ __device__ inline uint32_t Length(size_t Idx) const {
                 return fields.Length(Idx);
             }
-            __host__ __device__ __forceinline vector_t Dimensions() const {
+            __host__ __device__ inline vector_t Dimensions() const {
                 return fields.Dimensions();
             }
-            __host__ __device__ __forceinline dim3 DimensionsD() const {
+            __host__ __device__ inline dim3 DimensionsD() const {
                 return fields.DimensionsD();
             }
-            __host__ __device__ __forceinline vector_t IdxToCoords(uint64_t Index) const {
+            __host__ __device__ inline vector_t IdxToCoords(uint64_t Index) const {
                 return fields.IdxToCoords(Index);
             }
-            __host__ __device__ __forceinline uint64_t CoordsToIdx(vector_t Coords) const {
+            __host__ __device__ inline uint64_t CoordsToIdx(vector_t Coords) const {
                 return fields.CoordsToIdx(Coords);
             }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __host__ __device__ __forceinline uint64_t CoordsToIdx(_Ts... Coords) const {
+            __host__ __device__ inline uint64_t CoordsToIdx(_Ts... Coords) const {
                 return fields.CoordsToIdx(Coords...);
             }
 
-            __host__ __device__ __forceinline size_t EachValueCount() const {
+            __host__ __device__ inline size_t EachValueCount() const {
                 return fields.EachValueCount();
             }
             template <size_t _Idx>
                 requires (_Idx < sizeof...(_Ts))
-            __host__ __device__ __forceinline size_t EachSizeOnGPU() const {
+            __host__ __device__ inline size_t EachSizeOnGPU() const {
                 return fields.EachSizeOnGPU<_Idx>();
             }
-            __host__ __device__ __forceinline size_t TotalValueCount() const {
+            __host__ __device__ inline size_t TotalValueCount() const {
                 return fields.TotalValueCount();
             }
-            __host__ __device__ __forceinline size_t TotalSizeOnGPU() const {
+            __host__ __device__ inline size_t TotalSizeOnGPU() const {
                 return fields.TotalSizeOnGPU();
             }
             template <bool _Front, size_t _Idx>
@@ -286,15 +286,15 @@ namespace bcuda {
                 constexpr size_t tIdx = _Front ? _Idx : sizeof...(_Ts) + _Idx;
                 return fields.FData<tIdx>();
             }
-            __forceinline size_t SerializedSize() const requires (BSerializer::Serializable<_Ts> && ...) {
+            inline size_t SerializedSize() const requires (BSerializer::Serializable<_Ts> && ...) {
                 return fields.SerializedSize();
             }
-            __forceinline void Serialize(void*& Data) const requires (BSerializer::Serializable<_Ts> && ...) {
+            inline void Serialize(void*& Data) const requires (BSerializer::Serializable<_Ts> && ...) {
                 fields.Serialize(Data);
             }
 #pragma endregion
 
-            __host__ __device__ __forceinline MDField<_DimensionCount, _Ts...> Clone() const {
+            __host__ __device__ inline MDField<_DimensionCount, _Ts...> Clone() const {
                 return *(MDField<_DimensionCount, _Ts...>*)&((details::MFieldBase<_DimensionCount, _Ts..., _Ts...>)&fields)->Clone();
             }
 
@@ -315,51 +315,51 @@ namespace bcuda {
             using element_t = std::tuple_element_t<_Idx, tuple_t>;
 
 #pragma region Wrapper
-            __host__ __device__ __forceinline uint32_t LengthX() const requires (_DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthX() const requires (_DimensionCount <= 4) {
                 return fields.LengthX();
             }
-            __host__ __device__ __forceinline uint32_t LengthY() const requires (_DimensionCount >= 2 && _DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthY() const requires (_DimensionCount >= 2 && _DimensionCount <= 4) {
                 return fields.LengthY();
             }
-            __host__ __device__ __forceinline uint32_t LengthZ() const requires (_DimensionCount >= 3 && _DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthZ() const requires (_DimensionCount >= 3 && _DimensionCount <= 4) {
                 return fields.LengthZ();
             }
-            __host__ __device__ __forceinline uint32_t LengthW() const requires (_DimensionCount == 4) {
+            __host__ __device__ inline uint32_t LengthW() const requires (_DimensionCount == 4) {
                 return fields.LengthW();
             }
-            __host__ __device__ __forceinline uint32_t Length(size_t Idx) const {
+            __host__ __device__ inline uint32_t Length(size_t Idx) const {
                 return fields.Length(Idx);
             }
-            __host__ __device__ __forceinline vector_t Dimensions() const {
+            __host__ __device__ inline vector_t Dimensions() const {
                 return fields.Dimensions();
             }
-            __host__ __device__ __forceinline dim3 DimensionsD() const {
+            __host__ __device__ inline dim3 DimensionsD() const {
                 return fields.DimensionsD();
             }
-            __host__ __device__ __forceinline vector_t IdxToCoords(uint64_t Index) const {
+            __host__ __device__ inline vector_t IdxToCoords(uint64_t Index) const {
                 return fields.IdxToCoords(Index);
             }
-            __host__ __device__ __forceinline uint64_t CoordsToIdx(vector_t Coords) const {
+            __host__ __device__ inline uint64_t CoordsToIdx(vector_t Coords) const {
                 return fields.CoordsToIdx(Coords);
             }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __host__ __device__ __forceinline uint64_t CoordsToIdx(_Ts... Coords) const {
+            __host__ __device__ inline uint64_t CoordsToIdx(_Ts... Coords) const {
                 return fields.CoordsToIdx(Coords...);
             }
 
-            __host__ __device__ __forceinline size_t EachValueCount() const {
+            __host__ __device__ inline size_t EachValueCount() const {
                 return fields.EachValueCount();
             }
             template <size_t _Idx>
                 requires (_Idx < sizeof...(_Ts))
-            __host__ __device__ __forceinline size_t EachSizeOnGPU() const {
+            __host__ __device__ inline size_t EachSizeOnGPU() const {
                 return fields.EachSizeOnGPU<_Idx>();
             }
-            __host__ __device__ __forceinline size_t TotalValueCount() const {
+            __host__ __device__ inline size_t TotalValueCount() const {
                 return fields.TotalValueCount();
             }
-            __host__ __device__ __forceinline size_t TotalSizeOnGPU() const {
+            __host__ __device__ inline size_t TotalSizeOnGPU() const {
                 return fields.TotalSizeOnGPU();
             }
             template <bool _Front, size_t _Idx>
@@ -379,15 +379,15 @@ namespace bcuda {
                 constexpr size_t tIdx = _Front ? _Idx : sizeof...(_Ts) + _Idx;
                 return fields.FData<tIdx>();
             }
-            __forceinline size_t SerializedSize() const requires (BSerializer::Serializable<_Ts> && ...) {
+            inline size_t SerializedSize() const requires (BSerializer::Serializable<_Ts> && ...) {
                 return fields.SerializedSize();
             }
-            __forceinline void Serialize(void*& Data) const requires (BSerializer::Serializable<_Ts> && ...) {
+            inline void Serialize(void*& Data) const requires (BSerializer::Serializable<_Ts> && ...) {
                 fields.Serialize(Data);
             }
 #pragma endregion
 
-            __host__ __device__ __forceinline MDField<_DimensionCount, _Ts...> Clone() const {
+            __host__ __device__ inline MDField<_DimensionCount, _Ts...> Clone() const {
                 return *(MDField<_DimensionCount, _Ts...>*)&(((details::MFieldBase<_DimensionCount, _Ts..., _Ts...>*)&fields)->Clone());
             }
 

--- a/fields_mdfield.h
+++ b/fields_mdfield.h
@@ -122,35 +122,35 @@ namespace bcuda {
             }
             template <bool _Front, size_t _Idx>
                 requires (_Idx < sizeof...(_Ts))
-            __host__ __device__ FieldProxy<element_t<_Idx>, _DimensionCount> F() {
+            __host__ __device__ inline FieldProxy<element_t<_Idx>, _DimensionCount> F() {
                 constexpr size_t tIdx = _Front ? _Idx : sizeof...(_Ts) + _Idx;
                 return fields.F<tIdx>();
             }
             template <bool _Front, size_t _Idx>
                 requires (_Idx < sizeof...(_Ts))
-            __host__ __device__ FieldProxyConst<element_t<_Idx>, _DimensionCount> FConst() const {
+            __host__ __device__ inline FieldProxyConst<element_t<_Idx>, _DimensionCount> FConst() const {
                 constexpr size_t tIdx = _Front ? _Idx : sizeof...(_Ts) + _Idx;
                 return fields.FConst<tIdx>();
             }
             template <size_t _Idx>
                 requires (_Idx < sizeof...(_Ts))
-            __host__ __device__ DFieldProxy<element_t<_Idx>, _DimensionCount> F() {
+            __host__ __device__ inline DFieldProxy<element_t<_Idx>, _DimensionCount> F() {
                 return DFieldProxy<element_t<_Idx>, _DimensionCount>(Dimensions(), fields.FData<_Idx>(), fields.FData<_Idx + sizeof...(_Ts)>());
             }
             template <size_t _Idx>
                 requires (_Idx < sizeof...(_Ts))
-            __host__ __device__ DFieldProxyConst<element_t<_Idx>, _DimensionCount> FConst() const {
+            __host__ __device__ inline DFieldProxyConst<element_t<_Idx>, _DimensionCount> FConst() const {
                 return DFieldProxyConst<element_t<_Idx>, _DimensionCount>(Dimensions(), fields.FData<_Idx>(), fields.FData<_Idx + sizeof...(_Ts)>());
             }
             template <bool _Front, size_t _Idx>
                 requires (_Idx < sizeof...(_Ts))
-            __host__ __device__ element_t<_Idx>* FData() {
+            __host__ __device__ inline element_t<_Idx>* FData() {
                 constexpr size_t tIdx = _Front ? _Idx : sizeof...(_Ts) + _Idx;
                 return fields.FData<tIdx>();
             }
             template <bool _Front, size_t _Idx>
                 requires (_Idx < sizeof...(_Ts))
-            __host__ __device__ const element_t<_Idx>* FData() const {
+            __host__ __device__ inline const element_t<_Idx>* FData() const {
                 constexpr size_t tIdx = _Front ? _Idx : sizeof...(_Ts) + _Idx;
                 return fields.FData<tIdx>();
             }
@@ -169,10 +169,10 @@ namespace bcuda {
                 details::MFieldBase<_DimensionCount, _Ts..., _Ts...>(Data, Value);
             }
 
-            inline MDField(const this_t&) = default;
-            inline MDField(this_t&&) = default;
-            inline this_t& operator=(const this_t&) = default;
-            inline this_t& operator=(this_t&&) = default;
+            inline inline MDField(const this_t&) = default;
+            inline inline MDField(this_t&&) = default;
+            inline inline this_t& operator=(const this_t&) = default;
+            inline inline this_t& operator=(this_t&&) = default;
 
             __host__ __device__ inline MDFieldProxy<_DimensionCount, _Ts...> MakeProxy() {
                 return MDFieldProxy<_DimensionCount, _Ts...>(*this);
@@ -260,29 +260,29 @@ namespace bcuda {
             }
             template <bool _Front, size_t _Idx>
                 requires (_Idx < sizeof...(_Ts))
-            __host__ __device__ FieldProxy<element_t<_Idx>, _DimensionCount> F() const {
+            __host__ __device__ inline FieldProxy<element_t<_Idx>, _DimensionCount> F() const {
                 constexpr size_t tIdx = _Front ? _Idx : sizeof...(_Ts) + _Idx;
                 return fields.F<tIdx>();
             }
             template <bool _Front, size_t _Idx>
                 requires (_Idx < sizeof...(_Ts))
-            __host__ __device__ FieldProxyConst<element_t<_Idx>, _DimensionCount> FConst() const {
+            __host__ __device__ inline FieldProxyConst<element_t<_Idx>, _DimensionCount> FConst() const {
                 constexpr size_t tIdx = _Front ? _Idx : sizeof...(_Ts) + _Idx;
                 return fields.FConst<tIdx>();
             }
             template <size_t _Idx>
                 requires (_Idx < sizeof...(_Ts))
-            __host__ __device__ DFieldProxy<element_t<_Idx>, _DimensionCount> F() const {
+            __host__ __device__ inline DFieldProxy<element_t<_Idx>, _DimensionCount> F() const {
                 return DFieldProxy<element_t<_Idx>, _DimensionCount>(Dimensions(), const_cast<element_t<_Idx>*>(fields.FData<_Idx>()), const_cast<element_t<_Idx>*>(fields.FData<_Idx + sizeof...(_Ts)>()));
             }
             template <size_t _Idx>
                 requires (_Idx < sizeof...(_Ts))
-            __host__ __device__ DFieldProxyConst<element_t<_Idx>, _DimensionCount> FConst() const {
+            __host__ __device__ inline DFieldProxyConst<element_t<_Idx>, _DimensionCount> FConst() const {
                 return DFieldProxyConst<element_t<_Idx>, _DimensionCount>(Dimensions(), fields.FData<_Idx>(), fields.FData<_Idx + sizeof...(_Ts)>());
             }
             template <bool _Front, size_t _Idx>
                 requires (_Idx < sizeof...(_Ts))
-            __host__ __device__ element_t<_Idx>* FData() const {
+            __host__ __device__ inline element_t<_Idx>* FData() const {
                 constexpr size_t tIdx = _Front ? _Idx : sizeof...(_Ts) + _Idx;
                 return fields.FData<tIdx>();
             }
@@ -298,9 +298,9 @@ namespace bcuda {
                 return *(MDField<_DimensionCount, _Ts...>*)&((details::MFieldBase<_DimensionCount, _Ts..., _Ts...>)&fields)->Clone();
             }
 
-            __host__ __device__ MDFieldProxy(const vector_t& Dimensions, void* const* Arrays)
+            __host__ __device__ inline MDFieldProxy(const vector_t& Dimensions, void* const* Arrays)
                 : fields(Dimensions, Arrays) { }
-            __host__ __device__ MDFieldProxy(MDField<_DimensionCount, _Ts...>& Parent)
+            __host__ __device__ inline MDFieldProxy(MDField<_DimensionCount, _Ts...>& Parent)
                 : fields(Parent.Dimensions(), ((details::MFieldBase<_DimensionCount, _Ts..., _Ts...>*)&(((this_t*)&Parent)->fields))->FieldDataArray()) { }
         };
         template <size_t _DimensionCount, typename... _Ts>
@@ -364,18 +364,18 @@ namespace bcuda {
             }
             template <bool _Front, size_t _Idx>
                 requires (_Idx < sizeof...(_Ts))
-            __host__ __device__ FieldProxyConst<element_t<_Idx>, _DimensionCount> FConst() const {
+            __host__ __device__ inline FieldProxyConst<element_t<_Idx>, _DimensionCount> FConst() const {
                 constexpr size_t tIdx = _Front ? _Idx : sizeof...(_Ts) + _Idx;
                 return fields.FConst<tIdx>();
             }
             template <size_t _Idx>
                 requires (_Idx < sizeof...(_Ts))
-            __host__ __device__ DFieldProxyConst<element_t<_Idx>, _DimensionCount> FConst() const {
+            __host__ __device__ inline DFieldProxyConst<element_t<_Idx>, _DimensionCount> FConst() const {
                 return DFieldProxyConst<element_t<_Idx>, _DimensionCount>(Dimensions(), fields.FData<_Idx>(), fields.FData<_Idx + sizeof...(_Ts)>());
             }
             template <bool _Front, size_t _Idx>
                 requires (_Idx < sizeof...(_Ts))
-            __host__ __device__ const element_t<_Idx>* FData() const {
+            __host__ __device__ inline const element_t<_Idx>* FData() const {
                 constexpr size_t tIdx = _Front ? _Idx : sizeof...(_Ts) + _Idx;
                 return fields.FData<tIdx>();
             }
@@ -391,11 +391,11 @@ namespace bcuda {
                 return *(MDField<_DimensionCount, _Ts...>*)&(((details::MFieldBase<_DimensionCount, _Ts..., _Ts...>*)&fields)->Clone());
             }
 
-            __host__ __device__ MDFieldProxyConst(const vector_t& Dimensions, void* const* Arrays)
+            __host__ __device__ inline MDFieldProxyConst(const vector_t& Dimensions, void* const* Arrays)
                 : fields(Dimensions, Arrays) { }
-            __host__ __device__ MDFieldProxyConst(MDField<_DimensionCount, _Ts...>& Parent)
+            __host__ __device__ inline MDFieldProxyConst(MDField<_DimensionCount, _Ts...>& Parent)
                 : fields(Parent.Dimensions(), &((this_t*)&Parent)->fields) { }
-            __host__ __device__ MDFieldProxyConst(MDFieldProxy<_DimensionCount, _Ts...>& Partner)
+            __host__ __device__ inline MDFieldProxyConst(MDFieldProxy<_DimensionCount, _Ts...>& Partner)
                 : fields(Partner.Dimensions(), &((this_t*)&Partner)->fields) { }
         };
     }

--- a/fields_mfield.h
+++ b/fields_mfield.h
@@ -28,57 +28,57 @@ namespace bcuda {
             using element_t = typename basefb_t::template element_t<_Idx>;
 
 #pragma region Wrapper
-            __host__ __device__ __forceinline MField(const vector_t& Dimensions)
+            __host__ __device__ inline MField(const vector_t& Dimensions)
                 : basefb_t(Dimensions) { }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __host__ __device__ __forceinline MField(_Ts... Dimensions)
+            __host__ __device__ inline MField(_Ts... Dimensions)
                 : basefb_t(vector_t(Dimensions...)) { }
 
-            __host__ __device__ __forceinline uint32_t LengthX() const requires (_DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthX() const requires (_DimensionCount <= 4) {
                 return basedb_t::LengthX();
             }
-            __host__ __device__ __forceinline uint32_t LengthY() const requires (_DimensionCount >= 2 && _DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthY() const requires (_DimensionCount >= 2 && _DimensionCount <= 4) {
                 return basedb_t::LengthY();
             }
-            __host__ __device__ __forceinline uint32_t LengthZ() const requires (_DimensionCount >= 3 && _DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthZ() const requires (_DimensionCount >= 3 && _DimensionCount <= 4) {
                 return basedb_t::LengthZ();
             }
-            __host__ __device__ __forceinline uint32_t LengthW() const requires (_DimensionCount == 4) {
+            __host__ __device__ inline uint32_t LengthW() const requires (_DimensionCount == 4) {
                 return basedb_t::LengthW();
             }
-            __host__ __device__ __forceinline uint32_t Length(size_t Idx) const {
+            __host__ __device__ inline uint32_t Length(size_t Idx) const {
                 return basedb_t::Length(Idx);
             }
-            __host__ __device__ __forceinline vector_t Dimensions() const {
+            __host__ __device__ inline vector_t Dimensions() const {
                 return basedb_t::Dimensions();
             }
-            __host__ __device__ __forceinline dim3 DimensionsD() const {
+            __host__ __device__ inline dim3 DimensionsD() const {
                 return basedb_t::DimensionsD();
             }
-            __host__ __device__ __forceinline vector_t IdxToCoords(uint64_t Index) const {
+            __host__ __device__ inline vector_t IdxToCoords(uint64_t Index) const {
                 return basedb_t::IdxToCoords(Index);
             }
-            __host__ __device__ __forceinline uint64_t CoordsToIdx(vector_t Coords) const {
+            __host__ __device__ inline uint64_t CoordsToIdx(vector_t Coords) const {
                 return basedb_t::CoordsToIdx(Coords);
             }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __host__ __device__ __forceinline uint64_t CoordsToIdx(_Ts... Coords) const {
+            __host__ __device__ inline uint64_t CoordsToIdx(_Ts... Coords) const {
                 return basedb_t::CoordsToIdx(Coords...);
             }
 
-            __host__ __device__ __forceinline size_t EachValueCount() const {
+            __host__ __device__ inline size_t EachValueCount() const {
                 return basefb_t::ValueCount();
             }
             template <size_t _Idx>
-            __host__ __device__ __forceinline size_t EachSizeOnGPU() const {
+            __host__ __device__ inline size_t EachSizeOnGPU() const {
                 return basefb_t::template EachSizeOnGPU<_Idx>();
             }
-            __host__ __device__ __forceinline size_t TotalValueCount() const {
+            __host__ __device__ inline size_t TotalValueCount() const {
                 return basefb_t::TotalValueCount();
             }
-            __host__ __device__ __forceinline size_t TotalSizeOnGPU() const {
+            __host__ __device__ inline size_t TotalSizeOnGPU() const {
                 return basefb_t::TotalSizeOnGPU();
             }
             template <size_t _Idx>
@@ -97,48 +97,48 @@ namespace bcuda {
             __host__ __device__ const element_t<_Idx>* FData() const {
                 return basefb_t::template FData<_Idx>();
             }
-            __forceinline size_t SerializedSize() const requires (BSerializer::Serializable<_Ts> && ...) {
+            inline size_t SerializedSize() const requires (BSerializer::Serializable<_Ts> && ...) {
                 return basefb_t::SerializedSize();
             }
-            __forceinline void Serialize(void*& Data) const requires (BSerializer::Serializable<_Ts> && ...) {
+            inline void Serialize(void*& Data) const requires (BSerializer::Serializable<_Ts> && ...) {
                 basefb_t::Serialize(Data);
             }
 #pragma endregion
 
-            static __forceinline this_t Deserialize(const void*& Data) requires (BSerializer::Serializable<_Ts> && ...) {
+            static inline this_t Deserialize(const void*& Data) requires (BSerializer::Serializable<_Ts> && ...) {
                 return *(this_t*)&basefb_t::Deserialize(Data);
             }
-            static __forceinline void Deserialize(const void*& Data, void* Value) requires (BSerializer::Serializable<_Ts> && ...) {
+            static inline void Deserialize(const void*& Data, void* Value) requires (BSerializer::Serializable<_Ts> && ...) {
                 basefb_t::Deserialize(Data, Value);
             }
 
-            __host__ __device__ __forceinline MField(const this_t& Other)
+            __host__ __device__ inline MField(const this_t& Other)
                 : MField(Other.Clone()) { }
-            __host__ __device__ __forceinline MField(this_t&& Other)
+            __host__ __device__ inline MField(this_t&& Other)
                 : basefb_t(Other.Dimensions(), Other.FieldDataArray()) {
                 void* arrs[sizeof...(_Ts)];
                 for (size_t i = 0; i < sizeof...(_Ts); ++i)
                     arrs[i] = 0;
                 new (&Other) basefb_t(this->Dimensions(), &arrs);
             }
-            __host__ __device__ __forceinline ~MField() {
+            __host__ __device__ inline ~MField() {
                 basefb_t::Dispose();
             }
-            __host__ __device__ __forceinline this_t& operator=(const this_t& Other) {
+            __host__ __device__ inline this_t& operator=(const this_t& Other) {
                 this->~MField();
                 new (this) MField(Other);
                 return *this;
             }
-            __host__ __device__ __forceinline this_t& operator=(this_t&& Other) {
+            __host__ __device__ inline this_t& operator=(this_t&& Other) {
                 this->~MField();
                 new (this) MField(Other);
                 return *this;
             }
 
-            __host__ __device__ __forceinline MFieldProxy<_DimensionCount, _Ts...> MakeProxy() {
+            __host__ __device__ inline MFieldProxy<_DimensionCount, _Ts...> MakeProxy() {
                 return MFieldProxy<_DimensionCount, _Ts...>(*this);
             }
-            __host__ __device__ __forceinline MFieldProxyConst<_DimensionCount, _Ts...> MakeProxyConst() const {
+            __host__ __device__ inline MFieldProxyConst<_DimensionCount, _Ts...> MakeProxyConst() const {
                 return MFieldProxyConst<_DimensionCount, _Ts...>(*this);
             }
         };
@@ -153,50 +153,50 @@ namespace bcuda {
             using element_t = typename basefb_t::template element_t<_Idx>;
 
 #pragma region Wrapper
-            __host__ __device__ __forceinline uint32_t LengthX() const requires (_DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthX() const requires (_DimensionCount <= 4) {
                 return basedb_t::LengthX();
             }
-            __host__ __device__ __forceinline uint32_t LengthY() const requires (_DimensionCount >= 2 && _DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthY() const requires (_DimensionCount >= 2 && _DimensionCount <= 4) {
                 return basedb_t::LengthY();
             }
-            __host__ __device__ __forceinline uint32_t LengthZ() const requires (_DimensionCount >= 3 && _DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthZ() const requires (_DimensionCount >= 3 && _DimensionCount <= 4) {
                 return basedb_t::LengthZ();
             }
-            __host__ __device__ __forceinline uint32_t LengthW() const requires (_DimensionCount == 4) {
+            __host__ __device__ inline uint32_t LengthW() const requires (_DimensionCount == 4) {
                 return basedb_t::LengthW();
             }
-            __host__ __device__ __forceinline uint32_t Length(size_t Idx) const {
+            __host__ __device__ inline uint32_t Length(size_t Idx) const {
                 return basedb_t::Length(Idx);
             }
-            __host__ __device__ __forceinline vector_t Dimensions() const {
+            __host__ __device__ inline vector_t Dimensions() const {
                 return basedb_t::Dimensions();
             }
-            __host__ __device__ __forceinline dim3 DimensionsD() const {
+            __host__ __device__ inline dim3 DimensionsD() const {
                 return basedb_t::DimensionsD();
             }
-            __host__ __device__ __forceinline vector_t IdxToCoords(uint64_t Index) const {
+            __host__ __device__ inline vector_t IdxToCoords(uint64_t Index) const {
                 return basedb_t::IdxToCoords(Index);
             }
-            __host__ __device__ __forceinline uint64_t CoordsToIdx(vector_t Coords) const {
+            __host__ __device__ inline uint64_t CoordsToIdx(vector_t Coords) const {
                 return basedb_t::CoordsToIdx(Coords);
             }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __host__ __device__ __forceinline uint64_t CoordsToIdx(_Ts... Coords) const {
+            __host__ __device__ inline uint64_t CoordsToIdx(_Ts... Coords) const {
                 return basedb_t::CoordsToIdx(Coords...);
             }
 
-            __host__ __device__ __forceinline size_t EachValueCount() const {
+            __host__ __device__ inline size_t EachValueCount() const {
                 return basefb_t::ValueCount();
             }
             template <size_t _Idx>
-            __host__ __device__ __forceinline size_t EachSizeOnGPU() const {
+            __host__ __device__ inline size_t EachSizeOnGPU() const {
                 return basefb_t::template EachSizeOnGPU<_Idx>();
             }
-            __host__ __device__ __forceinline size_t TotalValueCount() const {
+            __host__ __device__ inline size_t TotalValueCount() const {
                 return basefb_t::TotalValueCount();
             }
-            __host__ __device__ __forceinline size_t TotalSizeOnGPU() const {
+            __host__ __device__ inline size_t TotalSizeOnGPU() const {
                 return basefb_t::TotalSizeOnGPU();
             }
             template <size_t _Idx>
@@ -211,15 +211,15 @@ namespace bcuda {
             __host__ __device__ element_t<_Idx>* FData() const {
                 return basefb_t::template FData<_Idx>();
             }
-            __forceinline size_t SerializedSize() const requires (BSerializer::Serializable<_Ts> && ...) {
+            inline size_t SerializedSize() const requires (BSerializer::Serializable<_Ts> && ...) {
                 return basefb_t::SerializedSize();
             }
-            __forceinline void Serialize(void*& Data) const requires (BSerializer::Serializable<_Ts> && ...) {
+            inline void Serialize(void*& Data) const requires (BSerializer::Serializable<_Ts> && ...) {
                 basefb_t::Serialize(Data);
             }
 #pragma endregion
 
-            __host__ __device__ __forceinline MField<_DimensionCount, _Ts...> Clone() const {
+            __host__ __device__ inline MField<_DimensionCount, _Ts...> Clone() const {
                 return *(MField<_DimensionCount, _Ts...>*)&basefb_t::Clone();
             }
 
@@ -239,50 +239,50 @@ namespace bcuda {
             using element_t = typename basefb_t::template element_t<_Idx>;
 
 #pragma region Wrapper
-            __host__ __device__ __forceinline uint32_t LengthX() const requires (_DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthX() const requires (_DimensionCount <= 4) {
                 return basedb_t::LengthX();
             }
-            __host__ __device__ __forceinline uint32_t LengthY() const requires (_DimensionCount >= 2 && _DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthY() const requires (_DimensionCount >= 2 && _DimensionCount <= 4) {
                 return basedb_t::LengthY();
             }
-            __host__ __device__ __forceinline uint32_t LengthZ() const requires (_DimensionCount >= 3 && _DimensionCount <= 4) {
+            __host__ __device__ inline uint32_t LengthZ() const requires (_DimensionCount >= 3 && _DimensionCount <= 4) {
                 return basedb_t::LengthZ();
             }
-            __host__ __device__ __forceinline uint32_t LengthW() const requires (_DimensionCount == 4) {
+            __host__ __device__ inline uint32_t LengthW() const requires (_DimensionCount == 4) {
                 return basedb_t::LengthW();
             }
-            __host__ __device__ __forceinline uint32_t Length(size_t Idx) const {
+            __host__ __device__ inline uint32_t Length(size_t Idx) const {
                 return basedb_t::Length(Idx);
             }
-            __host__ __device__ __forceinline vector_t Dimensions() const {
+            __host__ __device__ inline vector_t Dimensions() const {
                 return basedb_t::Dimensions();
             }
-            __host__ __device__ __forceinline dim3 DimensionsD() const {
+            __host__ __device__ inline dim3 DimensionsD() const {
                 return basedb_t::DimensionsD();
             }
-            __host__ __device__ __forceinline vector_t IdxToCoords(uint64_t Index) const {
+            __host__ __device__ inline vector_t IdxToCoords(uint64_t Index) const {
                 return basedb_t::IdxToCoords(Index);
             }
-            __host__ __device__ __forceinline uint64_t CoordsToIdx(vector_t Coords) const {
+            __host__ __device__ inline uint64_t CoordsToIdx(vector_t Coords) const {
                 return basedb_t::CoordsToIdx(Coords);
             }
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
-            __host__ __device__ __forceinline uint64_t CoordsToIdx(_Ts... Coords) const {
+            __host__ __device__ inline uint64_t CoordsToIdx(_Ts... Coords) const {
                 return basedb_t::CoordsToIdx(Coords...);
             }
 
-            __host__ __device__ __forceinline size_t EachValueCount() const {
+            __host__ __device__ inline size_t EachValueCount() const {
                 return basefb_t::ValueCount();
             }
             template <size_t _Idx>
-            __host__ __device__ __forceinline size_t EachSizeOnGPU() const {
+            __host__ __device__ inline size_t EachSizeOnGPU() const {
                 return basefb_t::template EachSizeOnGPU<_Idx>();
             }
-            __host__ __device__ __forceinline size_t TotalValueCount() const {
+            __host__ __device__ inline size_t TotalValueCount() const {
                 return basefb_t::TotalValueCount();
             }
-            __host__ __device__ __forceinline size_t TotalSizeOnGPU() const {
+            __host__ __device__ inline size_t TotalSizeOnGPU() const {
                 return basefb_t::TotalSizeOnGPU();
             }
             template <size_t _Idx>
@@ -293,15 +293,15 @@ namespace bcuda {
             __host__ __device__ const element_t<_Idx>* FData() const {
                 return basefb_t::template FData<_Idx>();
             }
-            __forceinline size_t SerializedSize() const requires (BSerializer::Serializable<_Ts> && ...) {
+            inline size_t SerializedSize() const requires (BSerializer::Serializable<_Ts> && ...) {
                 return basefb_t::SerializedSize();
             }
-            __forceinline void Serialize(void*& Data) const requires (BSerializer::Serializable<_Ts> && ...) {
+            inline void Serialize(void*& Data) const requires (BSerializer::Serializable<_Ts> && ...) {
                 basefb_t::Serialize(Data);
             }
 #pragma endregion
 
-            __host__ __device__ __forceinline MField<_DimensionCount, _Ts...> Clone() const {
+            __host__ __device__ inline MField<_DimensionCount, _Ts...> Clone() const {
                 return *(MField<_DimensionCount, _Ts...>*)&basefb_t::Clone();
             }
 

--- a/fields_mfield.h
+++ b/fields_mfield.h
@@ -82,19 +82,19 @@ namespace bcuda {
                 return basefb_t::TotalSizeOnGPU();
             }
             template <size_t _Idx>
-            __host__ __device__ fields::FieldProxy<element_t<_Idx>, _DimensionCount> F() {
+            __host__ __device__ inline fields::FieldProxy<element_t<_Idx>, _DimensionCount> F() {
                 return basefb_t::template F<_Idx>();
             }
             template <size_t _Idx>
-            __host__ __device__ fields::FieldProxyConst<element_t<_Idx>, _DimensionCount> FConst() const {
+            __host__ __device__ inline fields::FieldProxyConst<element_t<_Idx>, _DimensionCount> FConst() const {
                 return basefb_t::template FConst<_Idx>();
             }
             template <size_t _Idx>
-            __host__ __device__ element_t<_Idx>* FData() {
+            __host__ __device__ inline element_t<_Idx>* FData() {
                 return basefb_t::template FData<_Idx>();
             }
             template <size_t _Idx>
-            __host__ __device__ const element_t<_Idx>* FData() const {
+            __host__ __device__ inline const element_t<_Idx>* FData() const {
                 return basefb_t::template FData<_Idx>();
             }
             inline size_t SerializedSize() const requires (BSerializer::Serializable<_Ts> && ...) {
@@ -200,15 +200,15 @@ namespace bcuda {
                 return basefb_t::TotalSizeOnGPU();
             }
             template <size_t _Idx>
-            __host__ __device__ fields::FieldProxy<element_t<_Idx>, _DimensionCount> F() const {
+            __host__ __device__ inline fields::FieldProxy<element_t<_Idx>, _DimensionCount> F() const {
                 return basefb_t::template F<_Idx>();
             }
             template <size_t _Idx>
-            __host__ __device__ fields::FieldProxyConst<element_t<_Idx>, _DimensionCount> FConst() const {
+            __host__ __device__ inline fields::FieldProxyConst<element_t<_Idx>, _DimensionCount> FConst() const {
                 return basefb_t::template FConst<_Idx>();
             }
             template <size_t _Idx>
-            __host__ __device__ element_t<_Idx>* FData() const {
+            __host__ __device__ inline element_t<_Idx>* FData() const {
                 return basefb_t::template FData<_Idx>();
             }
             inline size_t SerializedSize() const requires (BSerializer::Serializable<_Ts> && ...) {
@@ -223,9 +223,9 @@ namespace bcuda {
                 return *(MField<_DimensionCount, _Ts...>*)&basefb_t::Clone();
             }
 
-            __host__ __device__ MFieldProxy(const vector_t& Dimensions, void* const* Arrays)
+            __host__ __device__ inline MFieldProxy(const vector_t& Dimensions, void* const* Arrays)
                 : basefb_t(Dimensions, Arrays) { }
-            __host__ __device__ MFieldProxy(MField<_DimensionCount, _Ts...>& Parent)
+            __host__ __device__ inline MFieldProxy(MField<_DimensionCount, _Ts...>& Parent)
                 : basefb_t(Parent.Dimensions(), Parent.FieldDataArray()) { }
         };
         template <size_t _DimensionCount, typename... _Ts>
@@ -286,11 +286,11 @@ namespace bcuda {
                 return basefb_t::TotalSizeOnGPU();
             }
             template <size_t _Idx>
-            __host__ __device__ fields::FieldProxyConst<element_t<_Idx>, _DimensionCount> FConst() const {
+            __host__ __device__ inline fields::FieldProxyConst<element_t<_Idx>, _DimensionCount> FConst() const {
                 return basefb_t::template FConst<_Idx>();
             }
             template <size_t _Idx>
-            __host__ __device__ const element_t<_Idx>* FData() const {
+            __host__ __device__ inline const element_t<_Idx>* FData() const {
                 return basefb_t::template FData<_Idx>();
             }
             inline size_t SerializedSize() const requires (BSerializer::Serializable<_Ts> && ...) {
@@ -305,11 +305,11 @@ namespace bcuda {
                 return *(MField<_DimensionCount, _Ts...>*)&basefb_t::Clone();
             }
 
-            __host__ __device__ MFieldProxyConst(const vector_t& Dimensions, const void* const* Arrays)
+            __host__ __device__ inline MFieldProxyConst(const vector_t& Dimensions, const void* const* Arrays)
                 : basefb_t(Dimensions, const_cast<void* const*>(Arrays)) { }
-            __host__ __device__ MFieldProxyConst(const MField<_DimensionCount, _Ts...>& Parent)
+            __host__ __device__ inline MFieldProxyConst(const MField<_DimensionCount, _Ts...>& Parent)
                 : basefb_t(Parent.Dimensions(), Parent.FieldDataArray()) { }
-            __host__ __device__ MFieldProxyConst(const MFieldProxy<_DimensionCount, _Ts...>& Partner)
+            __host__ __device__ inline MFieldProxyConst(const MFieldProxy<_DimensionCount, _Ts...>& Partner)
                 : basefb_t(Partner.Dimensions(), Partner.FieldDataArray()) { }
         };
     }

--- a/fixedvectors.h
+++ b/fixedvectors.h
@@ -50,47 +50,148 @@ namespace bcuda {
         requires std::is_arithmetic_v<_T>
     struct FixedVector
         : public details::FixedVectorBase<_T, _Size> {
-        __host__ __device__ __forceinline constexpr FixedVector();
+        __host__ __device__ inline constexpr FixedVector() {
+            for (size_t i = 0; i < _Size; ++i) {
+                this->v[i] = 0;
+            }
+        }
         template <std::convertible_to<uint32_t>... _Ts>
             requires (sizeof...(_Ts) == _Size)
-        __host__ __device__ __forceinline constexpr FixedVector(_Ts... V) {
+        __host__ __device__ inline constexpr FixedVector(_Ts... V) {
             _T tempVs[_Size] = { V... };
             for (size_t i = 0; i < _Size; ++i)
                 this->v[i] = tempVs[i];
         }
-        __host__ __device__ __forceinline constexpr FixedVector(const _T V[_Size]);
+        __host__ __device__ inline constexpr FixedVector(const _T V[_Size]) {
+            for (size_t i = 0; i < _Size; ++i) {
+                this->v[i] = V[i];
+            }
+        }
 
-        __host__ __device__ __forceinline constexpr _T& operator[](size_t Index);
-        __host__ __device__ __forceinline constexpr const _T& operator[](size_t Index) const;
+        __host__ __device__ inline constexpr _T& operator[](size_t Index) {
+            return this->v[Index];
+        }
+        __host__ __device__ inline constexpr const _T& operator[](size_t Index) const {
+            return this->v[Index];
+        }
 
-        __host__ __device__ __forceinline constexpr FixedVector<_T, _Size> operator+(FixedVector<_T, _Size> Other) const;
-        __host__ __device__ __forceinline void operator+=(FixedVector<_T, _Size> Other);
-        __host__ __device__ __forceinline constexpr FixedVector<_T, _Size> operator-(FixedVector<_T, _Size> Other) const;
-        __host__ __device__ __forceinline void operator-=(FixedVector<_T, _Size> Other);
-        __host__ __device__ __forceinline constexpr FixedVector<_T, _Size> operator*(_T Other) const;
-        __host__ __device__ __forceinline void operator*=(_T Other);
-        __host__ __device__ __forceinline constexpr FixedVector<_T, _Size> operator/(_T Other) const;
-        __host__ __device__ __forceinline void operator/=(_T Other);
+        __host__ __device__ inline constexpr FixedVector<_T, _Size> operator+(FixedVector<_T, _Size> Other) const {
+            FixedVector<_T, _Size> r;
+            for (size_t i = 0; i < _Size; ++i) {
+                r[i] = this->v[i] + Other[i];
+            }
+            return r;
+        }
+        __host__ __device__ inline void operator+=(FixedVector<_T, _Size> Other) {
+            for (size_t i = 0; i < _Size; ++i) {
+                this->v[i] += Other[i];
+            }
+        }
+        __host__ __device__ inline constexpr FixedVector<_T, _Size> operator-(FixedVector<_T, _Size> Other) const {
+            FixedVector<_T, _Size> r;
+            for (size_t i = 0; i < _Size; ++i) {
+                r[i] = this->v[i] - Other[i];
+            }
+            return r;
+        }
+        __host__ __device__ inline void operator-=(FixedVector<_T, _Size> Other) {
+            for (size_t i = 0; i < _Size; ++i) {
+                this->v[i] -= Other[i];
+            }
+        }
+        __host__ __device__ inline constexpr FixedVector<_T, _Size> operator*(_T Other) const {
+            FixedVector<_T, _Size> r;
+            for (size_t i = 0; i < _Size; ++i) {
+                r[i] = this->v[i] * Other;
+            }
+            return r;
+        }
+        __host__ __device__ inline void operator*=(_T Other) {
+            for (size_t i = 0; i < _Size; ++i) {
+                this->v[i] *= Other;
+            }
+        }
+        __host__ __device__ inline constexpr FixedVector<_T, _Size> operator/(_T Other) const {
+            FixedVector<_T, _Size> r;
+            for (size_t i = 0; i < _Size; ++i) {
+                r[i] = this->v[i] / Other;
+            }
+            return r;
+        }
+        __host__ __device__ inline void operator/=(_T Other) {
+            for (size_t i = 0; i < _Size; ++i) {
+                this->v[i] /= Other;
+            }
+        }
 
-        __host__ __device__ static __forceinline constexpr _T Dot(FixedVector<_T, _Size> Left, FixedVector<_T, _Size> Right);
+        __host__ __device__ static inline constexpr _T Dot(FixedVector<_T, _Size> Left, FixedVector<_T, _Size> Right) {
+            _T t = 0;
+            for (size_t i = 0; i < _Size; ++i) {
+                t += Left[i] * Right[i];
+            }
+            return t;
+        }
 
-        __host__ __device__ __forceinline constexpr FixedVector<_T, 2> Cross() const requires (_Size == 2) {
+        __host__ __device__ inline constexpr FixedVector<_T, 2> Cross() const requires (_Size == 2) {
             return FixedVector<_T, 2>(-this->y, this->x);
         }
-        __host__ __device__ static __forceinline constexpr FixedVector<_T, 2> Cross(FixedVector<_T, 2> Value) requires (_Size == 2);
-        __host__ __device__ static __forceinline constexpr _T Cross(FixedVector<_T, 2> Left, FixedVector<_T, 2> Right) requires (_Size == 2);
+        __host__ __device__ static inline constexpr FixedVector<_T, 2> Cross(FixedVector<_T, 2> Value) requires (_Size == 2) {
+            return Value.Cross();
+        }
+        __host__ __device__ static inline constexpr _T Cross(FixedVector<_T, 2> Left, FixedVector<_T, 2> Right) requires (_Size == 2) {
+            return Left.x * Right.y - Left.y * Right.x;
+        }
 
-        __host__ __device__ static __forceinline constexpr FixedVector<_T, 3> Cross(FixedVector<_T, 3> Left, FixedVector<_T, 3> Right) requires (_Size == 3);
+        __host__ __device__ static inline constexpr FixedVector<_T, 3> Cross(FixedVector<_T, 3> Left, FixedVector<_T, 3> Right) requires (_Size == 3) {
+            return FixedVector<_T, 3>(
+                Left.y * Right.z - Left.z * Right.y,
+                Left.z * Right.x - Left.x * Right.z,
+                Left.x * Right.y - Left.y * Right.x
+            );
+        }
         
-        __host__ __device__ __forceinline constexpr _T MagnatudeSquared() const;
-        __host__ __device__ __forceinline _T MagnatudeI() const requires std::integral<_T>;
-        __host__ __device__ __forceinline float MagnatudeF() const requires std::integral<_T>;
-        __host__ __device__ __forceinline std::conditional_t<std::floating_point<_T>, _T, double> Magnatude() const;
+        __host__ __device__ inline constexpr _T MagnatudeSquared() const {
+            _T t = 0;
+            for (size_t i = 0; i < _Size; ++i) {
+                _T thisV = this->v[i];
+                t += thisV * thisV;
+            }
+            return t;
+        }
+        __host__ __device__ inline _T MagnatudeI() const requires std::integral<_T> {
+            return math::sqrt(MagnatudeSquared());
+        }
+        __host__ __device__ inline float MagnatudeF() const requires std::integral<_T> {
+            return sqrt((float)MagnatudeSquared());
+        }
+        __host__ __device__ inline std::conditional_t<std::floating_point<_T>, _T, double> Magnatude() const {
+            if constexpr (std::floating_point<_T>) {
+                return sqrt(MagnatudeSquared());
+            }
+            else {
+                return sqrt((double)MagnatudeSquared());
+            }
+        }
 
-        __forceinline size_t SerializedSize() const;
-        __forceinline void Serialize(void*& Data) const;
-        static __forceinline FixedVector<_T, _Size> Deserialize(const void*& Data);
-        static __forceinline void Deserialize(const void*& Data, void* Value);
+        inline size_t SerializedSize() const {
+            return sizeof(_T) * _Size;
+        }
+        inline void Serialize(void*& Data) const {
+            for (size_t i = 0; i < _Size; ++i)
+                BSerializer::Serialize(Data, this->v[i]);
+        }
+        static inline FixedVector<_T, _Size> Deserialize(const void*& Data) {
+            bcuda::FixedVector<_T, _Size> vec;
+            for (size_t i = 0; i < _Size; ++i)
+                vec[i] = BSerializer::Deserialize<_T>(Data);
+            return vec;
+        }
+        static inline void Deserialize(const void*& Data, void* Value) {
+            FixedVector<_T, _Size>* p_vec = new (Value) FixedVector<_T, _Size>;
+            FixedVector<_T, _Size>& vec = *p_vec;
+            for (size_t i = 0; i < _Size; ++i)
+                vec[i] = BSerializer::Deserialize<_T>(Data);
+        }
     };
 
     using float_1 = FixedVector<float, 1>;
@@ -133,180 +234,4 @@ namespace bcuda {
     using uint64_2 = FixedVector<uint64_t, 2>;
     using uint64_3 = FixedVector<uint64_t, 3>;
     using uint64_4 = FixedVector<uint64_t, 4>;
-}
-
-template <typename _T, size_t _Size>
-    requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr bcuda::FixedVector<_T, _Size>::FixedVector() {
-    for (size_t i = 0; i < _Size; ++i) {
-        this->v[i] = 0;
-    }
-}
-template <typename _T, size_t _Size>
-    requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr bcuda::FixedVector<_T, _Size>::FixedVector(const _T V[_Size]) {
-    for (size_t i = 0; i < _Size; ++i) {
-        this->v[i] = V[i];
-    }
-}
-template <typename _T, size_t _Size>
-    requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr _T& bcuda::FixedVector<_T, _Size>::operator[](size_t Index) {
-    return this->v[Index];
-}
-template <typename _T, size_t _Size>
-    requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr const _T& bcuda::FixedVector<_T, _Size>::operator[](size_t Index) const {
-    return this->v[Index];
-}
-template <typename _T, size_t _Size>
-    requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr auto bcuda::FixedVector<_T, _Size>::operator+(FixedVector<_T, _Size> Other) const -> FixedVector<_T, _Size> {
-    FixedVector<_T, _Size> r;
-    for (size_t i = 0; i < _Size; ++i) {
-        r[i] = this->v[i] + Other[i];
-    }
-    return r;
-}
-template <typename _T, size_t _Size>
-    requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline void bcuda::FixedVector<_T, _Size>::operator+=(FixedVector<_T, _Size> Other) {
-    for (size_t i = 0; i < _Size; ++i) {
-        this->v[i] += Other[i];
-    }
-}
-template <typename _T, size_t _Size>
-    requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr auto bcuda::FixedVector<_T, _Size>::operator-(FixedVector<_T, _Size> Other) const -> FixedVector<_T, _Size> {
-    FixedVector<_T, _Size> r;
-    for (size_t i = 0; i < _Size; ++i) {
-        r[i] = this->v[i] - Other[i];
-    }
-    return r;
-}
-template <typename _T, size_t _Size>
-    requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline void bcuda::FixedVector<_T, _Size>::operator-=(FixedVector<_T, _Size> Other) {
-    for (size_t i = 0; i < _Size; ++i) {
-        this->v[i] -= Other[i];
-    }
-}
-template <typename _T, size_t _Size>
-    requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr auto bcuda::FixedVector<_T, _Size>::operator*(_T Other) const -> FixedVector<_T, _Size> {
-    FixedVector<_T, _Size> r;
-    for (size_t i = 0; i < _Size; ++i) {
-        r[i] = this->v[i] * Other;
-    }
-    return r;
-}
-template <typename _T, size_t _Size>
-    requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline void bcuda::FixedVector<_T, _Size>::operator*=(_T Other) {
-    for (size_t i = 0; i < _Size; ++i) {
-        this->v[i] *= Other;
-    }
-}
-template <typename _T, size_t _Size>
-    requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr auto bcuda::FixedVector<_T, _Size>::operator/(_T Other) const -> FixedVector<_T, _Size> {
-    FixedVector<_T, _Size> r;
-    for (size_t i = 0; i < _Size; ++i) {
-        r[i] = this->v[i] / Other;
-    }
-    return r;
-}
-template <typename _T, size_t _Size>
-    requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline void bcuda::FixedVector<_T, _Size>::operator/=(_T Other) {
-    for (size_t i = 0; i < _Size; ++i) {
-        this->v[i] /= Other;
-    }
-}
-template <typename _T, size_t _Size>
-    requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr _T bcuda::FixedVector<_T, _Size>::Dot(FixedVector<_T, _Size> Left, FixedVector<_T, _Size> Right) {
-    _T t = 0;
-    for (size_t i = 0; i < _Size; ++i) {
-        t += Left[i] * Right[i];
-    }
-    return t;
-}
-template <typename _T, size_t _Size>
-    requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr _T bcuda::FixedVector<_T, _Size>::MagnatudeSquared() const {
-    _T t = 0;
-    for (size_t i = 0; i < _Size; ++i) {
-        _T thisV = this->v[i];
-        t += thisV * thisV;
-    }
-    return t;
-}
-template <typename _T, size_t _Size>
-    requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline _T bcuda::FixedVector<_T, _Size>::MagnatudeI() const requires std::integral<_T> {
-    return math::sqrt(MagnatudeSquared());
-}
-template <typename _T, size_t _Size>
-    requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline float bcuda::FixedVector<_T, _Size>::MagnatudeF() const requires std::integral<_T> {
-    return sqrt((float)MagnatudeSquared());
-}
-template <typename _T, size_t _Size>
-    requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline std::conditional_t<std::floating_point<_T>, _T, double> bcuda::FixedVector<_T, _Size>::Magnatude() const {
-    if constexpr (std::floating_point<_T>) {
-        return sqrt(MagnatudeSquared());
-    }
-    else {
-        return sqrt((double)MagnatudeSquared());
-    }
-}
-template <typename _T, size_t _Size>
-    requires std::is_arithmetic_v<_T>
-__forceinline size_t bcuda::FixedVector<_T, _Size>::SerializedSize() const {
-    return sizeof(_T) * _Size;
-}
-template <typename _T, size_t _Size>
-    requires std::is_arithmetic_v<_T>
-__forceinline void bcuda::FixedVector<_T, _Size>::Serialize(void*& Data) const {
-    for (size_t i = 0; i < _Size; ++i)
-        BSerializer::Serialize(Data, this->v[i]);
-}
-template <typename _T, size_t _Size>
-    requires std::is_arithmetic_v<_T>
-__forceinline bcuda::FixedVector<_T, _Size> bcuda::FixedVector<_T, _Size>::Deserialize(const void*& Data) {
-    bcuda::FixedVector<_T, _Size> vec;
-    for (size_t i = 0; i < _Size; ++i)
-        vec[i] = BSerializer::Deserialize<_T>(Data);
-    return vec;
-}
-template <typename _T, size_t _Size>
-    requires std::is_arithmetic_v<_T>
-__forceinline void bcuda::FixedVector<_T, _Size>::Deserialize(const void*& Data, void* Value) {
-    FixedVector<_T, _Size>* p_vec = new (Value) FixedVector<_T, _Size>;
-    FixedVector<_T, _Size>& vec = *p_vec;
-    for (size_t i = 0; i < _Size; ++i)
-        vec[i] = BSerializer::Deserialize<_T>(Data);
-}
-
-template <typename _T, size_t _Size>
-    requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr bcuda::FixedVector<_T, 2> bcuda::FixedVector<_T, _Size>::Cross(FixedVector<_T, 2> Value) requires (_Size == 2) {
-    return Value.Cross();
-}
-template <typename _T, size_t _Size>
-    requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr _T bcuda::FixedVector<_T, _Size>::Cross(FixedVector<_T, 2> Left, FixedVector<_T, 2> Right) requires (_Size == 2) {
-    return Left.x * Right.y - Left.y * Right.x;
-}
-
-template <typename _T, size_t _Size>
-    requires std::is_arithmetic_v<_T>
-__host__ __device__ __forceinline constexpr bcuda::FixedVector<_T, 3> bcuda::FixedVector<_T, _Size>::Cross(FixedVector<_T, 3> Left, FixedVector<_T, 3> Right) requires (_Size == 3) {
-    return FixedVector<_T, 3>(
-        Left.y * Right.z - Left.z * Right.y,
-        Left.z * Right.x - Left.x * Right.z,
-        Left.x * Right.y - Left.y * Right.x
-    );
 }

--- a/kernellaunch.cuh
+++ b/kernellaunch.cuh
@@ -6,16 +6,16 @@
 
 namespace bcuda {
 #ifdef __CUDACC__
-    __device__ uint32_t GetCoordinates1() {
+    __device__ static inline uint32_t GetCoordinates1() {
         return blockIdx.x * blockDim.x + threadIdx.x;
     }
-    __device__ uint32_2 GetCoordinates2() {
+    __device__ static inline uint32_2 GetCoordinates2() {
         return uint32_2(
             blockIdx.x * blockDim.x + threadIdx.x,
             blockIdx.y * blockDim.y + threadIdx.y
         );
     }
-    __device__ uint32_3 GetCoordinates3() {
+    __device__ static inline uint32_3 GetCoordinates3() {
         return uint32_3(
             blockIdx.x * blockDim.x + threadIdx.x,
             blockIdx.y * blockDim.y + threadIdx.y,

--- a/mathfuncs.h
+++ b/mathfuncs.h
@@ -8,14 +8,7 @@
 namespace bcuda {
     namespace math {
         template <typename _T>
-        __host__ __device__ static inline _T sqrt(_T value) {
-            if constexpr (std::signed_integral<_T>)
-                return (_T)sqrt((int32_t)value);
-            else if constexpr (std::unsigned_integral<_T>)
-                return (_T)sqrt((uint32_t)value);
-            else
-                return std::sqrt(value);
-        }
+        __host__ __device__ static inline _T sqrt(_T value);
         template <>
         __host__ __device__ static inline int32_t sqrt<int32_t>(int32_t value) {
             if (value < 0)
@@ -91,6 +84,15 @@ namespace bcuda {
             } while (upper > (lower + 1));
 
             return lower;
+        }
+        template <typename _T>
+        __host__ __device__ static inline _T sqrt(_T value) {
+            if constexpr (std::signed_integral<_T>)
+                return (_T)sqrt((int32_t)value);
+            else if constexpr (std::unsigned_integral<_T>)
+                return (_T)sqrt((uint32_t)value);
+            else
+                return std::sqrt(value);
         }
 
         template <typename _T>

--- a/mathfuncs.h
+++ b/mathfuncs.h
@@ -8,120 +8,98 @@
 namespace bcuda {
     namespace math {
         template <typename _T>
-        __host__ __device__ static __forceinline _T sqrt(_T value);
+        __host__ __device__ static inline _T sqrt(_T value) {
+            if constexpr (std::signed_integral<_T>)
+                return (_T)sqrt((int32_t)value);
+            else if constexpr (std::unsigned_integral<_T>)
+                return (_T)sqrt((uint32_t)value);
+            else
+                return std::sqrt(value);
+        }
+        template <>
+        __host__ __device__ static inline int32_t sqrt<int32_t>(int32_t value) {
+            if (value < 0)
+                return -1;
+            else if (value < 2)
+                return value;
+
+            int32_t lower = 2;
+            int32_t upper = value >> 1;
+
+            do {
+                int32_t mid = lower + ((upper - lower) >> 1);
+                if (value >= mid * mid)
+                    lower = mid;
+                else
+                    upper = mid;
+            } while (upper > (lower + 1));
+
+            return lower;
+        }
+        template <>
+        __host__ __device__ static inline uint32_t sqrt<uint32_t>(uint32_t value) {
+            if (value < 2)
+                return value;
+
+            uint32_t lower = 2;
+            uint32_t upper = value >> 1;
+
+            do {
+                uint32_t mid = lower + ((upper - lower) >> 1);
+                if (value >= mid * mid)
+                    lower = mid;
+                else
+                    upper = mid;
+            } while (upper > (lower + 1));
+
+            return lower;
+        }
+        template <>
+        __host__ __device__ static inline int64_t sqrt<int64_t>(int64_t value) {
+            if (value < 0)
+                return -1;
+            else if (value < 2)
+                return value;
+
+            int64_t lower = 2;
+            int64_t upper = value >> 1;
+
+            do {
+                int64_t mid = lower + ((upper - lower) >> 1);
+                if (value >= mid * mid)
+                    lower = mid;
+                else
+                    upper = mid;
+            } while (upper > (lower + 1));
+
+            return lower;
+        }
+        template <>
+        __host__ __device__ static inline uint64_t sqrt<uint64_t>(uint64_t value) {
+            if (value < 2)
+                return value;
+
+            uint64_t lower = 2;
+            uint64_t upper = value >> 1;
+
+            do {
+                uint64_t mid = lower + ((upper - lower) >> 1);
+                if (value >= mid * mid)
+                    lower = mid;
+                else
+                    upper = mid;
+            } while (upper > (lower + 1));
+
+            return lower;
+        }
 
         template <typename _T>
-        __host__ __device__ static __forceinline _T clamp(_T value, _T lower, _T upper);
-    }
-}
-
-template <>
-__host__ __device__ static __forceinline int32_t bcuda::math::sqrt<int32_t>(int32_t value) {
-    if (value < 0) {
-        return -1;
-    }
-    else if (value < 2) {
-        return value;
-    }
-
-    int32_t lower = 2;
-    int32_t upper = value >> 1;
-
-    do {
-        int32_t mid = lower + ((upper - lower) >> 1);
-        if (value >= mid * mid) {
-            lower = mid;
+        __host__ __device__ static inline _T clamp(_T value, _T lower, _T upper) {
+            if (value < lower)
+                return lower;
+            if (value > upper)
+                return upper;
+            return value;
         }
-        else {
-            upper = mid;
-        }
-    } while (upper > (lower + 1));
-
-    return lower;
-}
-template <>
-__host__ __device__ static __forceinline uint32_t bcuda::math::sqrt<uint32_t>(uint32_t value) {
-    if (value < 2) {
-        return value;
     }
-
-    uint32_t lower = 2;
-    uint32_t upper = value >> 1;
-
-    do {
-        uint32_t mid = lower + ((upper - lower) >> 1);
-        if (value >= mid * mid) {
-            lower = mid;
-        }
-        else {
-            upper = mid;
-        }
-    } while (upper > (lower + 1));
-
-    return lower;
-}
-template <>
-__host__ __device__ static __forceinline int64_t bcuda::math::sqrt<int64_t>(int64_t value) {
-    if (value < 0) {
-        return -1;
-    }
-    else if (value < 2) {
-        return value;
-    }
-
-    int64_t lower = 2;
-    int64_t upper = value >> 1;
-
-    do {
-        int64_t mid = lower + ((upper - lower) >> 1);
-        if (value >= mid * mid) {
-            lower = mid;
-        }
-        else {
-            upper = mid;
-        }
-    } while (upper > (lower + 1));
-
-    return lower;
-}
-template <>
-__host__ __device__ static __forceinline uint64_t bcuda::math::sqrt<uint64_t>(uint64_t value) {
-    if (value < 2) {
-        return value;
-    }
-
-    uint64_t lower = 2;
-    uint64_t upper = value >> 1;
-
-    do {
-        uint64_t mid = lower + ((upper - lower) >> 1);
-        if (value >= mid * mid) {
-            lower = mid;
-        }
-        else {
-            upper = mid;
-        }
-    } while (upper > (lower + 1));
-
-    return lower;
-}
-template <typename _T>
-__host__ __device__ static __forceinline _T bcuda::math::sqrt(_T value) {
-    if constexpr (std::signed_integral<_T>)
-        return (_T)sqrt((int32_t)value);
-    else if constexpr (std::unsigned_integral<_T>)
-        return (_T)sqrt((uint32_t)value);
-    else
-        return std::sqrt(value);
-}
-
-template <typename _T>
-__host__ __device__ static __forceinline _T bcuda::math::clamp(_T value, _T lower, _T upper) {
-    if (value < lower) {
-        return lower;
-    }
-    if (value > upper) {
-        return upper;
-    }
-    return value;
 }

--- a/nets_net.cu
+++ b/nets_net.cu
@@ -19,667 +19,671 @@ __global__ void replaceBase(bcuda::nets::NetNode* oldBase, bcuda::nets::NetNode*
     newNode = oldNode - oldBase + newBase;
 }
 
-bcuda::nets::Net bcuda::nets::Net::Clone(dataCloner_t DataCloner) const {
-    thrust::device_vector<NetNode>* p_newNodes = new thrust::device_vector<NetNode>(nodes.size());
-    thrust::device_vector<NetNode>& newNodes = *p_newNodes;
-    NetNode* oldBaseNN = nodes.data().get();
-    NetNode* newBaseNN = newNodes.data().get();
-    for (size_t i = 0; i < nodes.size(); ++i) {
-        NetNode oldNN = nodes[i];
-        NetNode newNN;
-        newNN.data = DataCloner(oldNN);
-        newNN.inputCount = oldNN.inputCount;
-        newNN.outputCount = oldNN.outputCount;
-        cudaMalloc(&newNN.inputs, sizeof(NetNode*) * oldNN.inputCount);
-        cudaMalloc(&newNN.outputs, sizeof(NetNode*) * oldNN.outputCount);
-        replaceBase<<<oldNN.inputCount, 1>>>(oldBaseNN, oldNN.inputs, newBaseNN, newNN.inputs);
-        replaceBase<<<oldNN.outputCount, 1>>>(oldBaseNN, oldNN.outputs, newBaseNN, newNN.outputs);
-        newNodes[i] = newNN;
-    }
-    return Net(newNodes);
-}
-
-bool bcuda::nets::Net::AddConnection_OnlyInput(NetNode* InputNode, NetNode* OutputNode, bool CheckForPreexistence, bool CheckForAvailableExcess) {
-    NetNode in = GetVR(InputNode);
-
-    if (in.outputs) {
-        if (CheckForPreexistence) {
-            bool f = false;
-            bool* opt;
-            ThrowIfBad(cudaMalloc(&opt, sizeof(bool)));
-            ThrowIfBad(cudaMemcpy(opt, &f, sizeof(bool), cudaMemcpyHostToDevice));
-            net_addConnection_checkForPreexistence<<<in.outputCount, 1>>>(in.outputs, OutputNode, opt);
-            ThrowIfBad(cudaMemcpy(&f, opt, sizeof(bool), cudaMemcpyDeviceToHost));
-            ThrowIfBad(cudaFree(opt));
-            if (f) {
-                return false;
+namespace bcuda {
+    namespace nets {
+        Net Net::Clone(dataCloner_t DataCloner) const {
+            thrust::device_vector<NetNode>* p_newNodes = new thrust::device_vector<NetNode>(nodes.size());
+            thrust::device_vector<NetNode>& newNodes = *p_newNodes;
+            NetNode* oldBaseNN = nodes.data().get();
+            NetNode* newBaseNN = newNodes.data().get();
+            for (size_t i = 0; i < nodes.size(); ++i) {
+                NetNode oldNN = nodes[i];
+                NetNode newNN;
+                newNN.data = DataCloner(oldNN);
+                newNN.inputCount = oldNN.inputCount;
+                newNN.outputCount = oldNN.outputCount;
+                cudaMalloc(&newNN.inputs, sizeof(NetNode*) * oldNN.inputCount);
+                cudaMalloc(&newNN.outputs, sizeof(NetNode*) * oldNN.outputCount);
+                replaceBase<<<oldNN.inputCount, 1>>>(oldBaseNN, oldNN.inputs, newBaseNN, newNN.inputs);
+                replaceBase<<<oldNN.outputCount, 1>>>(oldBaseNN, oldNN.outputs, newBaseNN, newNN.outputs);
+                newNodes[i] = newNN;
             }
+            return Net(newNodes);
         }
 
-        bool in_o_e;
-        if (CheckForAvailableExcess) {
-            size_t s;
-            ThrowIfBad(cuMemGetAddressRange_v2(0, &s, (CUdeviceptr_v2)in.outputs));
-            in_o_e = (s >= (in.outputCount + 1) * sizeof(NetNode*));
-        }
-        else {
-            in_o_e = false;
-        }
+        bool Net::AddConnection_OnlyInput(NetNode* InputNode, NetNode* OutputNode, bool CheckForPreexistence, bool CheckForAvailableExcess) {
+            NetNode in = GetVR(InputNode);
 
-        if (!in.outputs) {
-            ThrowIfBad(cudaMalloc(&in.outputs, sizeof(NetNode*)));
-            SetVR(in.outputs, OutputNode);
-            in.outputCount = 1;
-        }
-        else if (in_o_e) {
-            ThrowIfBad(cudaMemcpy(in.outputs + in.outputCount, &OutputNode, sizeof(NetNode*), cudaMemcpyHostToDevice));
-            in.outputCount++;
-        }
-        else {
-            NetNode** n;
-            size_t noc = in.outputCount + 1;
-            ThrowIfBad(cudaMalloc(&n, sizeof(NetNode*) * noc));
-            ThrowIfBad(cudaMemcpy(n, in.outputs, sizeof(NetNode*) * in.outputCount, cudaMemcpyDeviceToDevice));
-            ThrowIfBad(cudaMemcpy(n + in.outputCount, &OutputNode, sizeof(NetNode*), cudaMemcpyHostToDevice));
-            ThrowIfBad(cudaFree(in.outputs));
-            in.outputs = n;
-            in.outputCount = noc;
-        }
-    }
-    else {
-        ThrowIfBad(cudaMalloc(&in.outputs, sizeof(NetNode*)));
-        SetVR(in.outputs, OutputNode);
-        in.outputCount = 1;
-    }
-
-    SetVR(InputNode, in);
-    return true;
-}
-bool bcuda::nets::Net::AddConnection_OnlyOutput(NetNode* InputNode, NetNode* OutputNode, bool CheckForPreexistence, bool CheckForAvailableExcess) {
-    NetNode on = GetVR(InputNode);
-
-    if (on.inputs) {
-        if (CheckForPreexistence) {
-            bool f = false;
-            bool* opt;
-            ThrowIfBad(cudaMalloc(&opt, sizeof(bool)));
-            ThrowIfBad(cudaMemcpy(opt, &f, sizeof(bool), cudaMemcpyHostToDevice));
-            net_addConnection_checkForPreexistence<<<on.inputCount, 1>>>(on.inputs, InputNode, opt);
-            ThrowIfBad(cudaMemcpy(&f, opt, sizeof(bool), cudaMemcpyDeviceToHost));
-            ThrowIfBad(cudaFree(opt));
-            if (f) {
-                return false;
-            }
-        }
-
-        bool on_i_e;
-        if (CheckForAvailableExcess) {
-            size_t s;
-            ThrowIfBad(cuMemGetAddressRange_v2(0, &s, (CUdeviceptr_v2)on.inputs));
-            on_i_e = (s >= (on.inputCount + 1) * sizeof(NetNode*));
-        }
-        else {
-            on_i_e = false;
-        }
-
-        if (!on.inputs) {
-            ThrowIfBad(cudaMalloc(&on.inputs, sizeof(NetNode*)));
-            SetVR(on.inputs, InputNode);
-            on.inputCount = 1;
-        }
-        else if (on_i_e) {
-            ThrowIfBad(cudaMemcpy(on.inputs + on.inputCount, &InputNode, sizeof(NetNode*), cudaMemcpyHostToDevice));
-            on.inputCount++;
-        }
-        else {
-            NetNode** n;
-            size_t nic = on.inputCount + 1;
-            ThrowIfBad(cudaMalloc(&n, sizeof(NetNode*) * nic));
-            ThrowIfBad(cudaMemcpy(n, on.inputs, sizeof(NetNode*) * on.inputCount, cudaMemcpyDeviceToDevice));
-            ThrowIfBad(cudaMemcpy(n + on.inputCount, &InputNode, sizeof(NetNode*), cudaMemcpyHostToDevice));
-            ThrowIfBad(cudaFree(on.inputs));
-            on.inputs = n;
-            on.inputCount = nic;
-        }
-    }
-    else {
-        ThrowIfBad(cudaMalloc(&on.inputs, sizeof(NetNode*)));
-        SetVR(on.inputs, InputNode);
-        on.inputCount = 1;
-    }
-
-    SetVR(OutputNode, on);
-    return true;
-}
-bool bcuda::nets::Net::AddConnection(NetNode* InputNode, NetNode* OutputNode, bool CheckForPreexistence, bool CheckForAvailableExcess) {
-    if (InputNode != OutputNode) {
-        NetNode in = GetVR(InputNode);
-        NetNode on = GetVR(OutputNode);
-
-        if (CheckForPreexistence && in.outputs) {
-            bool f = false;
-            bool* opt;
-            ThrowIfBad(cudaMalloc(&opt, sizeof(bool)));
-            ThrowIfBad(cudaMemcpy(opt, &f, sizeof(bool), cudaMemcpyHostToDevice));
-            net_addConnection_checkForPreexistence<<<in.outputCount, 1>>>(in.outputs, OutputNode, opt);
-            ThrowIfBad(cudaMemcpy(&f, opt, sizeof(bool), cudaMemcpyDeviceToHost));
-            ThrowIfBad(cudaFree(opt));
-            if (f) {
-                return false;
-            }
-        }
-
-        bool in_o_e;
-        bool on_i_e;
-        if (CheckForAvailableExcess) {
-            size_t s;
             if (in.outputs) {
-                ThrowIfBad(cuMemGetAddressRange_v2(0, &s, (CUdeviceptr_v2)in.outputs));
-                in_o_e = (s >= (in.outputCount + 1) * sizeof(NetNode*));
-            }
-            else {
-                in_o_e = false;
-            }
-            if (on.inputs) {
-                ThrowIfBad(cuMemGetAddressRange_v2(0, &s, (CUdeviceptr_v2)on.inputs));
-                on_i_e = (s >= (on.inputCount + 1) * sizeof(NetNode*));
-            }
-            else {
-                on_i_e = false;
-            }
-        }
-        else {
-            in_o_e = false;
-            on_i_e = false;
-        }
-
-        if (!in.outputs) {
-            ThrowIfBad(cudaMalloc(&in.outputs, sizeof(NetNode*)));
-            SetVR(in.outputs, OutputNode);
-            in.outputCount = 1;
-        }
-        else if (in_o_e) {
-            ThrowIfBad(cudaMemcpy(in.outputs + in.outputCount, &OutputNode, sizeof(NetNode*), cudaMemcpyHostToDevice));
-            in.outputCount++;
-        }
-        else {
-            NetNode** n;
-            size_t noc = in.outputCount + 1;
-            ThrowIfBad(cudaMalloc(&n, sizeof(NetNode*) * noc));
-            if (in.outputs) {
-                ThrowIfBad(cudaMemcpy(n, in.outputs, sizeof(NetNode*) * in.outputCount, cudaMemcpyDeviceToDevice));
-            }
-            ThrowIfBad(cudaMemcpy(n + in.outputCount, &OutputNode, sizeof(NetNode*), cudaMemcpyHostToDevice));
-            ThrowIfBad(cudaFree(in.outputs));
-            in.outputs = n;
-            in.outputCount = noc;
-        }
-
-        if (!on.inputs) {
-            ThrowIfBad(cudaMalloc(&on.inputs, sizeof(NetNode*)));
-            SetVR(on.inputs, InputNode);
-            on.inputCount = 1;
-        }
-        else if (on_i_e) {
-            ThrowIfBad(cudaMemcpy(on.inputs + on.inputCount, &InputNode, sizeof(NetNode*), cudaMemcpyHostToDevice));
-            on.inputCount++;
-        }
-        else {
-            NetNode** n;
-            size_t nic = on.inputCount + 1;
-            ThrowIfBad(cudaMalloc(&n, sizeof(NetNode*) * nic));
-            if (on.inputs) {
-                ThrowIfBad(cudaMemcpy(n, on.inputs, sizeof(NetNode*) * on.inputCount, cudaMemcpyDeviceToDevice));
-            }
-            ThrowIfBad(cudaMemcpy(n + on.inputCount, &InputNode, sizeof(NetNode*), cudaMemcpyHostToDevice));
-            ThrowIfBad(cudaFree(on.inputs));
-            on.inputs = n;
-            on.inputCount = nic;
-        }
-
-        SetVR(InputNode, in);
-        SetVR(OutputNode, on);
-        return true;
-    }
-    else {
-        NetNode n = GetVR(InputNode);
-
-        if (CheckForPreexistence && n.inputs) {
-            bool f = false;
-            bool* opt;
-            ThrowIfBad(cudaMalloc(&opt, sizeof(bool)));
-            ThrowIfBad(cudaMemcpy(opt, &f, sizeof(bool), cudaMemcpyHostToDevice));
-            net_addConnection_checkForPreexistence<<<n.inputCount, 1>>>(n.inputs, InputNode, opt);
-            ThrowIfBad(cudaMemcpy(&f, opt, sizeof(bool), cudaMemcpyDeviceToHost));
-            ThrowIfBad(cudaFree(opt));
-            if (f) {
-                return false;
-            }
-        }
-
-        bool n_o_e;
-        bool n_i_e;
-        if (CheckForAvailableExcess) {
-            size_t s;
-            if (n.outputs) {
-                ThrowIfBad(cuMemGetAddressRange_v2(0, &s, (CUdeviceptr_v2)n.outputs));
-                n_o_e = (s >= (n.outputCount + 1) * sizeof(NetNode*));
-            }
-            else {
-                n_o_e = false;
-            }
-            if (n.inputs) {
-                ThrowIfBad(cuMemGetAddressRange_v2(0, &s, (CUdeviceptr_v2)n.inputs));
-                n_i_e = (s >= (n.inputCount + 1) * sizeof(NetNode*));
-            }
-            else {
-                n_i_e = false;
-            }
-        }
-        else {
-            n_o_e = false;
-            n_i_e = false;
-        }
-
-        if (!n.outputs) {
-            ThrowIfBad(cudaMalloc(&n.outputs, sizeof(NetNode*)));
-            SetVR(n.outputs, OutputNode);
-            n.outputCount = 1;
-        }
-        else if (n_o_e) {
-            ThrowIfBad(cudaMemcpy(n.outputs + n.outputCount, &OutputNode, sizeof(NetNode*), cudaMemcpyHostToDevice));
-            n.outputCount++;
-        }
-        else {
-            NetNode** ns;
-            size_t noc = n.outputCount + 1;
-            ThrowIfBad(cudaMalloc(&ns, sizeof(NetNode*) * noc));
-            if (n.outputs) {
-                ThrowIfBad(cudaMemcpy(ns, n.outputs, sizeof(NetNode*) * n.outputCount, cudaMemcpyDeviceToDevice));
-            }
-            ThrowIfBad(cudaMemcpy(ns + n.outputCount, &OutputNode, sizeof(NetNode*), cudaMemcpyHostToDevice));
-            ThrowIfBad(cudaFree(n.outputs));
-            n.outputs = ns;
-            n.outputCount = noc;
-        }
-
-        if (!n.inputs) {
-            ThrowIfBad(cudaMalloc(&n.inputs, sizeof(NetNode*)));
-            SetVR(n.inputs, InputNode);
-            n.inputCount = 1;
-        }
-        else if (n_i_e) {
-            ThrowIfBad(cudaMemcpy(n.inputs + n.inputCount, &InputNode, sizeof(NetNode*), cudaMemcpyHostToDevice));
-            n.inputCount++;
-        }
-        else {
-            NetNode** ns;
-            size_t nic = n.inputCount + 1;
-            ThrowIfBad(cudaMalloc(&ns, sizeof(NetNode*) * nic));
-            if (n.inputs) {
-                ThrowIfBad(cudaMemcpy(ns, n.inputs, sizeof(NetNode*) * n.inputCount, cudaMemcpyDeviceToDevice));
-            }
-            ThrowIfBad(cudaMemcpy(ns + n.inputCount, &InputNode, sizeof(NetNode*), cudaMemcpyHostToDevice));
-            ThrowIfBad(cudaFree(n.inputs));
-            n.inputs = ns;
-            n.inputCount = nic;
-        }
-
-        SetVR(InputNode, n);
-        return true;
-    }
-}
-
-bool bcuda::nets::Net::RemoveConnection_OnlyInput(NetNode* InputNode, NetNode* OutputNode, bool RemoveExcess) {
-    NetNode in = GetVR(InputNode);
-
-    if (in.outputs) {
-        NetNode** in_o = new NetNode*[in.outputCount];
-
-        ThrowIfBad(cudaMemcpy(in_o, in.outputs, sizeof(NetNode*) * in.outputCount, cudaMemcpyDeviceToHost));
-
-        if (RemoveExcess) {
-            for (size_t i = 0; i < in.outputCount; ++i) {
-                if (in_o[i] == OutputNode) {
-                    in_o[i] = in_o[in.outputCount - 1];
-                    goto ExitA;
-                }
-            }
-            return false;
-
-ExitA:
-            in.outputCount--;
-
-            NetNode** in_o_n;
-
-            if (in.outputCount) {
-                ThrowIfBad(cudaMalloc(&in_o_n, sizeof(NetNode*) * in.outputCount));
-
-                ThrowIfBad(cudaMemcpy(in_o_n, in_o, sizeof(NetNode*) * in.outputCount, cudaMemcpyHostToDevice));
-            }
-            else {
-                in_o_n = 0;
-            }
-
-            delete[] in_o;
-
-            ThrowIfBad(cudaFree(in.outputs));
-
-            in.outputs = in_o_n;
-        }
-        else {
-            for (size_t i = 0; i < in.outputCount; ++i) {
-                if (in_o[i] == OutputNode) {
-                    ThrowIfBad(cudaMemcpy(in.outputs + i, in.outputs + (in.outputCount - 1), sizeof(NetNode*), cudaMemcpyDeviceToDevice));
-                    in_o[i] = in_o[in.outputCount - 1];
-                    goto ExitB;
-                }
-            }
-            return false;
-
-ExitB:
-            in.outputCount--;
-        }
-        SetVR(InputNode, in);
-        return true;
-    }
-    else {
-        return false;
-    }
-}
-bool bcuda::nets::Net::RemoveConnection_OnlyOutput(NetNode* InputNode, NetNode* OutputNode, bool RemoveExcess) {
-    NetNode on = GetVR(OutputNode);
-
-    if (on.inputs) {
-        NetNode** on_i = new NetNode*[on.inputCount];
-
-        ThrowIfBad(cudaMemcpy(on_i, on.inputs, sizeof(NetNode*) * on.inputCount, cudaMemcpyDeviceToHost));
-
-        if (RemoveExcess) {
-            for (size_t i = 0; i < on.inputCount; ++i) {
-                if (on_i[i] == InputNode) {
-                    on_i[i] = on_i[on.inputCount - 1];
-                    goto ExitA;
-                }
-            }
-            return false;
-
-ExitA:
-            on.inputCount--;
-
-            NetNode** on_i_n;
-
-            if (on.inputCount) {
-                ThrowIfBad(cudaMalloc(&on_i_n, sizeof(NetNode*) * on.inputCount));
-
-                ThrowIfBad(cudaMemcpy(on_i_n, on_i, sizeof(NetNode*) * on.inputCount, cudaMemcpyHostToDevice));
-            }
-            else {
-                on_i_n = 0;
-            }
-
-            delete[] on_i;
-
-            ThrowIfBad(cudaFree(on.inputs));
-
-            on.inputs = on_i_n;
-        }
-        else {
-            for (size_t i = 0; i < on.inputCount; ++i) {
-                if (on_i[i] == InputNode) {
-                    ThrowIfBad(cudaMemcpy(on.inputs + i, on.inputs + (on.inputCount - 1), sizeof(NetNode*), cudaMemcpyDeviceToDevice));
-                    on_i[i] = on_i[on.inputCount - 1];
-                    goto ExitB;
-                }
-            }
-            return false;
-
-ExitB:
-            on.inputCount--;
-        }
-        SetVR(OutputNode, on);
-        return true;
-    }
-    else {
-        return false;
-    }
-}
-bool bcuda::nets::Net::RemoveConnection(NetNode* InputNode, NetNode* OutputNode, bool RemoveExcess) {
-    if (InputNode != OutputNode) {
-        NetNode in = GetVR(InputNode);
-        NetNode on = GetVR(OutputNode);
-
-        if (in.outputs || on.inputs) {
-            NetNode** in_o = new NetNode*[in.outputCount];
-            NetNode** on_i = new NetNode*[on.inputCount];
-
-            ThrowIfBad(cudaMemcpy(in_o, in.outputs, sizeof(NetNode*) * in.outputCount, cudaMemcpyDeviceToHost));
-            ThrowIfBad(cudaMemcpy(on_i, on.inputs, sizeof(NetNode*) * on.inputCount, cudaMemcpyDeviceToHost));
-
-            if (RemoveExcess) {
-                for (size_t i = 0; i < in.outputCount; ++i) {
-                    if (in_o[i] == OutputNode) {
-                        in_o[i] = in_o[in.outputCount - 1];
-                        goto Exit0A;
+                if (CheckForPreexistence) {
+                    bool f = false;
+                    bool* opt;
+                    ThrowIfBad(cudaMalloc(&opt, sizeof(bool)));
+                    ThrowIfBad(cudaMemcpy(opt, &f, sizeof(bool), cudaMemcpyHostToDevice));
+                    net_addConnection_checkForPreexistence<<<in.outputCount, 1>>>(in.outputs, OutputNode, opt);
+                    ThrowIfBad(cudaMemcpy(&f, opt, sizeof(bool), cudaMemcpyDeviceToHost));
+                    ThrowIfBad(cudaFree(opt));
+                    if (f) {
+                        return false;
                     }
                 }
-                return false;
 
-Exit0A:
-                for (size_t i = 0; i < on.inputCount; ++i) {
-                    if (on_i[i] == InputNode) {
-                        on_i[i] = on_i[on.inputCount - 1];
-                        goto Exit1A;
-                    }
-                }
-                throw std::exception();
-
-Exit1A:
-                in.outputCount--;
-                on.inputCount--;
-
-                NetNode** in_o_n;
-                NetNode** on_i_n;
-
-                if (in.outputCount) {
-                    ThrowIfBad(cudaMalloc(&in_o_n, sizeof(NetNode*) * in.outputCount));
-                    ThrowIfBad(cudaMemcpy(in_o_n, in_o, sizeof(NetNode*) * in.outputCount, cudaMemcpyHostToDevice));
+                bool in_o_e;
+                if (CheckForAvailableExcess) {
+                    size_t s;
+                    ThrowIfBad(cuMemGetAddressRange_v2(0, &s, (CUdeviceptr_v2)in.outputs));
+                    in_o_e = (s >= (in.outputCount + 1) * sizeof(NetNode*));
                 }
                 else {
-                    in_o_n = 0;
+                    in_o_e = false;
                 }
 
-                if (in.outputCount) {
-                    ThrowIfBad(cudaMalloc(&on_i_n, sizeof(NetNode*) * on.inputCount));
-                    ThrowIfBad(cudaMemcpy(on_i_n, on_i, sizeof(NetNode*) * on.inputCount, cudaMemcpyHostToDevice));
+                if (!in.outputs) {
+                    ThrowIfBad(cudaMalloc(&in.outputs, sizeof(NetNode*)));
+                    SetVR(in.outputs, OutputNode);
+                    in.outputCount = 1;
+                }
+                else if (in_o_e) {
+                    ThrowIfBad(cudaMemcpy(in.outputs + in.outputCount, &OutputNode, sizeof(NetNode*), cudaMemcpyHostToDevice));
+                    in.outputCount++;
                 }
                 else {
-                    on_i_n = 0;
+                    NetNode** n;
+                    size_t noc = in.outputCount + 1;
+                    ThrowIfBad(cudaMalloc(&n, sizeof(NetNode*) * noc));
+                    ThrowIfBad(cudaMemcpy(n, in.outputs, sizeof(NetNode*) * in.outputCount, cudaMemcpyDeviceToDevice));
+                    ThrowIfBad(cudaMemcpy(n + in.outputCount, &OutputNode, sizeof(NetNode*), cudaMemcpyHostToDevice));
+                    ThrowIfBad(cudaFree(in.outputs));
+                    in.outputs = n;
+                    in.outputCount = noc;
                 }
-
-                delete[] in_o;
-                delete[] on_i;
-
-                ThrowIfBad(cudaFree(in.outputs));
-                ThrowIfBad(cudaFree(on.inputs));
-
-                in.outputs = in_o_n;
-                on.inputs = on_i_n;
             }
             else {
-                for (size_t i = 0; i < in.outputCount; ++i) {
-                    if (in_o[i] == OutputNode) {
-                        ThrowIfBad(cudaMemcpy(in.outputs + i, in.outputs + (in.outputCount - 1), sizeof(NetNode*), cudaMemcpyDeviceToDevice));
-                        in_o[i] = in_o[in.outputCount - 1];
-                        goto Exit0B;
-                    }
-                }
-                return false;
-
-Exit0B:
-                for (size_t i = 0; i < on.inputCount; ++i) {
-                    if (on_i[i] == InputNode) {
-                        ThrowIfBad(cudaMemcpy(on.inputs + i, on.inputs + (on.inputCount - 1), sizeof(NetNode*), cudaMemcpyDeviceToDevice));
-                        on_i[i] = on_i[on.inputCount - 1];
-                        goto Exit1B;
-                    }
-                }
-                throw std::exception();
-
-Exit1B:
-                in.outputCount--;
-                on.inputCount--;
+                ThrowIfBad(cudaMalloc(&in.outputs, sizeof(NetNode*)));
+                SetVR(in.outputs, OutputNode);
+                in.outputCount = 1;
             }
+
             SetVR(InputNode, in);
+            return true;
+        }
+        bool Net::AddConnection_OnlyOutput(NetNode* InputNode, NetNode* OutputNode, bool CheckForPreexistence, bool CheckForAvailableExcess) {
+            NetNode on = GetVR(InputNode);
+
+            if (on.inputs) {
+                if (CheckForPreexistence) {
+                    bool f = false;
+                    bool* opt;
+                    ThrowIfBad(cudaMalloc(&opt, sizeof(bool)));
+                    ThrowIfBad(cudaMemcpy(opt, &f, sizeof(bool), cudaMemcpyHostToDevice));
+                    net_addConnection_checkForPreexistence<<<on.inputCount, 1>>>(on.inputs, InputNode, opt);
+                    ThrowIfBad(cudaMemcpy(&f, opt, sizeof(bool), cudaMemcpyDeviceToHost));
+                    ThrowIfBad(cudaFree(opt));
+                    if (f) {
+                        return false;
+                    }
+                }
+
+                bool on_i_e;
+                if (CheckForAvailableExcess) {
+                    size_t s;
+                    ThrowIfBad(cuMemGetAddressRange_v2(0, &s, (CUdeviceptr_v2)on.inputs));
+                    on_i_e = (s >= (on.inputCount + 1) * sizeof(NetNode*));
+                }
+                else {
+                    on_i_e = false;
+                }
+
+                if (!on.inputs) {
+                    ThrowIfBad(cudaMalloc(&on.inputs, sizeof(NetNode*)));
+                    SetVR(on.inputs, InputNode);
+                    on.inputCount = 1;
+                }
+                else if (on_i_e) {
+                    ThrowIfBad(cudaMemcpy(on.inputs + on.inputCount, &InputNode, sizeof(NetNode*), cudaMemcpyHostToDevice));
+                    on.inputCount++;
+                }
+                else {
+                    NetNode** n;
+                    size_t nic = on.inputCount + 1;
+                    ThrowIfBad(cudaMalloc(&n, sizeof(NetNode*) * nic));
+                    ThrowIfBad(cudaMemcpy(n, on.inputs, sizeof(NetNode*) * on.inputCount, cudaMemcpyDeviceToDevice));
+                    ThrowIfBad(cudaMemcpy(n + on.inputCount, &InputNode, sizeof(NetNode*), cudaMemcpyHostToDevice));
+                    ThrowIfBad(cudaFree(on.inputs));
+                    on.inputs = n;
+                    on.inputCount = nic;
+                }
+            }
+            else {
+                ThrowIfBad(cudaMalloc(&on.inputs, sizeof(NetNode*)));
+                SetVR(on.inputs, InputNode);
+                on.inputCount = 1;
+            }
+
             SetVR(OutputNode, on);
             return true;
         }
-        else {
-            return false;
-        }
-    }
-    else {
-        NetNode n = GetVR(InputNode);
+        bool Net::AddConnection(NetNode* InputNode, NetNode* OutputNode, bool CheckForPreexistence, bool CheckForAvailableExcess) {
+            if (InputNode != OutputNode) {
+                NetNode in = GetVR(InputNode);
+                NetNode on = GetVR(OutputNode);
 
-        if (n.outputs || n.inputs) {
-            NetNode** n_o = new NetNode*[n.outputCount];
-            NetNode** n_i = new NetNode*[n.inputCount];
-
-            ThrowIfBad(cudaMemcpy(n_o, n.outputs, sizeof(NetNode*) * n.outputCount, cudaMemcpyDeviceToHost));
-            ThrowIfBad(cudaMemcpy(n_i, n.inputs, sizeof(NetNode*) * n.inputCount, cudaMemcpyDeviceToHost));
-
-            if (RemoveExcess) {
-                for (size_t i = 0; i < n.outputCount; ++i) {
-                    if (n_o[i] == OutputNode) {
-                        n_o[i] = n_o[n.outputCount - 1];
-                        goto Exit0C;
+                if (CheckForPreexistence && in.outputs) {
+                    bool f = false;
+                    bool* opt;
+                    ThrowIfBad(cudaMalloc(&opt, sizeof(bool)));
+                    ThrowIfBad(cudaMemcpy(opt, &f, sizeof(bool), cudaMemcpyHostToDevice));
+                    net_addConnection_checkForPreexistence<<<in.outputCount, 1>>>(in.outputs, OutputNode, opt);
+                    ThrowIfBad(cudaMemcpy(&f, opt, sizeof(bool), cudaMemcpyDeviceToHost));
+                    ThrowIfBad(cudaFree(opt));
+                    if (f) {
+                        return false;
                     }
                 }
-                return false;
 
-Exit0C:
-                for (size_t i = 0; i < n.inputCount; ++i) {
-                    if (n_i[i] == InputNode) {
-                        n_i[i] = n_i[n.inputCount - 1];
-                        goto Exit1C;
+                bool in_o_e;
+                bool on_i_e;
+                if (CheckForAvailableExcess) {
+                    size_t s;
+                    if (in.outputs) {
+                        ThrowIfBad(cuMemGetAddressRange_v2(0, &s, (CUdeviceptr_v2)in.outputs));
+                        in_o_e = (s >= (in.outputCount + 1) * sizeof(NetNode*));
+                    }
+                    else {
+                        in_o_e = false;
+                    }
+                    if (on.inputs) {
+                        ThrowIfBad(cuMemGetAddressRange_v2(0, &s, (CUdeviceptr_v2)on.inputs));
+                        on_i_e = (s >= (on.inputCount + 1) * sizeof(NetNode*));
+                    }
+                    else {
+                        on_i_e = false;
                     }
                 }
-                throw std::exception();
+                else {
+                    in_o_e = false;
+                    on_i_e = false;
+                }
 
-Exit1C:
-                n.outputCount--;
-                n.inputCount--;
-
-                NetNode** n_o_n;
-                NetNode** n_i_n;
-
-                if (n.outputCount) {
-                    ThrowIfBad(cudaMalloc(&n_o_n, sizeof(NetNode*) * n.outputCount));
-                    ThrowIfBad(cudaMemcpy(n_o_n, n_o, sizeof(NetNode*) * n.outputCount, cudaMemcpyHostToDevice));
+                if (!in.outputs) {
+                    ThrowIfBad(cudaMalloc(&in.outputs, sizeof(NetNode*)));
+                    SetVR(in.outputs, OutputNode);
+                    in.outputCount = 1;
+                }
+                else if (in_o_e) {
+                    ThrowIfBad(cudaMemcpy(in.outputs + in.outputCount, &OutputNode, sizeof(NetNode*), cudaMemcpyHostToDevice));
+                    in.outputCount++;
                 }
                 else {
-                    n_o_n = 0;
+                    NetNode** n;
+                    size_t noc = in.outputCount + 1;
+                    ThrowIfBad(cudaMalloc(&n, sizeof(NetNode*) * noc));
+                    if (in.outputs) {
+                        ThrowIfBad(cudaMemcpy(n, in.outputs, sizeof(NetNode*) * in.outputCount, cudaMemcpyDeviceToDevice));
+                    }
+                    ThrowIfBad(cudaMemcpy(n + in.outputCount, &OutputNode, sizeof(NetNode*), cudaMemcpyHostToDevice));
+                    ThrowIfBad(cudaFree(in.outputs));
+                    in.outputs = n;
+                    in.outputCount = noc;
                 }
 
-                if (n.outputCount) {
-                    ThrowIfBad(cudaMalloc(&n_i_n, sizeof(NetNode*) * n.inputCount));
-                    ThrowIfBad(cudaMemcpy(n_i_n, n_i, sizeof(NetNode*) * n.inputCount, cudaMemcpyHostToDevice));
+                if (!on.inputs) {
+                    ThrowIfBad(cudaMalloc(&on.inputs, sizeof(NetNode*)));
+                    SetVR(on.inputs, InputNode);
+                    on.inputCount = 1;
+                }
+                else if (on_i_e) {
+                    ThrowIfBad(cudaMemcpy(on.inputs + on.inputCount, &InputNode, sizeof(NetNode*), cudaMemcpyHostToDevice));
+                    on.inputCount++;
                 }
                 else {
-                    n_i_n = 0;
+                    NetNode** n;
+                    size_t nic = on.inputCount + 1;
+                    ThrowIfBad(cudaMalloc(&n, sizeof(NetNode*) * nic));
+                    if (on.inputs) {
+                        ThrowIfBad(cudaMemcpy(n, on.inputs, sizeof(NetNode*) * on.inputCount, cudaMemcpyDeviceToDevice));
+                    }
+                    ThrowIfBad(cudaMemcpy(n + on.inputCount, &InputNode, sizeof(NetNode*), cudaMemcpyHostToDevice));
+                    ThrowIfBad(cudaFree(on.inputs));
+                    on.inputs = n;
+                    on.inputCount = nic;
                 }
 
-                delete[] n_o;
-                delete[] n_i;
-
-                ThrowIfBad(cudaFree(n.outputs));
-                ThrowIfBad(cudaFree(n.inputs));
-
-                n.outputs = n_o_n;
-                n.inputs = n_i_n;
+                SetVR(InputNode, in);
+                SetVR(OutputNode, on);
+                return true;
             }
             else {
-                for (size_t i = 0; i < n.outputCount; ++i) {
-                    if (n_o[i] == OutputNode) {
-                        ThrowIfBad(cudaMemcpy(n.outputs + i, n.outputs + (n.outputCount - 1), sizeof(NetNode*), cudaMemcpyDeviceToDevice));
-                        n_o[i] = n_o[n.outputCount - 1];
-                        goto Exit0D;
+                NetNode n = GetVR(InputNode);
+
+                if (CheckForPreexistence && n.inputs) {
+                    bool f = false;
+                    bool* opt;
+                    ThrowIfBad(cudaMalloc(&opt, sizeof(bool)));
+                    ThrowIfBad(cudaMemcpy(opt, &f, sizeof(bool), cudaMemcpyHostToDevice));
+                    net_addConnection_checkForPreexistence<<<n.inputCount, 1>>>(n.inputs, InputNode, opt);
+                    ThrowIfBad(cudaMemcpy(&f, opt, sizeof(bool), cudaMemcpyDeviceToHost));
+                    ThrowIfBad(cudaFree(opt));
+                    if (f) {
+                        return false;
                     }
                 }
-                return false;
 
-Exit0D:
-                for (size_t i = 0; i < n.inputCount; ++i) {
-                    if (n_i[i] == InputNode) {
-                        ThrowIfBad(cudaMemcpy(n.inputs + i, n.inputs + (n.inputCount - 1), sizeof(NetNode*), cudaMemcpyDeviceToDevice));
-                        n_i[i] = n_i[n.inputCount - 1];
-                        goto Exit1D;
+                bool n_o_e;
+                bool n_i_e;
+                if (CheckForAvailableExcess) {
+                    size_t s;
+                    if (n.outputs) {
+                        ThrowIfBad(cuMemGetAddressRange_v2(0, &s, (CUdeviceptr_v2)n.outputs));
+                        n_o_e = (s >= (n.outputCount + 1) * sizeof(NetNode*));
+                    }
+                    else {
+                        n_o_e = false;
+                    }
+                    if (n.inputs) {
+                        ThrowIfBad(cuMemGetAddressRange_v2(0, &s, (CUdeviceptr_v2)n.inputs));
+                        n_i_e = (s >= (n.inputCount + 1) * sizeof(NetNode*));
+                    }
+                    else {
+                        n_i_e = false;
                     }
                 }
-                throw std::exception();
+                else {
+                    n_o_e = false;
+                    n_i_e = false;
+                }
 
-Exit1D:
-                n.outputCount--;
-                n.inputCount--;
+                if (!n.outputs) {
+                    ThrowIfBad(cudaMalloc(&n.outputs, sizeof(NetNode*)));
+                    SetVR(n.outputs, OutputNode);
+                    n.outputCount = 1;
+                }
+                else if (n_o_e) {
+                    ThrowIfBad(cudaMemcpy(n.outputs + n.outputCount, &OutputNode, sizeof(NetNode*), cudaMemcpyHostToDevice));
+                    n.outputCount++;
+                }
+                else {
+                    NetNode** ns;
+                    size_t noc = n.outputCount + 1;
+                    ThrowIfBad(cudaMalloc(&ns, sizeof(NetNode*) * noc));
+                    if (n.outputs) {
+                        ThrowIfBad(cudaMemcpy(ns, n.outputs, sizeof(NetNode*) * n.outputCount, cudaMemcpyDeviceToDevice));
+                    }
+                    ThrowIfBad(cudaMemcpy(ns + n.outputCount, &OutputNode, sizeof(NetNode*), cudaMemcpyHostToDevice));
+                    ThrowIfBad(cudaFree(n.outputs));
+                    n.outputs = ns;
+                    n.outputCount = noc;
+                }
+
+                if (!n.inputs) {
+                    ThrowIfBad(cudaMalloc(&n.inputs, sizeof(NetNode*)));
+                    SetVR(n.inputs, InputNode);
+                    n.inputCount = 1;
+                }
+                else if (n_i_e) {
+                    ThrowIfBad(cudaMemcpy(n.inputs + n.inputCount, &InputNode, sizeof(NetNode*), cudaMemcpyHostToDevice));
+                    n.inputCount++;
+                }
+                else {
+                    NetNode** ns;
+                    size_t nic = n.inputCount + 1;
+                    ThrowIfBad(cudaMalloc(&ns, sizeof(NetNode*) * nic));
+                    if (n.inputs) {
+                        ThrowIfBad(cudaMemcpy(ns, n.inputs, sizeof(NetNode*) * n.inputCount, cudaMemcpyDeviceToDevice));
+                    }
+                    ThrowIfBad(cudaMemcpy(ns + n.inputCount, &InputNode, sizeof(NetNode*), cudaMemcpyHostToDevice));
+                    ThrowIfBad(cudaFree(n.inputs));
+                    n.inputs = ns;
+                    n.inputCount = nic;
+                }
+
+                SetVR(InputNode, n);
+                return true;
             }
-            SetVR(InputNode, n);
-            return true;
         }
-        else {
-            return false;
-        }
-    }
-}
 
-void bcuda::nets::Net::RemoveAllConnections(NetNode* Node, bool RemoveExcess) {
-    NetNode nn = GetVR(Node);
-    NetNode** inputs = new NetNode*[nn.inputCount];
-    NetNode** outputs = new NetNode*[nn.outputCount];
-    ThrowIfBad(cudaMemcpy(inputs, nn.inputs, sizeof(NetNode*) * nn.inputCount, cudaMemcpyDeviceToHost));
-    ThrowIfBad(cudaMemcpy(outputs, nn.outputs, sizeof(NetNode*) * nn.outputCount, cudaMemcpyDeviceToHost));
-    for (size_t i = 0; i < nn.inputCount; ++i) {
-        NetNode* o = inputs[i];
-        if (o != Node) {
-            RemoveConnection_OnlyInput(o, Node, RemoveExcess);
+        bool Net::RemoveConnection_OnlyInput(NetNode* InputNode, NetNode* OutputNode, bool RemoveExcess) {
+            NetNode in = GetVR(InputNode);
+
+            if (in.outputs) {
+                NetNode** in_o = new NetNode*[in.outputCount];
+
+                ThrowIfBad(cudaMemcpy(in_o, in.outputs, sizeof(NetNode*) * in.outputCount, cudaMemcpyDeviceToHost));
+
+                if (RemoveExcess) {
+                    for (size_t i = 0; i < in.outputCount; ++i) {
+                        if (in_o[i] == OutputNode) {
+                            in_o[i] = in_o[in.outputCount - 1];
+                            goto ExitA;
+                        }
+                    }
+                    return false;
+
+                ExitA:
+                    in.outputCount--;
+
+                    NetNode** in_o_n;
+
+                    if (in.outputCount) {
+                        ThrowIfBad(cudaMalloc(&in_o_n, sizeof(NetNode*) * in.outputCount));
+
+                        ThrowIfBad(cudaMemcpy(in_o_n, in_o, sizeof(NetNode*) * in.outputCount, cudaMemcpyHostToDevice));
+                    }
+                    else {
+                        in_o_n = 0;
+                    }
+
+                    delete[] in_o;
+
+                    ThrowIfBad(cudaFree(in.outputs));
+
+                    in.outputs = in_o_n;
+                }
+                else {
+                    for (size_t i = 0; i < in.outputCount; ++i) {
+                        if (in_o[i] == OutputNode) {
+                            ThrowIfBad(cudaMemcpy(in.outputs + i, in.outputs + (in.outputCount - 1), sizeof(NetNode*), cudaMemcpyDeviceToDevice));
+                            in_o[i] = in_o[in.outputCount - 1];
+                            goto ExitB;
+                        }
+                    }
+                    return false;
+
+                ExitB:
+                    in.outputCount--;
+                }
+                SetVR(InputNode, in);
+                return true;
+            }
+            else {
+                return false;
+            }
         }
-    }
-    for (size_t i = 0; i < nn.outputCount; ++i) {
-        NetNode* o = outputs[i];
-        if (o != Node) {
-            RemoveConnection_OnlyOutput(Node, o, RemoveExcess);
+        bool Net::RemoveConnection_OnlyOutput(NetNode* InputNode, NetNode* OutputNode, bool RemoveExcess) {
+            NetNode on = GetVR(OutputNode);
+
+            if (on.inputs) {
+                NetNode** on_i = new NetNode*[on.inputCount];
+
+                ThrowIfBad(cudaMemcpy(on_i, on.inputs, sizeof(NetNode*) * on.inputCount, cudaMemcpyDeviceToHost));
+
+                if (RemoveExcess) {
+                    for (size_t i = 0; i < on.inputCount; ++i) {
+                        if (on_i[i] == InputNode) {
+                            on_i[i] = on_i[on.inputCount - 1];
+                            goto ExitA;
+                        }
+                    }
+                    return false;
+
+                ExitA:
+                    on.inputCount--;
+
+                    NetNode** on_i_n;
+
+                    if (on.inputCount) {
+                        ThrowIfBad(cudaMalloc(&on_i_n, sizeof(NetNode*) * on.inputCount));
+
+                        ThrowIfBad(cudaMemcpy(on_i_n, on_i, sizeof(NetNode*) * on.inputCount, cudaMemcpyHostToDevice));
+                    }
+                    else {
+                        on_i_n = 0;
+                    }
+
+                    delete[] on_i;
+
+                    ThrowIfBad(cudaFree(on.inputs));
+
+                    on.inputs = on_i_n;
+                }
+                else {
+                    for (size_t i = 0; i < on.inputCount; ++i) {
+                        if (on_i[i] == InputNode) {
+                            ThrowIfBad(cudaMemcpy(on.inputs + i, on.inputs + (on.inputCount - 1), sizeof(NetNode*), cudaMemcpyDeviceToDevice));
+                            on_i[i] = on_i[on.inputCount - 1];
+                            goto ExitB;
+                        }
+                    }
+                    return false;
+
+                ExitB:
+                    on.inputCount--;
+                }
+                SetVR(OutputNode, on);
+                return true;
+            }
+            else {
+                return false;
+            }
         }
-    }
-    delete[] inputs;
-    delete[] outputs;
-    if (RemoveExcess) {
-        ThrowIfBad(cudaFree(nn.inputs));
-        ThrowIfBad(cudaFree(nn.outputs));
-        nn.inputs = 0;
-        nn.outputs = 0;
-    }
-    nn.inputCount = 0;
-    nn.outputCount = 0;
-    SetVR(Node, nn);
-}
-void bcuda::nets::Net::PrintTo(std::ostream& Output, size_t IndentPre, size_t IndentSize) const {
-    std::string pi(IndentPre, ' ');
-    std::string si(IndentSize, ' ');
-    const thrust::device_vector<NetNode>& vec = DataVec();
-    for (size_t i = 0; i < vec.size(); ++i) {
-        thrust::device_ptr<const NetNode> dp = vec.data() + i;
-        const NetNode* p = dp.get();
-        NetNode v = *dp;
-        Output << pi << p << ":" << std::endl;
-        Output << pi << si << "Data: " << v.data << std::endl;
-        Output << pi << si << "Input Count: " << v.inputCount << std::endl;
-        Output << pi << si << "Inputs: " << v.inputs << std::endl;
-        for (size_t j = 0; j < v.inputCount; ++j) {
-            Output << pi << si << si << j << ": " << GetVR(v.inputs + j) << std::endl;
+        bool Net::RemoveConnection(NetNode* InputNode, NetNode* OutputNode, bool RemoveExcess) {
+            if (InputNode != OutputNode) {
+                NetNode in = GetVR(InputNode);
+                NetNode on = GetVR(OutputNode);
+
+                if (in.outputs || on.inputs) {
+                    NetNode** in_o = new NetNode*[in.outputCount];
+                    NetNode** on_i = new NetNode*[on.inputCount];
+
+                    ThrowIfBad(cudaMemcpy(in_o, in.outputs, sizeof(NetNode*) * in.outputCount, cudaMemcpyDeviceToHost));
+                    ThrowIfBad(cudaMemcpy(on_i, on.inputs, sizeof(NetNode*) * on.inputCount, cudaMemcpyDeviceToHost));
+
+                    if (RemoveExcess) {
+                        for (size_t i = 0; i < in.outputCount; ++i) {
+                            if (in_o[i] == OutputNode) {
+                                in_o[i] = in_o[in.outputCount - 1];
+                                goto Exit0A;
+                            }
+                        }
+                        return false;
+
+                    Exit0A:
+                        for (size_t i = 0; i < on.inputCount; ++i) {
+                            if (on_i[i] == InputNode) {
+                                on_i[i] = on_i[on.inputCount - 1];
+                                goto Exit1A;
+                            }
+                        }
+                        throw std::exception();
+
+                    Exit1A:
+                        in.outputCount--;
+                        on.inputCount--;
+
+                        NetNode** in_o_n;
+                        NetNode** on_i_n;
+
+                        if (in.outputCount) {
+                            ThrowIfBad(cudaMalloc(&in_o_n, sizeof(NetNode*) * in.outputCount));
+                            ThrowIfBad(cudaMemcpy(in_o_n, in_o, sizeof(NetNode*) * in.outputCount, cudaMemcpyHostToDevice));
+                        }
+                        else {
+                            in_o_n = 0;
+                        }
+
+                        if (in.outputCount) {
+                            ThrowIfBad(cudaMalloc(&on_i_n, sizeof(NetNode*) * on.inputCount));
+                            ThrowIfBad(cudaMemcpy(on_i_n, on_i, sizeof(NetNode*) * on.inputCount, cudaMemcpyHostToDevice));
+                        }
+                        else {
+                            on_i_n = 0;
+                        }
+
+                        delete[] in_o;
+                        delete[] on_i;
+
+                        ThrowIfBad(cudaFree(in.outputs));
+                        ThrowIfBad(cudaFree(on.inputs));
+
+                        in.outputs = in_o_n;
+                        on.inputs = on_i_n;
+                    }
+                    else {
+                        for (size_t i = 0; i < in.outputCount; ++i) {
+                            if (in_o[i] == OutputNode) {
+                                ThrowIfBad(cudaMemcpy(in.outputs + i, in.outputs + (in.outputCount - 1), sizeof(NetNode*), cudaMemcpyDeviceToDevice));
+                                in_o[i] = in_o[in.outputCount - 1];
+                                goto Exit0B;
+                            }
+                        }
+                        return false;
+
+                    Exit0B:
+                        for (size_t i = 0; i < on.inputCount; ++i) {
+                            if (on_i[i] == InputNode) {
+                                ThrowIfBad(cudaMemcpy(on.inputs + i, on.inputs + (on.inputCount - 1), sizeof(NetNode*), cudaMemcpyDeviceToDevice));
+                                on_i[i] = on_i[on.inputCount - 1];
+                                goto Exit1B;
+                            }
+                        }
+                        throw std::exception();
+
+                    Exit1B:
+                        in.outputCount--;
+                        on.inputCount--;
+                    }
+                    SetVR(InputNode, in);
+                    SetVR(OutputNode, on);
+                    return true;
+                }
+                else {
+                    return false;
+                }
+            }
+            else {
+                NetNode n = GetVR(InputNode);
+
+                if (n.outputs || n.inputs) {
+                    NetNode** n_o = new NetNode*[n.outputCount];
+                    NetNode** n_i = new NetNode*[n.inputCount];
+
+                    ThrowIfBad(cudaMemcpy(n_o, n.outputs, sizeof(NetNode*) * n.outputCount, cudaMemcpyDeviceToHost));
+                    ThrowIfBad(cudaMemcpy(n_i, n.inputs, sizeof(NetNode*) * n.inputCount, cudaMemcpyDeviceToHost));
+
+                    if (RemoveExcess) {
+                        for (size_t i = 0; i < n.outputCount; ++i) {
+                            if (n_o[i] == OutputNode) {
+                                n_o[i] = n_o[n.outputCount - 1];
+                                goto Exit0C;
+                            }
+                        }
+                        return false;
+
+                    Exit0C:
+                        for (size_t i = 0; i < n.inputCount; ++i) {
+                            if (n_i[i] == InputNode) {
+                                n_i[i] = n_i[n.inputCount - 1];
+                                goto Exit1C;
+                            }
+                        }
+                        throw std::exception();
+
+                    Exit1C:
+                        n.outputCount--;
+                        n.inputCount--;
+
+                        NetNode** n_o_n;
+                        NetNode** n_i_n;
+
+                        if (n.outputCount) {
+                            ThrowIfBad(cudaMalloc(&n_o_n, sizeof(NetNode*) * n.outputCount));
+                            ThrowIfBad(cudaMemcpy(n_o_n, n_o, sizeof(NetNode*) * n.outputCount, cudaMemcpyHostToDevice));
+                        }
+                        else {
+                            n_o_n = 0;
+                        }
+
+                        if (n.outputCount) {
+                            ThrowIfBad(cudaMalloc(&n_i_n, sizeof(NetNode*) * n.inputCount));
+                            ThrowIfBad(cudaMemcpy(n_i_n, n_i, sizeof(NetNode*) * n.inputCount, cudaMemcpyHostToDevice));
+                        }
+                        else {
+                            n_i_n = 0;
+                        }
+
+                        delete[] n_o;
+                        delete[] n_i;
+
+                        ThrowIfBad(cudaFree(n.outputs));
+                        ThrowIfBad(cudaFree(n.inputs));
+
+                        n.outputs = n_o_n;
+                        n.inputs = n_i_n;
+                    }
+                    else {
+                        for (size_t i = 0; i < n.outputCount; ++i) {
+                            if (n_o[i] == OutputNode) {
+                                ThrowIfBad(cudaMemcpy(n.outputs + i, n.outputs + (n.outputCount - 1), sizeof(NetNode*), cudaMemcpyDeviceToDevice));
+                                n_o[i] = n_o[n.outputCount - 1];
+                                goto Exit0D;
+                            }
+                        }
+                        return false;
+
+                    Exit0D:
+                        for (size_t i = 0; i < n.inputCount; ++i) {
+                            if (n_i[i] == InputNode) {
+                                ThrowIfBad(cudaMemcpy(n.inputs + i, n.inputs + (n.inputCount - 1), sizeof(NetNode*), cudaMemcpyDeviceToDevice));
+                                n_i[i] = n_i[n.inputCount - 1];
+                                goto Exit1D;
+                            }
+                        }
+                        throw std::exception();
+
+                    Exit1D:
+                        n.outputCount--;
+                        n.inputCount--;
+                    }
+                    SetVR(InputNode, n);
+                    return true;
+                }
+                else {
+                    return false;
+                }
+            }
         }
-        Output << pi << si << "Output Count: " << v.outputCount << std::endl;
-        Output << pi << si << "Outputs: " << v.outputs << std::endl;
-        for (size_t j = 0; j < v.outputCount; ++j) {
-            Output << pi << si << si << j << ": " << GetVR(v.outputs + j) << std::endl;
+
+        void Net::RemoveAllConnections(NetNode* Node, bool RemoveExcess) {
+            NetNode nn = GetVR(Node);
+            NetNode** inputs = new NetNode*[nn.inputCount];
+            NetNode** outputs = new NetNode*[nn.outputCount];
+            ThrowIfBad(cudaMemcpy(inputs, nn.inputs, sizeof(NetNode*) * nn.inputCount, cudaMemcpyDeviceToHost));
+            ThrowIfBad(cudaMemcpy(outputs, nn.outputs, sizeof(NetNode*) * nn.outputCount, cudaMemcpyDeviceToHost));
+            for (size_t i = 0; i < nn.inputCount; ++i) {
+                NetNode* o = inputs[i];
+                if (o != Node) {
+                    RemoveConnection_OnlyInput(o, Node, RemoveExcess);
+                }
+            }
+            for (size_t i = 0; i < nn.outputCount; ++i) {
+                NetNode* o = outputs[i];
+                if (o != Node) {
+                    RemoveConnection_OnlyOutput(Node, o, RemoveExcess);
+                }
+            }
+            delete[] inputs;
+            delete[] outputs;
+            if (RemoveExcess) {
+                ThrowIfBad(cudaFree(nn.inputs));
+                ThrowIfBad(cudaFree(nn.outputs));
+                nn.inputs = 0;
+                nn.outputs = 0;
+            }
+            nn.inputCount = 0;
+            nn.outputCount = 0;
+            SetVR(Node, nn);
+        }
+        void Net::PrintTo(std::ostream& Output, size_t IndentPre, size_t IndentSize) const {
+            std::string pi(IndentPre, ' ');
+            std::string si(IndentSize, ' ');
+            const thrust::device_vector<NetNode>& vec = DataVec();
+            for (size_t i = 0; i < vec.size(); ++i) {
+                thrust::device_ptr<const NetNode> dp = vec.data() + i;
+                const NetNode* p = dp.get();
+                NetNode v = *dp;
+                Output << pi << p << ":" << std::endl;
+                Output << pi << si << "Data: " << v.data << std::endl;
+                Output << pi << si << "Input Count: " << v.inputCount << std::endl;
+                Output << pi << si << "Inputs: " << v.inputs << std::endl;
+                for (size_t j = 0; j < v.inputCount; ++j) {
+                    Output << pi << si << si << j << ": " << GetVR(v.inputs + j) << std::endl;
+                }
+                Output << pi << si << "Output Count: " << v.outputCount << std::endl;
+                Output << pi << si << "Outputs: " << v.outputs << std::endl;
+                for (size_t j = 0; j < v.outputCount; ++j) {
+                    Output << pi << si << si << j << ": " << GetVR(v.outputs + j) << std::endl;
+                }
+            }
         }
     }
 }

--- a/points.h
+++ b/points.h
@@ -6,7 +6,7 @@
 
 namespace bcuda {
     template <std::unsigned_integral _TIndex, std::unsigned_integral _TVectorElement, size_t _VectorLength, bool _RowMajor>
-    __host__ __device__ constexpr __forceinline _TIndex CoordinatesToIndex(FixedVector<_TVectorElement, _VectorLength> Dimensions, FixedVector<_TVectorElement, _VectorLength> Coordinates) {
+    __host__ __device__ constexpr inline _TIndex CoordinatesToIndex(FixedVector<_TVectorElement, _VectorLength> Dimensions, FixedVector<_TVectorElement, _VectorLength> Coordinates) {
         _TIndex idx = 0;
         if constexpr (_RowMajor) {
             for (size_t i = _VectorLength - 1; i != (size_t)-1; --i) {
@@ -23,7 +23,7 @@ namespace bcuda {
         return idx;
     }
     template <std::unsigned_integral _TIndex, std::unsigned_integral _TVectorElement, size_t _VectorLength, bool _RowMajor>
-    __host__ __device__ constexpr __forceinline FixedVector<_TVectorElement, _VectorLength> IndexToCoordinates(FixedVector<_TVectorElement, _VectorLength> Dimensions, _TIndex Index) {
+    __host__ __device__ constexpr inline FixedVector<_TVectorElement, _VectorLength> IndexToCoordinates(FixedVector<_TVectorElement, _VectorLength> Dimensions, _TIndex Index) {
         FixedVector<_TVectorElement, _VectorLength> r;
         if constexpr (_RowMajor) {
             for (size_t i = _VectorLength - 1; i != (size_t)-1; ++i) {

--- a/points.h
+++ b/points.h
@@ -6,42 +6,37 @@
 
 namespace bcuda {
     template <std::unsigned_integral _TIndex, std::unsigned_integral _TVectorElement, size_t _VectorLength, bool _RowMajor>
-    __host__ __device__ constexpr __forceinline _TIndex CoordinatesToIndex(FixedVector<_TVectorElement, _VectorLength> Dimensions, FixedVector<_TVectorElement, _VectorLength> Coordinates);
+    __host__ __device__ constexpr __forceinline _TIndex CoordinatesToIndex(FixedVector<_TVectorElement, _VectorLength> Dimensions, FixedVector<_TVectorElement, _VectorLength> Coordinates) {
+        _TIndex idx = 0;
+        if constexpr (_RowMajor) {
+            for (size_t i = _VectorLength - 1; i != (size_t)-1; --i) {
+                idx *= Dimensions[i];
+                idx += Coordinates[i];
+            }
+        }
+        else {
+            for (size_t i = 0; i < _VectorLength; ++i) {
+                idx *= Dimensions[i];
+                idx += Coordinates[i];
+            }
+        }
+        return idx;
+    }
     template <std::unsigned_integral _TIndex, std::unsigned_integral _TVectorElement, size_t _VectorLength, bool _RowMajor>
-    __host__ __device__ constexpr __forceinline FixedVector<_TVectorElement, _VectorLength> IndexToCoordinates(FixedVector<_TVectorElement, _VectorLength> Dimensions, _TIndex Index);
-}
-
-template <std::unsigned_integral _TIndex, std::unsigned_integral _TVectorElement, size_t _VectorLength, bool _RowMajor>
-__host__ __device__ constexpr __forceinline _TIndex bcuda::CoordinatesToIndex(FixedVector<_TVectorElement, _VectorLength> Dimensions, FixedVector<_TVectorElement, _VectorLength> Coordinates) {
-    _TIndex idx = 0;
-    if constexpr (_RowMajor) {
-        for (size_t i = _VectorLength - 1; i != (size_t)-1; --i) {
-            idx *= Dimensions[i];
-            idx += Coordinates[i];
+    __host__ __device__ constexpr __forceinline FixedVector<_TVectorElement, _VectorLength> IndexToCoordinates(FixedVector<_TVectorElement, _VectorLength> Dimensions, _TIndex Index) {
+        FixedVector<_TVectorElement, _VectorLength> r;
+        if constexpr (_RowMajor) {
+            for (size_t i = _VectorLength - 1; i != (size_t)-1; ++i) {
+                r[i] = Index % Dimensions[i];
+                Index /= Dimensions[i];
+            }
         }
-    }
-    else {
-        for (size_t i = 0; i < _VectorLength; ++i) {
-            idx *= Dimensions[i];
-            idx += Coordinates[i];
+        else {
+            for (size_t i = 0; i < _VectorLength; ++i) {
+                r[i] = Index % Dimensions[i];
+                Index /= Dimensions[i];
+            }
         }
+        return r;
     }
-    return idx;
-}
-template <std::unsigned_integral _TIndex, std::unsigned_integral _TVectorElement, size_t _VectorLength, bool _RowMajor>
-__host__ __device__ constexpr __forceinline bcuda::FixedVector<_TVectorElement, _VectorLength> bcuda::IndexToCoordinates(FixedVector<_TVectorElement, _VectorLength> Dimensions, _TIndex Index) {
-    FixedVector<_TVectorElement, _VectorLength> r;
-    if constexpr (_RowMajor) {
-        for (size_t i = _VectorLength - 1; i != (size_t)-1; ++i) {
-            r[i] = Index % Dimensions[i];
-            Index /= Dimensions[i];
-        }
-    }
-    else {
-        for (size_t i = 0; i < _VectorLength; ++i) {
-            r[i] = Index % Dimensions[i];
-            Index /= Dimensions[i];
-        }
-    }
-    return r;
 }

--- a/rand_anyrng.h
+++ b/rand_anyrng.h
@@ -8,7 +8,7 @@
 namespace bcuda {
     namespace details {
         template <typename _TOutputType, typename _TRNG>
-        _TOutputType RunRNGFunc(void* RNG) {
+        static inline _TOutputType RunRNGFunc(void* RNG) {
             std::uniform_int_distribution<_TOutputType> dis(0);
             return dis(*(_TRNG*)RNG);
         }
@@ -20,16 +20,16 @@ namespace bcuda {
         class AnyRNG {
         public:
             template <typename _TRNG>
-            AnyRNG(_TRNG* RNG) {
+            inline AnyRNG(_TRNG* RNG) {
                 i_rng = RNG;
                 r_rng = details::RunRNGFunc<_TOutputType, _TRNG>;
             }
             template <typename _TRNG>
-            AnyRNG(_TRNG& RNG) {
+            inline AnyRNG(_TRNG& RNG) {
                 i_rng = &RNG;
                 r_rng = details::RunRNGFunc<_TOutputType, _TRNG>;
             }
-            _TOutputType operator()() {
+            inline _TOutputType operator()() {
                 return r_rng(i_rng);
             }
             static constexpr _TOutputType min() {

--- a/rand_bits.h
+++ b/rand_bits.h
@@ -10,91 +10,64 @@
 namespace bcuda {
     namespace rand {
         template <std::uniform_random_bit_generator _TRNG>
-        __host__ __forceinline uint32_t Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG);
+        __host__ __forceinline uint32_t Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
+            uint32_t ct = bcuda::binary::CountBitsB(ProbabilityOf1);
+            if (!ct) return 0;
+            std::uniform_int_distribution<uint32_t> dis32(0);
+            uint32_t lb = 1u << 31 >> (ct - 1);
+            uint32_t cr = dis32(RNG);
+            for (uint32_t i = 1ui64 << 31; i > lb; i >>= 1) {
+                if (ProbabilityOf1 & i)
+                    cr |= dis32(RNG);
+                else
+                    cr &= dis32(RNG);
+            }
+            return cr;
+        }
         template <std::uniform_random_bit_generator _TRNG>
-        __host__ __forceinline uint64_t Get64Bits(uint32_t ProbabilityOf1, _TRNG& RNG);
+        __host__ __forceinline uint64_t Get64Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
+            uint32_t ct = bcuda::binary::CountBitsB(ProbabilityOf1);
+            if (!ct) return 0;
+            std::uniform_int_distribution<uint64_t> dis64(0);
+            uint32_t lb = 1u << 31 >> (ct - 1);
+            uint64_t cr = dis64(RNG);
+            for (uint32_t i = 1ui64 << 31; i > lb; i >>= 1) {
+                if (ProbabilityOf1 & i)
+                    cr |= dis64(RNG);
+                else
+                    cr &= dis64(RNG);
+            }
+            return cr;
+        }
 #ifdef __CUDACC__
         template <KernelCurandState _TRNG>
-        __device__ __forceinline uint32_t Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG);
+        __device__ __forceinline uint32_t Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
+            uint32_t ct = bcuda::binary::CountBitsB(ProbabilityOf1);
+            if (!ct) return 0;
+            uint32_t lb = 1u << 31 >> (ct - 1);
+            uint32_t cr = curand(&RNG);
+            for (uint32_t i = 1ui64 << 31; i > lb; i >>= 1) {
+                if (ProbabilityOf1 & i)
+                    cr |= curand(&RNG);
+                else
+                    cr &= curand(&RNG);
+            }
+            return cr;
+        }
         template <KernelCurandState _TRNG>
-        __device__ __forceinline uint64_t Get64Bits(uint32_t ProbabilityOf1, _TRNG& RNG);
+        __device__ __forceinline uint64_t Get64Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
+            uint32_t ct = bcuda::binary::CountBitsB(ProbabilityOf1);
+            if (!ct) return 0;
+            uint32_t lb = 1u << 31 >> (ct - 1);
+            uint64_t cr = ((uint64_t)curand(&RNG) << 32) | curand(&RNG);
+            for (uint32_t i = 1ui64 << 31; i > lb; i >>= 1) {
+                if (ProbabilityOf1 & i)
+                    cr |= ((uint64_t)curand(&RNG) << 32) | curand(&RNG);
+                else
+                    cr &= ((uint64_t)curand(&RNG) << 32) | curand(&RNG);
+            }
+            return cr;
+        }
 #endif
     }
 }
-
-template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline uint32_t bcuda::rand::Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
-    uint32_t ct = bcuda::binary::CountBitsB(ProbabilityOf1);
-    if (!ct) {
-        return 0;
-    }
-    std::uniform_int_distribution<uint32_t> dis32(0);
-    uint32_t lb = 1u << 31 >> (ct - 1);
-    uint32_t cr = dis32(RNG);
-    for (uint32_t i = 1ui64 << 31; i > lb; i >>= 1) {
-        if (ProbabilityOf1 & i) {
-            cr |= dis32(RNG);
-        }
-        else {
-            cr &= dis32(RNG);
-        }
-    }
-    return cr;
-}
-template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline uint64_t bcuda::rand::Get64Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
-    uint32_t ct = bcuda::binary::CountBitsB(ProbabilityOf1);
-    if (!ct) {
-        return 0;
-    }
-    std::uniform_int_distribution<uint64_t> dis64(0);
-    uint32_t lb = 1u << 31 >> (ct - 1);
-    uint64_t cr = dis64(RNG);
-    for (uint32_t i = 1ui64 << 31; i > lb; i >>= 1) {
-        if (ProbabilityOf1 & i) {
-            cr |= dis64(RNG);
-        }
-        else {
-            cr &= dis64(RNG);
-        }
-    }
-    return cr;
-}
-#ifdef __CUDACC__
-template <bcuda::KernelCurandState _TRNG>
-__device__ __forceinline uint32_t bcuda::rand::Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
-    uint32_t ct = bcuda::binary::CountBitsB(ProbabilityOf1);
-    if (!ct) {
-        return 0;
-    }
-    uint32_t lb = 1u << 31 >> (ct - 1);
-    uint32_t cr = curand(&RNG);
-    for (uint32_t i = 1ui64 << 31; i > lb; i >>= 1) {
-        if (ProbabilityOf1 & i) {
-            cr |= curand(&RNG);
-        }
-        else {
-            cr &= curand(&RNG);
-        }
-    }
-    return cr;
-}
-template <bcuda::KernelCurandState _TRNG>
-__device__ __forceinline uint64_t bcuda::rand::Get64Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
-    uint32_t ct = bcuda::binary::CountBitsB(ProbabilityOf1);
-    if (!ct) {
-        return 0;
-    }
-    uint32_t lb = 1u << 31 >> (ct - 1);
-    uint64_t cr = ((uint64_t)curand(&RNG) << 32) | curand(&RNG);
-    for (uint32_t i = 1ui64 << 31; i > lb; i >>= 1) {
-        if (ProbabilityOf1 & i) {
-            cr |= ((uint64_t)curand(&RNG) << 32) | curand(&RNG);
-        }
-        else {
-            cr &= ((uint64_t)curand(&RNG) << 32) | curand(&RNG);
-        }
-    }
-    return cr;
-}
-#endif

--- a/rand_bits.h
+++ b/rand_bits.h
@@ -10,7 +10,7 @@
 namespace bcuda {
     namespace rand {
         template <std::uniform_random_bit_generator _TRNG>
-        __host__ __forceinline uint32_t Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
+        __host__ inline uint32_t Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
             uint32_t ct = bcuda::binary::CountBitsB(ProbabilityOf1);
             if (!ct) return 0;
             std::uniform_int_distribution<uint32_t> dis32(0);
@@ -25,7 +25,7 @@ namespace bcuda {
             return cr;
         }
         template <std::uniform_random_bit_generator _TRNG>
-        __host__ __forceinline uint64_t Get64Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
+        __host__ inline uint64_t Get64Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
             uint32_t ct = bcuda::binary::CountBitsB(ProbabilityOf1);
             if (!ct) return 0;
             std::uniform_int_distribution<uint64_t> dis64(0);
@@ -41,7 +41,7 @@ namespace bcuda {
         }
 #ifdef __CUDACC__
         template <KernelCurandState _TRNG>
-        __device__ __forceinline uint32_t Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
+        __device__ inline uint32_t Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
             uint32_t ct = bcuda::binary::CountBitsB(ProbabilityOf1);
             if (!ct) return 0;
             uint32_t lb = 1u << 31 >> (ct - 1);
@@ -55,7 +55,7 @@ namespace bcuda {
             return cr;
         }
         template <KernelCurandState _TRNG>
-        __device__ __forceinline uint64_t Get64Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
+        __device__ inline uint64_t Get64Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
             uint32_t ct = bcuda::binary::CountBitsB(ProbabilityOf1);
             if (!ct) return 0;
             uint32_t lb = 1u << 31 >> (ct - 1);

--- a/rand_bits.h
+++ b/rand_bits.h
@@ -10,7 +10,7 @@
 namespace bcuda {
     namespace rand {
         template <std::uniform_random_bit_generator _TRNG>
-        __host__ inline uint32_t Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
+        __host__ static inline uint32_t Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
             uint32_t ct = bcuda::binary::CountBitsB(ProbabilityOf1);
             if (!ct) return 0;
             std::uniform_int_distribution<uint32_t> dis32(0);
@@ -25,7 +25,7 @@ namespace bcuda {
             return cr;
         }
         template <std::uniform_random_bit_generator _TRNG>
-        __host__ inline uint64_t Get64Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
+        __host__ static inline uint64_t Get64Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
             uint32_t ct = bcuda::binary::CountBitsB(ProbabilityOf1);
             if (!ct) return 0;
             std::uniform_int_distribution<uint64_t> dis64(0);
@@ -41,7 +41,7 @@ namespace bcuda {
         }
 #ifdef __CUDACC__
         template <KernelCurandState _TRNG>
-        __device__ inline uint32_t Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
+        __device__ static inline uint32_t Get32Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
             uint32_t ct = bcuda::binary::CountBitsB(ProbabilityOf1);
             if (!ct) return 0;
             uint32_t lb = 1u << 31 >> (ct - 1);
@@ -55,7 +55,7 @@ namespace bcuda {
             return cr;
         }
         template <KernelCurandState _TRNG>
-        __device__ inline uint64_t Get64Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
+        __device__ static inline uint64_t Get64Bits(uint32_t ProbabilityOf1, _TRNG& RNG) {
             uint32_t ct = bcuda::binary::CountBitsB(ProbabilityOf1);
             if (!ct) return 0;
             uint32_t lb = 1u << 31 >> (ct - 1);

--- a/rand_randomizer.cu
+++ b/rand_randomizer.cu
@@ -193,122 +193,126 @@ void getKernelLaunchParams(uint64_t ElementCount, uint32_t& ElementsPerThread, u
     }
 }
 
-void bcuda::details::RandomizeArray_CallKernel(Span<float> Array, float Scalar, uint64_t Seed) {
-    uint32_t elementsPerThread;
-    uint32_t threadsPerBlock;
-    uint32_t blockCount;
-    getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
-    randomizeArrayKernel<<<blockCount, threadsPerBlock>>>(Array, Scalar * 2.f, Seed, elementsPerThread);
-}
-void bcuda::details::RandomizeArray_CallKernel(Span<double> Array, double Scalar, uint64_t Seed) {
-    uint32_t elementsPerThread;
-    uint32_t threadsPerBlock;
-    uint32_t blockCount;
-    getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
-    randomizeArrayKernel<<<blockCount, threadsPerBlock>>>(Array, Scalar * 2., Seed, elementsPerThread);
-}
-void bcuda::details::RandomizeArray_CallKernel(Span<float> Array, float Scalar, float LowerBound, float UpperBound, uint64_t Seed) {
-    uint32_t elementsPerThread;
-    uint32_t threadsPerBlock;
-    uint32_t blockCount;
-    getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
-    randomizeArrayKernel<<<blockCount, threadsPerBlock>>>(Array, Scalar * 2.f, LowerBound, UpperBound, Seed, elementsPerThread);
-}
-void bcuda::details::RandomizeArray_CallKernel(Span<double> Array, double Scalar, double LowerBound, double UpperBound, uint64_t Seed) {
-    uint32_t elementsPerThread;
-    uint32_t threadsPerBlock;
-    uint32_t blockCount;
-    getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
-    randomizeArrayKernel<<<blockCount, threadsPerBlock>>>(Array, Scalar * 2., LowerBound, UpperBound, Seed, elementsPerThread);
-}
-void bcuda::details::RandomizeArrayWFlips_CallKernel(Span<uint32_t> Array, uint32_t FlipProbability, uint64_t Seed) {
-    uint32_t elementsPerThread;
-    uint32_t threadsPerBlock;
-    uint32_t blockCount;
-    getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
-    randomizeArrayWFlipsKernel<<<blockCount, threadsPerBlock>>>(Array, FlipProbability, Seed, elementsPerThread);
-}
-void bcuda::details::RandomizeArrayWTargets_CallKernel(Span<uint32_t> Array, uint32_t EachFlipProbability, uint64_t Seed) {
-    uint32_t elementsPerThread;
-    uint32_t threadsPerBlock;
-    uint32_t blockCount;
-    getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
-    randomizeArrayWTargetsKernel<<<blockCount, threadsPerBlock>>>(Array, EachFlipProbability, Seed, elementsPerThread);
-}
-void bcuda::details::RandomizeArrayWMutations_CallKernel(Span<uint32_t> Array, uint32_t MutationProbability, uint64_t Seed) {
-    uint32_t elementsPerThread;
-    uint32_t threadsPerBlock;
-    uint32_t blockCount;
-    getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
-    randomizeArrayWMutationsKernel<<<blockCount, threadsPerBlock>>>(Array, MutationProbability, Seed, elementsPerThread);
-}
-void bcuda::details::RandomizeArrayWMutations_CallKernel(Span<uint32_t> Array, uint32_t MutationProbability, uint32_t ProbabilityOf1, uint64_t Seed) {
-    uint32_t elementsPerThread;
-    uint32_t threadsPerBlock;
-    uint32_t blockCount;
-    getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
-    randomizeArrayWMutationsKernel<<<blockCount, threadsPerBlock>>>(Array, MutationProbability, ProbabilityOf1, Seed, elementsPerThread);
-}
-void bcuda::details::InitArray_CallKernel(Span<float> Array, uint64_t Seed) {
-    uint32_t elementsPerThread;
-    uint32_t threadsPerBlock;
-    uint32_t blockCount;
-    getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
-    initArrayKernel<<<blockCount, threadsPerBlock>>>(Array, Seed, elementsPerThread);
-}
-void bcuda::details::InitArray_CallKernel(Span<double> Array, uint64_t Seed) {
-    uint32_t elementsPerThread;
-    uint32_t threadsPerBlock;
-    uint32_t blockCount;
-    getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
-    initArrayKernel<<<blockCount, threadsPerBlock>>>(Array, Seed, elementsPerThread);
-}
-void bcuda::details::InitArray_CallKernel(Span<float> Array, float LowerBound, float UpperBound, uint64_t Seed) {
-    uint32_t elementsPerThread;
-    uint32_t threadsPerBlock;
-    uint32_t blockCount;
-    getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
-    initArrayKernel<<<blockCount, threadsPerBlock>>>(Array, LowerBound, UpperBound - LowerBound, Seed, elementsPerThread);
-}
-void bcuda::details::InitArray_CallKernel(Span<double> Array, double LowerBound, double UpperBound, uint64_t Seed) {
-    uint32_t elementsPerThread;
-    uint32_t threadsPerBlock;
-    uint32_t blockCount;
-    getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
-    initArrayKernel<<<blockCount, threadsPerBlock>>>(Array, LowerBound, UpperBound - LowerBound, Seed, elementsPerThread);
-}
-void bcuda::details::InitArray_CallKernel(Span<uint32_t> Array, uint64_t Seed) {
-    uint32_t elementsPerThread;
-    uint32_t threadsPerBlock;
-    uint32_t blockCount;
-    getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
-    initArrayKernel<<<blockCount, threadsPerBlock>>>(Array, Seed, elementsPerThread);
-}
-void bcuda::details::InitArray_CallKernel(Span<uint32_t> Array, uint32_t ProbabilityOf1, uint64_t Seed) {
-    uint32_t elementsPerThread;
-    uint32_t threadsPerBlock;
-    uint32_t blockCount;
-    getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
-    initArrayKernel<<<blockCount, threadsPerBlock>>>(Array, ProbabilityOf1, Seed, elementsPerThread);
-}
-void bcuda::details::ClearArray_CallKernel(Span<float> Array) {
-    uint32_t elementsPerThread;
-    uint32_t threadsPerBlock;
-    uint32_t blockCount;
-    getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
-    clearArrayKernel<<<blockCount, threadsPerBlock>>>(Array, elementsPerThread);
-}
-void bcuda::details::ClearArray_CallKernel(Span<double> Array) {
-    uint32_t elementsPerThread;
-    uint32_t threadsPerBlock;
-    uint32_t blockCount;
-    getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
-    clearArrayKernel<<<blockCount, threadsPerBlock>>>(Array, elementsPerThread);
-}
-void bcuda::details::ClearArray_CallKernel(Span<uint64_t> Array) {
-    uint32_t elementsPerThread;
-    uint32_t threadsPerBlock;
-    uint32_t blockCount;
-    getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
-    clearArrayKernel<<<blockCount, threadsPerBlock>>>(Array, elementsPerThread);
+namespace bcuda {
+    namespace details {
+        void RandomizeArray_CallKernel(Span<float> Array, float Scalar, uint64_t Seed) {
+            uint32_t elementsPerThread;
+            uint32_t threadsPerBlock;
+            uint32_t blockCount;
+            getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
+            randomizeArrayKernel<<<blockCount, threadsPerBlock>>>(Array, Scalar * 2.f, Seed, elementsPerThread);
+        }
+        void RandomizeArray_CallKernel(Span<double> Array, double Scalar, uint64_t Seed) {
+            uint32_t elementsPerThread;
+            uint32_t threadsPerBlock;
+            uint32_t blockCount;
+            getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
+            randomizeArrayKernel<<<blockCount, threadsPerBlock>>>(Array, Scalar * 2., Seed, elementsPerThread);
+        }
+        void RandomizeArray_CallKernel(Span<float> Array, float Scalar, float LowerBound, float UpperBound, uint64_t Seed) {
+            uint32_t elementsPerThread;
+            uint32_t threadsPerBlock;
+            uint32_t blockCount;
+            getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
+            randomizeArrayKernel<<<blockCount, threadsPerBlock>>>(Array, Scalar * 2.f, LowerBound, UpperBound, Seed, elementsPerThread);
+        }
+        void RandomizeArray_CallKernel(Span<double> Array, double Scalar, double LowerBound, double UpperBound, uint64_t Seed) {
+            uint32_t elementsPerThread;
+            uint32_t threadsPerBlock;
+            uint32_t blockCount;
+            getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
+            randomizeArrayKernel<<<blockCount, threadsPerBlock>>>(Array, Scalar * 2., LowerBound, UpperBound, Seed, elementsPerThread);
+        }
+        void RandomizeArrayWFlips_CallKernel(Span<uint32_t> Array, uint32_t FlipProbability, uint64_t Seed) {
+            uint32_t elementsPerThread;
+            uint32_t threadsPerBlock;
+            uint32_t blockCount;
+            getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
+            randomizeArrayWFlipsKernel<<<blockCount, threadsPerBlock>>>(Array, FlipProbability, Seed, elementsPerThread);
+        }
+        void RandomizeArrayWTargets_CallKernel(Span<uint32_t> Array, uint32_t EachFlipProbability, uint64_t Seed) {
+            uint32_t elementsPerThread;
+            uint32_t threadsPerBlock;
+            uint32_t blockCount;
+            getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
+            randomizeArrayWTargetsKernel<<<blockCount, threadsPerBlock>>>(Array, EachFlipProbability, Seed, elementsPerThread);
+        }
+        void RandomizeArrayWMutations_CallKernel(Span<uint32_t> Array, uint32_t MutationProbability, uint64_t Seed) {
+            uint32_t elementsPerThread;
+            uint32_t threadsPerBlock;
+            uint32_t blockCount;
+            getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
+            randomizeArrayWMutationsKernel<<<blockCount, threadsPerBlock>>>(Array, MutationProbability, Seed, elementsPerThread);
+        }
+        void RandomizeArrayWMutations_CallKernel(Span<uint32_t> Array, uint32_t MutationProbability, uint32_t ProbabilityOf1, uint64_t Seed) {
+            uint32_t elementsPerThread;
+            uint32_t threadsPerBlock;
+            uint32_t blockCount;
+            getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
+            randomizeArrayWMutationsKernel<<<blockCount, threadsPerBlock>>>(Array, MutationProbability, ProbabilityOf1, Seed, elementsPerThread);
+        }
+        void InitArray_CallKernel(Span<float> Array, uint64_t Seed) {
+            uint32_t elementsPerThread;
+            uint32_t threadsPerBlock;
+            uint32_t blockCount;
+            getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
+            initArrayKernel<<<blockCount, threadsPerBlock>>>(Array, Seed, elementsPerThread);
+        }
+        void InitArray_CallKernel(Span<double> Array, uint64_t Seed) {
+            uint32_t elementsPerThread;
+            uint32_t threadsPerBlock;
+            uint32_t blockCount;
+            getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
+            initArrayKernel<<<blockCount, threadsPerBlock>>>(Array, Seed, elementsPerThread);
+        }
+        void InitArray_CallKernel(Span<float> Array, float LowerBound, float UpperBound, uint64_t Seed) {
+            uint32_t elementsPerThread;
+            uint32_t threadsPerBlock;
+            uint32_t blockCount;
+            getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
+            initArrayKernel<<<blockCount, threadsPerBlock>>>(Array, LowerBound, UpperBound - LowerBound, Seed, elementsPerThread);
+        }
+        void InitArray_CallKernel(Span<double> Array, double LowerBound, double UpperBound, uint64_t Seed) {
+            uint32_t elementsPerThread;
+            uint32_t threadsPerBlock;
+            uint32_t blockCount;
+            getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
+            initArrayKernel<<<blockCount, threadsPerBlock>>>(Array, LowerBound, UpperBound - LowerBound, Seed, elementsPerThread);
+        }
+        void InitArray_CallKernel(Span<uint32_t> Array, uint64_t Seed) {
+            uint32_t elementsPerThread;
+            uint32_t threadsPerBlock;
+            uint32_t blockCount;
+            getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
+            initArrayKernel<<<blockCount, threadsPerBlock>>>(Array, Seed, elementsPerThread);
+        }
+        void InitArray_CallKernel(Span<uint32_t> Array, uint32_t ProbabilityOf1, uint64_t Seed) {
+            uint32_t elementsPerThread;
+            uint32_t threadsPerBlock;
+            uint32_t blockCount;
+            getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
+            initArrayKernel<<<blockCount, threadsPerBlock>>>(Array, ProbabilityOf1, Seed, elementsPerThread);
+        }
+        void ClearArray_CallKernel(Span<float> Array) {
+            uint32_t elementsPerThread;
+            uint32_t threadsPerBlock;
+            uint32_t blockCount;
+            getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
+            clearArrayKernel<<<blockCount, threadsPerBlock>>>(Array, elementsPerThread);
+        }
+        void ClearArray_CallKernel(Span<double> Array) {
+            uint32_t elementsPerThread;
+            uint32_t threadsPerBlock;
+            uint32_t blockCount;
+            getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
+            clearArrayKernel<<<blockCount, threadsPerBlock>>>(Array, elementsPerThread);
+        }
+        void ClearArray_CallKernel(Span<uint64_t> Array) {
+            uint32_t elementsPerThread;
+            uint32_t threadsPerBlock;
+            uint32_t blockCount;
+            getKernelLaunchParams(Array.size, elementsPerThread, threadsPerBlock, blockCount);
+            clearArrayKernel<<<blockCount, threadsPerBlock>>>(Array, elementsPerThread);
+        }
+    }
 }

--- a/rand_randomizer.h
+++ b/rand_randomizer.h
@@ -12,7 +12,21 @@
 namespace bcuda {
     namespace details {
         template <std::integral _T>
-        __host__ __device__ static __forceinline _T RandomizeWTargets_GetEditsOf1s(_T Value, uint32_t CountOf1s, uint32_t FlipProb, uint32_t RN1, uint32_t RN2);
+        __host__ __device__ static __forceinline _T RandomizeWTargets_GetEditsOf1s(_T Value, uint32_t CountOf1s, uint32_t FlipProb, uint32_t RN1, uint32_t RN2) {
+            if (RN1 < FlipProb) {
+                uint32_t mrn = RN2 % CountOf1s;
+
+                for (uint32_t m = 1ui32; m; m <<= 1) {
+                    if (m & Value) {
+                        if (!mrn) {
+                            return m;
+                        }
+                        --mrn;
+                    }
+                }
+            }
+            return 0;
+        }
 
         void RandomizeArray_CallKernel(Span<float> Array, float Scalar, uint64_t Seed);
         void RandomizeArray_CallKernel(Span<double> Array, double Scalar, uint64_t Seed);
@@ -34,802 +48,672 @@ namespace bcuda {
     }
     namespace rand {
         template <std::integral _T, std::uniform_random_bit_generator _TRNG>
-        __host__ static __forceinline _T RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG);
+        __host__ __forceinline _T RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
+            if constexpr (sizeof(_T) > 4) return Value ^ (_T)Get64Bits(FlipProbability, RNG);
+            else return Value ^ (_T)Get32Bits(FlipProbability, RNG);
+    }
 #ifdef __CUDACC__
         template <std::integral _T, bcuda::KernelCurandState _TRNG>
-        __device__ static __forceinline _T RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG);
+        __device__ __forceinline _T RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
+            if constexpr (sizeof(_T) > 4) return Value ^ (_T)Get64Bits(FlipProbability, RNG);
+            else return Value ^ (_T)Get32Bits(FlipProbability, RNG);
+}
 #endif
         template <std::integral _T, std::uniform_random_bit_generator _TRNG>
-        __host__ static __forceinline _T RandomizeWTargets(_T Value, uint32_t EachFlipProbability, _TRNG& RNG);
+        __host__ __forceinline _T RandomizeWTargets(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
+            constexpr uint32_t shiftMask = (sizeof(_T) << 3) - 1;
+
+            std::uniform_int_distribution<uint32_t> dis32(0);
+
+            if (!Value) {
+                if (dis32(RNG) < FlipProbability) {
+                    return ((_T)1) << (shiftMask & dis32(RNG));
+                }
+                return (_T)0;
+            }
+            else if (Value == ~(_T)0) {
+                if (dis32(RNG) < FlipProbability) {
+                    return ~(((_T)1) << (shiftMask & dis32(RNG)));
+                }
+                return ~(_T)0;
+            }
+            else {
+                uint32_t bc = std::popcount(Value);
+
+                return Value ^
+                    details::RandomizeWTargets_GetEditsOf1s(Value, bc, FlipProbability, dis32(RNG), dis32(RNG)) ^
+                    details::RandomizeWTargets_GetEditsOf1s(~Value, 64 - bc, FlipProbability, dis32(RNG), dis32(RNG));
+                }
+        }
 #ifdef __CUDACC__
         template <std::integral _T, bcuda::KernelCurandState _TRNG>
-        __device__ static __forceinline _T RandomizeWTargets(_T Value, uint32_t EachFlipProbability, _TRNG& RNG);
+        __device__ __forceinline _T RandomizeWTargets(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
+            constexpr uint32_t shiftMask = (sizeof(_T) << 3) - 1;
+
+            if (!Value) {
+                if (curand(&RNG) < FlipProbability) {
+                    return ((_T)1) << (shiftMask & curand(&RNG));
+                }
+                return (_T)0;
+            }
+            else if (!~Value) {
+                if (curand(&RNG) < FlipProbability) {
+                    return ~(((_T)1) << (shiftMask & curand(&RNG)));
+                }
+                return ~(_T)0;
+            }
+            else {
+                uint32_t bc = std::popcount(Value);
+
+                return Value ^
+                    details::RandomizeWTargets_GetEditsOf1s(Value, bc, FlipProbability, curand(&RNG), curand(&RNG)) ^
+                    details::RandomizeWTargets_GetEditsOf1s(~Value, 64 - bc, FlipProbability, curand(&RNG), curand(&RNG));
+            }
+            }
 #endif
         template <std::integral _T, std::uniform_random_bit_generator _TRNG>
-        __host__ static __forceinline _T RandomizeWMutations(_T Value, uint32_t MutationProbability, _TRNG& RNG);
+        __host__ __forceinline _T RandomizeWMutations(_T Value, uint32_t MutationProbability, _TRNG& RNG) {
+            std::uniform_int_distribution<uint32_t> dis32(0);
+            if (dis32(RNG) < MutationProbability) {
+                if constexpr (sizeof(_T) == 4) return (_T)dis32(RNG);
+                else if constexpr (sizeof(_T) > 4) {
+                    std::uniform_int_distribution<_T> disT(std::numeric_limits<_T>::min(), std::numeric_limits<_T>::max());
+                    return disT(RNG);
+                }
+                else {
+                    std::uniform_int_distribution<uint16_t> dis(0, (1 << (sizeof(_T) << 3)) - 1);
+                    return (_T)dis(RNG);
+                }
+            }
+            return Value;
+        }
 #ifdef __CUDACC__
         template <std::integral _T, bcuda::KernelCurandState _TRNG>
-        __device__ static __forceinline _T RandomizeWMutations(_T Value, uint32_t MutationProbability, _TRNG& RNG);
+        __device__ __forceinline _T RandomizeWMutations(_T Value, uint32_t MutationProbability, _TRNG& RNG) {
+            if (curand(&RNG) < MutationProbability) {
+                if constexpr (sizeof(_T) > 4) return (_T)(((uint64_t)curand(&RNG) << 32) | curand(&RNG));
+                else return (_T)curand(&RNG);
+            }
+            return Value;
+        }
 #endif
         template <std::integral _T, std::uniform_random_bit_generator _TRNG>
-        __host__ static __forceinline _T RandomizeWMutations(_T Value, uint32_t MutationProbability, uint32_t ProbabilityOf1, _TRNG& RNG);
+        __host__ __forceinline _T RandomizeWMutations(_T Value, uint32_t MutationProbability, uint32_t ProbabilityOf1, _TRNG& RNG) {
+            std::uniform_int_distribution<uint32_t> dis32(0);
+            if (dis32(RNG) < MutationProbability) {
+                if constexpr (sizeof(_T) > 4) return (_T)Get64Bits(ProbabilityOf1, RNG);
+                else return (_T)Get32Bits(ProbabilityOf1, RNG);
+        }
+            return Value;
+        }
 #ifdef __CUDACC__
         template <std::integral _T, bcuda::KernelCurandState _TRNG>
-        __device__ static __forceinline _T RandomizeWMutations(_T Value, uint32_t MutationProbability, uint32_t ProbabilityOf1, _TRNG& RNG);
+        __device__ __forceinline _T RandomizeWMutations(_T Value, uint32_t MutationProbability, uint32_t ProbabilityOf1, _TRNG& RNG) {
+            if (curand(&RNG) < MutationProbability) {
+                if constexpr (sizeof(_T) > 4) return (_T)Get64Bits(ProbabilityOf1, RNG);
+                else return (_T)Get32Bits(ProbabilityOf1, RNG);
+            }
+            return Value;
+        }
 #endif
         template <std::uniform_random_bit_generator _TRNG>
-        __host__ static __forceinline float Randomize(float Value, float Scalar, _TRNG& RNG);
+        __host__ __forceinline float Randomize(float Value, float Scalar, _TRNG& RNG) {
+            std::uniform_real_distribution<float> dis(-Scalar, Scalar);
+            return Value + dis(RNG);
+        }
         template <std::uniform_random_bit_generator _TRNG>
-        __host__ static __forceinline double Randomize(double Value, double Scalar, _TRNG& RNG);
+        __host__ __forceinline double Randomize(double Value, double Scalar, _TRNG& RNG) {
+            std::uniform_real_distribution<double> dis(-Scalar, Scalar);
+            return Value + dis(RNG);
+        }
 #ifdef __CUDACC__
         template <bcuda::KernelCurandState _TRNG>
-        __device__ static __forceinline float Randomize(float Value, float Scalar, _TRNG& RNG);
+        __device__ __forceinline float Randomize(float Value, float Scalar, _TRNG& RNG) {
+            return Value + Scalar * 2.f * (curand_uniform(&RNG) - 0.5f);
+        }
         template <bcuda::KernelCurandState _TRNG>
-        __device__ static __forceinline double Randomize(double Value, double Scalar, _TRNG& RNG);
+        __device__ __forceinline double Randomize(double Value, double Scalar, _TRNG& RNG) {
+            return Value + Scalar * 2. * (curand_uniform_double(&RNG) - 0.5);
+        }
 #endif
         template <std::uniform_random_bit_generator _TRNG>
-        __host__ static __forceinline float Randomize(float Value, float Scalar, float LowerBound, float UpperBound, _TRNG& RNG);
+        __host__ __forceinline float Randomize(float Value, float Scalar, float LowerBound, float UpperBound, _TRNG& RNG) {
+            std::uniform_real_distribution<float> dis(-Scalar, Scalar);
+            return std::clamp(Value + dis(RNG), LowerBound, UpperBound);
+        }
         template <std::uniform_random_bit_generator _TRNG>
-        __host__ static __forceinline double Randomize(double Value, double Scalar, double LowerBound, double UpperBound, _TRNG& RNG);
+        __host__ __forceinline double Randomize(double Value, double Scalar, double LowerBound, double UpperBound, _TRNG& RNG) {
+            std::uniform_real_distribution<double> dis(-Scalar, Scalar);
+            return std::clamp(Value + dis(RNG), LowerBound, UpperBound);
+        }
 #ifdef __CUDACC__
         template <bcuda::KernelCurandState _TRNG>
-        __device__ static __forceinline float Randomize(float Value, float Scalar, float LowerBound, float UpperBound, _TRNG& RNG);
+        __device__ __forceinline float Randomize(float Value, float Scalar, float LowerBound, float UpperBound, _TRNG& RNG) {
+            return std::clamp(Value + Scalar * 2.f * (curand_uniform(&RNG) - 0.5f), LowerBound, UpperBound);
+        }
         template <bcuda::KernelCurandState _TRNG>
-        __device__ static __forceinline double Randomize(double Value, double Scalar, double LowerBound, double UpperBound, _TRNG& RNG);
+        __device__ __forceinline double Randomize(double Value, double Scalar, double LowerBound, double UpperBound, _TRNG& RNG) {
+            return std::clamp(Value + Scalar * 2. * (curand_uniform_double(&RNG) - 0.5), LowerBound, UpperBound);
+        }
 #endif
 
         template <bool _MemoryOnHost, std::floating_point _T, std::uniform_random_bit_generator _TRNG>
-        __host__ static __forceinline void RandomizeArray(Span<_T> Array, _T Scalar, _TRNG& RNG);
+        __host__ __forceinline void RandomizeArray(Span<_T> Array, _T Scalar, _TRNG& RNG) {
+            if constexpr (_MemoryOnHost) {
+                Scalar *= 2.f;
+                std::uniform_real_distribution<_T> dis(-Scalar, Scalar);
+                _T* l = Array.ptr;
+                _T* u = Array.ptr + Array.size;
+                for (; l < u; ++l) *l += dis(RNG);
+            }
+            else {
+                std::uniform_int_distribution<uint64_t> dis64(0);
+                details::RandomizeArray_CallKernel(Array, Scalar, dis64(RNG));
+            }
+        }
 #ifdef __CUDACC__
         template <std::floating_point _T, bcuda::KernelCurandState _TRNG>
-        __device__ static __forceinline void RandomizeArray(Span<_T> Array, _T Scalar, _TRNG& RNG);
+        __device__ __forceinline void RandomizeArray(Span<_T> Array, _T Scalar, _TRNG& RNG) {
+            if constexpr (std::same_as<_T, float>) {
+                Scalar *= 2.f;
+                float* l = Array.ptr;
+                float* u = Array.ptr + Array.size;
+                for (; l < u; ++l) *l += Scalar * (curand_uniform(&RNG) - 0.5f);
+            }
+            else {
+                Scalar *= 2.;
+                double* l = Array.ptr;
+                double* u = Array.ptr + Array.size;
+                for (; l < u; ++l) *l += Scalar * (curand_uniform_double(&RNG) - 0.5);
+            }
+        }
 #endif
         template <bool _MemoryOnHost, std::floating_point _T, std::uniform_random_bit_generator _TRNG>
-        __host__ static __forceinline void RandomizeArray(Span<_T> Array, _T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG);
+        __host__ __forceinline void RandomizeArray(Span<_T> Array, _T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+            if constexpr (_MemoryOnHost) {
+                Scalar *= 2.f;
+                std::uniform_real_distribution<_T> dis(-Scalar, Scalar);
+                _T* l = Array.ptr;
+                _T* u = Array.ptr + Array.size;
+                for (; l < u; ++l) *l = std::clamp(*l + dis(RNG), LowerBound, UpperBound);
+            }
+            else {
+                std::uniform_int_distribution<uint64_t> dis64(0);
+                details::RandomizeArray_CallKernel(Array, Scalar, LowerBound, UpperBound, dis64(RNG));
+            }
+        }
 #ifdef __CUDACC__
         template <std::floating_point _T, bcuda::KernelCurandState _TRNG>
-        __device__ static __forceinline void RandomizeArray(Span<_T> Array, _T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG);
+        __device__ __forceinline void RandomizeArray(Span<_T> Array, _T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+            if constexpr (std::same_as<_T, float>) {
+                Scalar *= 2.f;
+                float* l = Array.ptr;
+                float* u = Array.ptr + Array.size;
+                for (; l < u; ++l) *l = std::clamp(*l + Scalar * (curand_uniform(&RNG) - 0.5f), LowerBound, UpperBound);
+            }
+            else {
+                Scalar *= 2.f;
+                double* l = Array.ptr;
+                double* u = Array.ptr + Array.size;
+                for (; l < u; ++l) *l = std::clamp(*l + Scalar * (curand_uniform_double(&RNG) - 0.5f), LowerBound, UpperBound);
+            }
+        }
 #endif
 
         template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-        __host__ static __forceinline void RandomizeArrayWFlips(Span<_T> Array, uint32_t FlipProb, _TRNG& RNG);
+        __host__ __forceinline void RandomizeArrayWFlips(Span<_T> Array, uint32_t FlipProb, _TRNG& RNG) {
+            if constexpr (std::same_as<_T, uint8_t>) {
+                if constexpr (_MemoryOnHost) {
+                    uint64_t* l64 = (uint64_t*)Array.ptr;
+                    uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
+                    for (; l64 < u64; ++l64) *l64 = RandomizeWFlips(*l64, FlipProb, RNG);
+
+                    uint64_t endV;
+                    size_t r = Array.size & 7;
+                    memcpy(&endV, u64, r);
+                    if (r > 4) endV = RandomizeWFlips(endV, FlipProb, RNG);
+                    else if (r > 2) endV = (uint64_t)RandomizeWFlips((uint32_t)endV, FlipProb, RNG);
+                    else if (r > 1) endV = (uint64_t)RandomizeWFlips((uint16_t)endV, FlipProb, RNG);
+                    else endV = (uint64_t)RandomizeWFlips((uint8_t)endV, FlipProb, RNG);
+                    memcpy(u64, &endV, r & 7);
+                }
+                else {
+                    std::uniform_int_distribution<uint64_t> dis64(0);
+                    details::RandomizeArrayWFlips_CallKernel(Span<uint32_t>((uint32_t*)Array.ptr, Array.size >> 2), FlipProb, dis64(RNG));
+
+                    uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
+
+                    uint64_t endV;
+                    size_t r = Array.size & 7;
+                    cudaMemcpy(&endV, u64, r, cudaMemcpyDefault);
+                    if (r > 4) endV = RandomizeWFlips(endV, FlipProb, RNG);
+                    else if (r > 2) endV = (uint64_t)RandomizeWFlips((uint32_t)endV, FlipProb, RNG);
+                    else if (r > 1) endV = (uint64_t)RandomizeWFlips((uint16_t)endV, FlipProb, RNG);
+                    else endV = (uint64_t)RandomizeWFlips((uint8_t)endV, FlipProb, RNG);
+                    cudaMemcpy(u64, &endV, r, cudaMemcpyDefault);
+                }
+            }
+            else {
+                RandomizeArrayWFlips<_MemoryOnHost, uint8_t, _TRNG>(Span<uint8_t>((uint8_t*)Array.ptr, Array.size * sizeof(_T)), FlipProb, RNG);
+            }
+        }
 #ifdef __CUDACC__
         template <std::integral _T, bcuda::KernelCurandState _TRNG>
-        __device__ static __forceinline void RandomizeArrayWFlips(Span<_T> Array, uint32_t FlipProb, _TRNG& RNG);
+        __device__ __forceinline void RandomizeArrayWFlips(Span<_T> Array, uint32_t FlipProb, _TRNG& RNG) {
+            if constexpr (std::same_as<_T, uint8_t>) {
+                uint64_t* l64 = (uint64_t*)Array.ptr;
+                uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
+                for (; l64 < u64; ++l64) *l64 = RandomizeWFlips(*l64, FlipProb, RNG);
+
+                uint64_t endV;
+                size_t r = Array.size & 7;
+                memcpy(&endV, u64, r);
+                if (r > 4) endV = RandomizeWFlips(endV, FlipProb, RNG);
+                else if (r > 2) endV = (uint64_t)RandomizeWFlips((uint32_t)endV, FlipProb, RNG);
+                else if (r > 1) endV = (uint64_t)RandomizeWFlips((uint16_t)endV, FlipProb, RNG);
+                else endV = (uint64_t)RandomizeWFlips((uint8_t)endV, FlipProb, RNG);
+                memcpy(u64, &endV, r);
+            }
+            else {
+                RandomizeArrayWFlips<uint8_t>(Span<uint8_t>((uint8_t*)Array.ptr, Array.size * sizeof(_T)), FlipProb, RNG);
+            }
+        }
 #endif
         template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-        __host__ static __forceinline void RandomizeArrayWTargets(Span<_T> Array, uint32_t EachFlipProb, _TRNG& RNG);
+        __host__ __forceinline void RandomizeArrayWTargets(Span<_T> Array, uint32_t EachFlipProb, _TRNG& RNG) {
+            if constexpr (std::same_as<_T, uint8_t>) {
+                if constexpr (_MemoryOnHost) {
+                    uint64_t* l64 = (uint64_t*)Array.ptr;
+                    uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
+                    for (; l64 < u64; ++l64) *l64 = RandomizeWTargets(*l64, EachFlipProb, RNG);
+
+                    uint64_t endV;
+                    size_t r = Array.size & 7;
+                    memcpy(&endV, u64, r);
+                    if (r > 4) endV = RandomizeWTargets(endV, EachFlipProb, RNG);
+                    else if (r > 2) endV = (uint64_t)RandomizeWTargets((uint32_t)endV, EachFlipProb, RNG);
+                    else if (r > 1) endV = (uint64_t)RandomizeWTargets((uint16_t)endV, EachFlipProb, RNG);
+                    else endV = (uint64_t)RandomizeWTargets((uint8_t)endV, EachFlipProb, RNG);
+                    memcpy(u64, &endV, r);
+                }
+                else {
+                    std::uniform_int_distribution<uint64_t> dis64(0);
+                    details::RandomizeArrayWTargets_CallKernel(Span<uint32_t>((uint32_t*)Array.ptr, Array.size >> 2), EachFlipProb, dis64(RNG));
+
+                    uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
+
+                    uint64_t endV;
+                    size_t r = Array.size & 7;
+                    cudaMemcpy(&endV, u64, r, cudaMemcpyDefault);
+                    if (r > 4) endV = RandomizeWTargets(endV, EachFlipProb, RNG);
+                    else if (r > 2) endV = (uint64_t)RandomizeWTargets((uint32_t)endV, EachFlipProb, RNG);
+                    else if (r > 1) endV = (uint64_t)RandomizeWTargets((uint16_t)endV, EachFlipProb, RNG);
+                    else endV = (uint64_t)RandomizeWTargets((uint8_t)endV, EachFlipProb, RNG);
+                    cudaMemcpy(u64, &endV, r, cudaMemcpyDefault);
+                }
+            }
+            else {
+                RandomizeArrayWTargets<_MemoryOnHost, uint8_t, _TRNG>(Span<uint8_t>((uint8_t*)Array.ptr, Array.size * sizeof(_T)), EachFlipProb, RNG);
+            }
+        }
 #ifdef __CUDACC__
         template <std::integral _T, bcuda::KernelCurandState _TRNG>
-        __device__ static __forceinline void RandomizeArrayWTargets(Span<_T> Array, uint32_t EachFlipProb, _TRNG& RNG);
+        __device__ __forceinline void RandomizeArrayWTargets(Span<_T> Array, uint32_t EachFlipProb, _TRNG& RNG) {
+            if constexpr (std::same_as<_T, uint8_t>) {
+                uint64_t* l64 = (uint64_t*)Array.ptr;
+                uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
+                for (; l64 < u64; ++l64) *l64 = RandomizeWTargets(*l64, EachFlipProb, RNG);
+
+                uint64_t endV;
+                size_t r = Array.size & 7;
+                memcpy(&endV, u64, r);
+                if (r > 4) endV = RandomizeWTargets(endV, EachFlipProb, RNG);
+                else if (r > 2) endV = (uint64_t)RandomizeWTargets((uint32_t)endV, EachFlipProb, RNG);
+                else if (r > 1) endV = (uint64_t)RandomizeWTargets((uint16_t)endV, EachFlipProb, RNG);
+                else endV = (uint64_t)RandomizeWTargets((uint8_t)endV, EachFlipProb, RNG);
+                memcpy(u64, &endV, r);
+            }
+            else {
+                RandomizeArrayWTargets<uint8_t>(Span<uint8_t>((uint8_t*)Array.ptr, Array.size * sizeof(_T)), EachFlipProb, RNG);
+            }
+        }
 #endif
         template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-        __host__ static __forceinline void RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, _TRNG& RNG);
+        __host__ __forceinline void RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, _TRNG& RNG) {
+            if constexpr (std::same_as<_T, uint8_t>) {
+                if constexpr (_MemoryOnHost) {
+                    uint64_t* l64 = (uint64_t*)Array.ptr;
+                    uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
+                    for (; l64 < u64; ++l64) *l64 = RandomizeWMutations(*l64, MutationProb, RNG);
+
+                    uint64_t endV;
+                    size_t r = Array.size & 7;
+                    memcpy(&endV, u64, r);
+                    if (r > 4) endV = RandomizeWMutations(endV, MutationProb, RNG);
+                    else if (r > 2) endV = (uint64_t)RandomizeWMutations((uint32_t)endV, MutationProb, RNG);
+                    else if (r > 1) endV = (uint64_t)RandomizeWMutations((uint16_t)endV, MutationProb, RNG);
+                    else endV = (uint64_t)RandomizeWMutations((uint8_t)endV, MutationProb, RNG);
+                    memcpy(u64, &endV, r);
+                }
+                else {
+                    std::uniform_int_distribution<uint64_t> dis64(0);
+                    details::RandomizeArrayWMutations_CallKernel(Span<uint32_t>((uint32_t*)Array.ptr, Array.size >> 2), MutationProb, dis64(RNG));
+
+                    uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
+
+                    uint64_t endV;
+                    size_t r = Array.size & 7;
+                    cudaMemcpy(&endV, u64, r, cudaMemcpyDefault);
+                    if (r > 4) endV = RandomizeWMutations(endV, MutationProb, RNG);
+                    else if (r > 2) endV = (uint64_t)RandomizeWMutations((uint32_t)endV, MutationProb, RNG);
+                    else if (r > 1) endV = (uint64_t)RandomizeWMutations((uint16_t)endV, MutationProb, RNG);
+                    else endV = (uint64_t)RandomizeWMutations((uint8_t)endV, MutationProb, RNG);
+                    cudaMemcpy(u64, &endV, r, cudaMemcpyDefault);
+                }
+            }
+            else {
+                RandomizeArrayWMutations<_MemoryOnHost, uint8_t, _TRNG>(Span<uint8_t>((uint8_t*)Array.ptr, Array.size * sizeof(_T)), MutationProb, RNG);
+            }
+        }
 #ifdef __CUDACC__
         template <std::integral _T, bcuda::KernelCurandState _TRNG>
-        __device__ static __forceinline void RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, _TRNG& RNG);
+        __device__ __forceinline void RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, _TRNG& RNG) {
+            if constexpr (std::same_as<_T, uint8_t>) {
+                uint64_t* l64 = (uint64_t*)Array.ptr;
+                uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
+                for (; l64 < u64; ++l64) *l64 = RandomizeWMutations(*l64, MutationProb, RNG);
+
+                uint64_t endV;
+                size_t r = Array.size & 7;
+                memcpy(&endV, u64, r);
+                if (r > 4) endV = RandomizeWMutations(endV, MutationProb, RNG);
+                else if (r > 2) endV = (uint64_t)RandomizeWMutations((uint32_t)endV, MutationProb, RNG);
+                else if (r > 1) endV = (uint64_t)RandomizeWMutations((uint16_t)endV, MutationProb, RNG);
+                else endV = (uint64_t)RandomizeWMutations((uint8_t)endV, MutationProb, RNG);
+                memcpy(u64, &endV, r);
+            }
+            else {
+                RandomizeArrayWMutations<uint8_t>(Span<uint8_t>((uint8_t*)Array.ptr, Array.size * sizeof(_T)), MutationProb, RNG);
+            }
+        }
 #endif
         template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-        __host__ static __forceinline void RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, _TRNG& RNG);
+        __host__ __forceinline void RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, _TRNG& RNG) {
+            if constexpr (std::same_as<_T, uint8_t>) {
+                if constexpr (_MemoryOnHost) {
+                    uint64_t* l64 = (uint64_t*)Array.ptr;
+                    uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
+                    for (; l64 < u64; ++l64) *l64 = RandomizeWMutations(*l64, MutationProb, ProbabilityOf1, RNG);
+
+                    uint64_t endV;
+                    size_t r = Array.size & 7;
+                    memcpy(&endV, u64, r);
+                    if (r > 4) endV = RandomizeWMutations(endV, MutationProb, ProbabilityOf1, RNG);
+                    else if (r > 2) endV = (uint64_t)RandomizeWMutations((uint32_t)endV, MutationProb, ProbabilityOf1, RNG);
+                    else if (r > 1) endV = (uint64_t)RandomizeWMutations((uint16_t)endV, MutationProb, ProbabilityOf1, RNG);
+                    else endV = (uint64_t)RandomizeWMutations((uint8_t)endV, MutationProb, ProbabilityOf1, RNG);
+                    memcpy(u64, &endV, r);
+                }
+                else {
+                    std::uniform_int_distribution<uint64_t> dis64(0);
+                    details::RandomizeArrayWMutations_CallKernel(Span<uint32_t>((uint32_t*)Array.ptr, Array.size >> 2), MutationProb, ProbabilityOf1, dis64(RNG));
+
+                    uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
+
+                    uint64_t endV;
+                    size_t r = Array.size & 7;
+                    cudaMemcpy(&endV, u64, r, cudaMemcpyDefault);
+                    if (r > 4) endV = RandomizeWMutations(endV, MutationProb, ProbabilityOf1, RNG);
+                    else if (r > 2) endV = (uint64_t)RandomizeWMutations((uint32_t)endV, MutationProb, ProbabilityOf1, RNG);
+                    else if (r > 1) endV = (uint64_t)RandomizeWMutations((uint16_t)endV, MutationProb, ProbabilityOf1, RNG);
+                    else endV = (uint64_t)RandomizeWMutations((uint8_t)endV, MutationProb, ProbabilityOf1, RNG);
+                    cudaMemcpy(u64, &endV, r, cudaMemcpyDefault);
+                }
+            }
+            else {
+                RandomizeArrayWMutations<_MemoryOnHost, uint8_t, _TRNG>(Span<uint8_t>((uint8_t*)Array.ptr, Array.size * sizeof(_T)), MutationProb, ProbabilityOf1, RNG);
+            }
+        }
 #ifdef __CUDACC__
         template <std::integral _T, bcuda::KernelCurandState _TRNG>
-        __device__ static __forceinline void RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, _TRNG& RNG);
+        __device__ __forceinline void RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, _TRNG& RNG) {
+            if constexpr (std::same_as<_T, uint8_t>) {
+                uint64_t* l64 = (uint64_t*)Array.ptr;
+                uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
+                for (; l64 < u64; ++l64) *l64 = RandomizeWMutations(*l64, MutationProb, ProbabilityOf1, RNG);
+
+                uint64_t endV;
+                size_t r = Array.size & 7;
+                memcpy(&endV, u64, r);
+                if (r > 4) endV = RandomizeWMutations(endV, MutationProb, ProbabilityOf1, RNG);
+                else if (r > 2) endV = (uint64_t)RandomizeWMutations((uint32_t)endV, MutationProb, ProbabilityOf1, RNG);
+                else if (r > 1) endV = (uint64_t)RandomizeWMutations((uint16_t)endV, MutationProb, ProbabilityOf1, RNG);
+                else endV = (uint64_t)RandomizeWMutations((uint8_t)endV, MutationProb, ProbabilityOf1, RNG);
+                memcpy(u64, &endV, r);
+            }
+            else {
+                RandomizeArrayWMutations<uint8_t>(Span<uint8_t>((uint8_t*)Array.ptr, Array.size * sizeof(_T)), MutationProb, ProbabilityOf1, RNG);
+            }
+        }
 #endif
 
         template <bool _MemoryOnHost, typename _T, std::uniform_random_bit_generator _TRNG>
             requires std::is_arithmetic_v<_T>
-        __host__ static __forceinline void InitRandomArray(Span<_T> Array, _TRNG& RNG);
+        __host__ __forceinline void InitRandomArray(Span<_T> Array, _TRNG& RNG) {
+            if constexpr (std::floating_point<_T>) {
+                if constexpr (_MemoryOnHost) {
+                    std::uniform_real_distribution<_T> dis(-1., 1.);
+                    _T* l = Array.ptr;
+                    _T* u = Array.ptr + Array.size;
+                    for (; l < u; ++l) *l = dis(RNG);
+                }
+                else {
+                    std::uniform_int_distribution<uint64_t> dis64(0);
+                    details::InitArray_CallKernel(Array, dis64(RNG));
+                }
+            }
+            else if (std::same_as<_T, uint8_t>) {
+                if constexpr (_MemoryOnHost) {
+                    std::uniform_int_distribution<uint64_t> dis64(0);
+                    uint64_t* l64 = (uint64_t*)Array.ptr;
+                    uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
+                    for (; l64 < u64; ++l64) *l64 = dis64(RNG);
+
+                    uint64_t endV;
+                    size_t r = Array.size & 7;
+                    memcpy(&endV, u64, r);
+                    endV = dis64(RNG);
+                    memcpy(u64, &endV, r);
+                }
+                else {
+                    std::uniform_int_distribution<uint64_t> dis64(0);
+                    details::InitArray_CallKernel(Span<uint32_t>((uint32_t*)Array.ptr, Array.size >> 2), dis64(RNG));
+
+                    uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
+
+                    uint64_t endV;
+                    size_t r = Array.size & 7;
+                    cudaMemcpy(&endV, u64, r, cudaMemcpyDefault);
+                    endV = dis64(RNG);
+                    cudaMemcpy(u64, &endV, r, cudaMemcpyDefault);
+                }
+            }
+            else {
+                InitRandomArray<_MemoryOnHost, uint8_t, _TRNG>(Span<uint8_t>((uint8_t*)Array.ptr, Array.size * sizeof(_T)), RNG);
+            }
+        }
 #ifdef __CUDACC__
         template <typename _T, bcuda::KernelCurandState _TRNG>
             requires std::is_arithmetic_v<_T>
-        __device__ static __forceinline void InitRandomArray(Span<_T> Array, _TRNG& RNG);
+        __device__ __forceinline void InitRandomArray(Span<_T> Array, _TRNG& RNG) {
+            if constexpr (std::same_as<_T, float>) {
+                float* l = Array.ptr;
+                float* u = Array.ptr + Array.size;
+                for (; l < u; ++l) *l = curand_uniform(&RNG);
+            }
+            else if constexpr (std::same_as<_T, double>) {
+                double* l = Array.ptr;
+                double* u = Array.ptr + Array.size;
+                for (; l < u; ++l) *l = curand_uniform_double(&RNG);
+            }
+            else {
+                static_assert(std::integral<_T>, "Type _T has not yet been implemented.");
+                uint32_t* l32 = (uint32_t*)Array.ptr;
+                uint32_t* u32 = ((uint32_t*)Array.ptr) + (Array.size >> 2);
+                for (; l32 < u32; ++l32) *l32 = curand(&RNG);
+
+                uint32_t endV;
+                size_t r = Array.size & 3;
+                memcpy(&endV, u32, r);
+                endV = curand(&RNG);
+                memcpy(u32, &endV, r);
+            }
+        }
+
 #endif
         template <bool _MemoryOnHost, std::floating_point _T, std::uniform_random_bit_generator _TRNG>
-        __host__ static __forceinline void InitRandomArray(Span<_T> Array, _T LowerBound, _T UpperBound, _TRNG& RNG);
+        __host__ __forceinline void InitRandomArray(Span<_T> Array, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+            if constexpr (_MemoryOnHost) {
+                std::uniform_real_distribution<_T> dis(LowerBound, UpperBound);
+                _T* l = Array.ptr;
+                _T* u = Array.ptr + Array.size;
+                for (; l < u; ++l) *l = dis(RNG);
+            }
+            else {
+                std::uniform_int_distribution<uint64_t> dis64(0);
+                details::InitArray_CallKernel(Array, LowerBound, UpperBound, dis64(RNG));
+            }
+        }
 #ifdef __CUDACC__
         template <std::floating_point _T, bcuda::KernelCurandState _TRNG>
-        __device__ static __forceinline void InitRandomArray(Span<_T> Array, _T LowerBound, _T UpperBound, _TRNG& RNG);
+        __device__ __forceinline void InitRandomArray(Span<_T> Array, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+            if constexpr (std::same_as<_T, float>) {
+                float range = UpperBound - LowerBound;
+                float* l = Array.ptr;
+                float* u = Array.ptr + Array.size;
+                for (; l < u; ++l) *l = curand_uniform(&RNG) * range + LowerBound;
+            }
+            else {
+                double range = UpperBound - LowerBound;
+                double* l = Array.ptr;
+                double* u = Array.ptr + Array.size;
+                for (; l < u; ++l) *l = curand_uniform_double(&RNG) * range + LowerBound;
+            }
+        }
 #endif
+
         template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-        __host__ static __forceinline void InitRandomArray(Span<_T> Array, uint32_t ProbabilityOf1, _TRNG& RNG);
+        __host__ __forceinline void InitRandomArray(Span<_T> Array, uint32_t ProbabilityOf1, _TRNG& RNG) {
+            if constexpr (std::same_as<_T, uint8_t>) {
+                if constexpr (_MemoryOnHost) {
+                    uint64_t* l64 = (uint64_t*)Array.ptr;
+                    uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
+                    for (; l64 < u64; ++l64) *l64 = Get64Bits(ProbabilityOf1, RNG);
+
+                    uint64_t endV;
+                    size_t r = Array.size & 7;
+                    memcpy(&endV, u64, r);
+                    endV = Get64Bits(ProbabilityOf1, RNG);
+                    memcpy(u64, &endV, r);
+                }
+                else {
+                    std::uniform_int_distribution<uint64_t> dis64(0);
+                    details::InitArray_CallKernel(Span<uint32_t>((uint32_t*)Array.ptr, Array.size >> 2), ProbabilityOf1, dis64(RNG));
+
+                    uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
+
+                    uint64_t endV;
+                    size_t r = Array.size & 7;
+                    cudaMemcpy(&endV, u64, r, cudaMemcpyDefault);
+                    endV = Get64Bits(ProbabilityOf1, RNG);
+                    cudaMemcpy(u64, &endV, r, cudaMemcpyDefault);
+                }
+            }
+            else {
+                InitRandomArray<_MemoryOnHost, uint8_t, _TRNG>(Span<uint8_t>((uint8_t*)Array.ptr, Array.size * sizeof(_T)), ProbabilityOf1, RNG);
+            }
+        }
 #ifdef __CUDACC__
         template <std::integral _T, bcuda::KernelCurandState _TRNG>
-        __device__ static __forceinline void InitRandomArray(Span<_T> Array, uint32_t ProbabilityOf1, _TRNG& RNG);
+        __device__ __forceinline void InitRandomArray(Span<_T> Array, uint32_t ProbabilityOf1, _TRNG& RNG) {
+            if constexpr (std::same_as<_T, uint8_t>) {
+                uint32_t* l32 = (uint32_t*)Array.ptr;
+                uint32_t* u32 = ((uint32_t*)Array.ptr) + (Array.size >> 2);
+                for (; l32 < u32; ++l32) *l32 = Get32Bits(ProbabilityOf1, RNG);
+
+                uint32_t endV;
+                size_t r = Array.size & 3;
+                memcpy(&endV, u32, r);
+                endV = Get32Bits(ProbabilityOf1, RNG);
+                memcpy(u32, &endV, r);
+            }
+            else {
+                InitRandomArray<uint8_t>(Span<uint8_t>((uint8_t*)Array.ptr, Array.size * sizeof(_T)), ProbabilityOf1, RNG);
+            }
+        }
 #endif
 
         template <bool _MemoryOnHost, typename _T>
             requires std::is_arithmetic_v<_T>
-        __host__ static __forceinline void ClearArray(Span<_T> Array);
+        __host__ __forceinline void ClearArray(Span<_T> Array) {
+            if constexpr (std::floating_point<_T>) {
+                if constexpr (_MemoryOnHost) {
+                    _T* l = Array.ptr;
+                    _T* u = Array.ptr + Array.size;
+                    for (; l < u; ++l) *l = (_T)0;
+                }
+                else {
+                    std::uniform_int_distribution<uint64_t> dis64(0);
+                    details::ClearArray_CallKernel(Array);
+                }
+            }
+            else if constexpr (std::same_as<_T, uint8_t>) {
+                if constexpr (_MemoryOnHost) {
+                    uint64_t* l64 = (uint64_t*)Array.ptr;
+                    uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
+                    for (; l64 < u64; ++l64) *l64 = 0;
+
+                    uint64_t endV = 0;
+                    size_t r = Array.size & 7;
+                    memcpy(u64, &endV, r);
+                }
+                else {
+                    std::uniform_int_distribution<uint64_t> dis64(0);
+                    details::ClearArray_CallKernel(Span<uint64_t>((uint64_t*)Array.ptr, Array.size >> 3));
+
+                    uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
+
+                    uint64_t endV = 0;
+                    size_t r = Array.size & 7;
+                    cudaMemcpy(u64, &endV, r, cudaMemcpyDefault);
+                }
+            }
+            else {
+                ClearArray<_MemoryOnHost, uint8_t>(Span<uint8_t>((uint8_t*)Array.ptr, Array.size * sizeof(_T)));
+            }
+        }
 #ifdef __CUDACC__
         template <typename _T>
             requires std::is_arithmetic_v<_T>
-        __device__ static __forceinline void ClearArray(Span<_T> Array);
-#endif
-    }
-}
+        __device__ __forceinline void ClearArray(Span<_T> Array) {
+            if constexpr (std::floating_point<_T>) {
+                _T* l = Array.ptr;
+                _T* u = Array.ptr + Array.size;
+                for (; l < u; ++l) *l = (_T)0;
+            }
+            else if constexpr (std::same_as<_T, uint8_t>) {
+                uint64_t* l64 = (uint64_t*)Array.ptr;
+                uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
+                for (; l64 < u64; ++l64) *l64 = 0;
 
-template <std::integral _T>
-__host__ __device__ __forceinline _T bcuda::details::RandomizeWTargets_GetEditsOf1s(_T Value, uint32_t CountOf1s, uint32_t FlipProb, uint32_t RN1, uint32_t RN2) {
-    if (RN1 < FlipProb) {
-        uint32_t mrn = RN2 % CountOf1s;
-
-        for (uint32_t m = 1ui32; m; m <<= 1) {
-            if (m & Value) {
-                if (!mrn) {
-                    return m;
-                }
-                --mrn;
+                uint64_t endV = 0;
+                size_t r = Array.size & 7;
+                memcpy(u64, &endV, r);
+            }
+            else {
+                ClearArray<uint8_t>(Span<uint8_t>((uint8_t*)Array.ptr, Array.size * sizeof(_T)));
             }
         }
-    }
-    return 0;
-}
-
-template <std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline _T bcuda::rand::RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
-    if constexpr (sizeof(_T) > 4) return Value ^ (_T)Get64Bits(FlipProbability, RNG);
-    else return Value ^ (_T)Get32Bits(FlipProbability, RNG);
-}
-#ifdef __CUDACC__
-template <std::integral _T, bcuda::KernelCurandState _TRNG>
-__device__ __forceinline _T bcuda::rand::RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
-    if constexpr (sizeof(_T) > 4) return Value ^ (_T)Get64Bits(FlipProbability, RNG);
-    else return Value ^ (_T)Get32Bits(FlipProbability, RNG);
-}
 #endif
-template <std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline _T bcuda::rand::RandomizeWTargets(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
-    constexpr uint32_t shiftMask = (sizeof(_T) << 3) - 1;
-
-    std::uniform_int_distribution<uint32_t> dis32(0);
-
-    if (!Value) {
-        if (dis32(RNG) < FlipProbability) {
-            return ((_T)1) << (shiftMask & dis32(RNG));
-        }
-        return (_T)0;
-    }
-    else if (Value == ~(_T)0) {
-        if (dis32(RNG) < FlipProbability) {
-            return ~(((_T)1) << (shiftMask & dis32(RNG)));
-        }
-        return ~(_T)0;
-    }
-    else {
-        uint32_t bc = std::popcount(Value);
-
-        return Value ^
-            details::RandomizeWTargets_GetEditsOf1s(Value, bc, FlipProbability, dis32(RNG), dis32(RNG)) ^
-            details::RandomizeWTargets_GetEditsOf1s(~Value, 64 - bc, FlipProbability, dis32(RNG), dis32(RNG));
     }
 }
-#ifdef __CUDACC__
-template <std::integral _T, bcuda::KernelCurandState _TRNG>
-__device__ __forceinline _T bcuda::rand::RandomizeWTargets(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
-    constexpr uint32_t shiftMask = (sizeof(_T) << 3) - 1;
-
-    if (!Value) {
-        if (curand(&RNG) < FlipProbability) {
-            return ((_T)1) << (shiftMask & curand(&RNG));
-        }
-        return (_T)0;
-    }
-    else if (!~Value) {
-        if (curand(&RNG) < FlipProbability) {
-            return ~(((_T)1) << (shiftMask & curand(&RNG)));
-        }
-        return ~(_T)0;
-    }
-    else {
-        uint32_t bc = std::popcount(Value);
-
-        return Value ^
-            details::RandomizeWTargets_GetEditsOf1s(Value, bc, FlipProbability, curand(&RNG), curand(&RNG)) ^
-            details::RandomizeWTargets_GetEditsOf1s(~Value, 64 - bc, FlipProbability, curand(&RNG), curand(&RNG));
-    }
-}
-#endif
-template <std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline _T bcuda::rand::RandomizeWMutations(_T Value, uint32_t MutationProbability, _TRNG& RNG) {
-    std::uniform_int_distribution<uint32_t> dis32(0);
-    if (dis32(RNG) < MutationProbability) {
-        if constexpr (sizeof(_T) == 4) return (_T)dis32(RNG);
-        else if constexpr (sizeof(_T) > 4) {
-            std::uniform_int_distribution<_T> disT(std::numeric_limits<_T>::min(), std::numeric_limits<_T>::max());
-            return disT(RNG);
-        }
-        else {
-            std::uniform_int_distribution<uint16_t> dis(0, (1 << (sizeof(_T) << 3)) - 1);
-            return (_T)dis(RNG);
-        }
-    }
-    return Value;
-}
-#ifdef __CUDACC__
-template <std::integral _T, bcuda::KernelCurandState _TRNG>
-__device__ __forceinline _T bcuda::rand::RandomizeWMutations(_T Value, uint32_t MutationProbability, _TRNG& RNG) {
-    if (curand(&RNG) < MutationProbability) {
-        if constexpr (sizeof(_T) > 4) return (_T)(((uint64_t)curand(&RNG) << 32) | curand(&RNG));
-        else return (_T)curand(&RNG);
-    }
-    return Value;
-}
-#endif
-template <std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline _T bcuda::rand::RandomizeWMutations(_T Value, uint32_t MutationProbability, uint32_t ProbabilityOf1, _TRNG& RNG) {
-    std::uniform_int_distribution<uint32_t> dis32(0);
-    if (dis32(RNG) < MutationProbability) {
-        if constexpr (sizeof(_T) > 4) return (_T)Get64Bits(ProbabilityOf1, RNG);
-        else return (_T)Get32Bits(ProbabilityOf1, RNG);
-    }
-    return Value;
-}
-#ifdef __CUDACC__
-template <std::integral _T, bcuda::KernelCurandState _TRNG>
-__device__ __forceinline _T bcuda::rand::RandomizeWMutations(_T Value, uint32_t MutationProbability, uint32_t ProbabilityOf1, _TRNG& RNG) {
-    if (curand(&RNG) < MutationProbability) {
-        if constexpr (sizeof(_T) > 4) return (_T)Get64Bits(ProbabilityOf1, RNG);
-        else return (_T)Get32Bits(ProbabilityOf1, RNG);
-    }
-    return Value;
-}
-#endif
-template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline float bcuda::rand::Randomize(float Value, float Scalar, _TRNG& RNG) {
-    std::uniform_real_distribution<float> dis(-Scalar, Scalar);
-    return Value + dis(RNG);
-}
-template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline double bcuda::rand::Randomize(double Value, double Scalar, _TRNG& RNG) {
-    std::uniform_real_distribution<double> dis(-Scalar, Scalar);
-    return Value + dis(RNG);
-}
-#ifdef __CUDACC__
-template <bcuda::KernelCurandState _TRNG>
-__device__ __forceinline float bcuda::rand::Randomize(float Value, float Scalar, _TRNG& RNG) {
-    return Value + Scalar * 2.f * (curand_uniform(&RNG) - 0.5f);
-}
-template <bcuda::KernelCurandState _TRNG>
-__device__ __forceinline double bcuda::rand::Randomize(double Value, double Scalar, _TRNG& RNG) {
-    return Value + Scalar * 2. * (curand_uniform_double(&RNG) - 0.5);
-}
-#endif
-template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline float bcuda::rand::Randomize(float Value, float Scalar, float LowerBound, float UpperBound, _TRNG& RNG) {
-    std::uniform_real_distribution<float> dis(-Scalar, Scalar);
-    return std::clamp(Value + dis(RNG), LowerBound, UpperBound);
-}
-template <std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline double bcuda::rand::Randomize(double Value, double Scalar, double LowerBound, double UpperBound, _TRNG& RNG) {
-    std::uniform_real_distribution<double> dis(-Scalar, Scalar);
-    return std::clamp(Value + dis(RNG), LowerBound, UpperBound);
-}
-#ifdef __CUDACC__
-template <bcuda::KernelCurandState _TRNG>
-__device__ __forceinline float bcuda::rand::Randomize(float Value, float Scalar, float LowerBound, float UpperBound, _TRNG& RNG) {
-    return std::clamp(Value + Scalar * 2.f * (curand_uniform(&RNG) - 0.5f), LowerBound, UpperBound);
-}
-template <bcuda::KernelCurandState _TRNG>
-__device__ __forceinline double bcuda::rand::Randomize(double Value, double Scalar, double LowerBound, double UpperBound, _TRNG& RNG) {
-    return std::clamp(Value + Scalar * 2. * (curand_uniform_double(&RNG) - 0.5), LowerBound, UpperBound);
-}
-#endif
-
-template <bool _MemoryOnHost, std::floating_point _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void bcuda::rand::RandomizeArray(Span<_T> Array, _T Scalar, _TRNG& RNG) {
-    if constexpr (_MemoryOnHost) {
-        Scalar *= 2.f;
-        std::uniform_real_distribution<_T> dis(-Scalar, Scalar);
-        _T* l = Array.ptr;
-        _T* u = Array.ptr + Array.size;
-        for (; l < u; ++l) *l += dis(RNG);
-    }
-    else {
-        std::uniform_int_distribution<uint64_t> dis64(0);
-        details::RandomizeArray_CallKernel(Array, Scalar, dis64(RNG));
-    }
-}
-#ifdef __CUDACC__
-template <std::floating_point _T, bcuda::KernelCurandState _TRNG>
-__device__ __forceinline void bcuda::rand::RandomizeArray(Span<_T> Array, _T Scalar, _TRNG& RNG) {
-    if constexpr (std::same_as<_T, float>) {
-        Scalar *= 2.f;
-        float* l = Array.ptr;
-        float* u = Array.ptr + Array.size;
-        for (; l < u; ++l) *l += Scalar * (curand_uniform(&RNG) - 0.5f);
-    }
-    else {
-        Scalar *= 2.;
-        double* l = Array.ptr;
-        double* u = Array.ptr + Array.size;
-        for (; l < u; ++l) *l += Scalar * (curand_uniform_double(&RNG) - 0.5);
-    }
-}
-#endif
-template <bool _MemoryOnHost, std::floating_point _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void bcuda::rand::RandomizeArray(Span<_T> Array, _T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
-    if constexpr (_MemoryOnHost) {
-        Scalar *= 2.f;
-        std::uniform_real_distribution<_T> dis(-Scalar, Scalar);
-        _T* l = Array.ptr;
-        _T* u = Array.ptr + Array.size;
-        for (; l < u; ++l) *l = std::clamp(*l + dis(RNG), LowerBound, UpperBound);
-    }
-    else {
-        std::uniform_int_distribution<uint64_t> dis64(0);
-        details::RandomizeArray_CallKernel(Array, Scalar, LowerBound, UpperBound, dis64(RNG));
-    }
-}
-#ifdef __CUDACC__
-template <std::floating_point _T, bcuda::KernelCurandState _TRNG>
-__device__ __forceinline void bcuda::rand::RandomizeArray(Span<_T> Array, _T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
-    if constexpr (std::same_as<_T, float>) {
-        Scalar *= 2.f;
-        float* l = Array.ptr;
-        float* u = Array.ptr + Array.size;
-        for (; l < u; ++l) *l = std::clamp(*l + Scalar * (curand_uniform(&RNG) - 0.5f), LowerBound, UpperBound);
-    }
-    else {
-        Scalar *= 2.f;
-        double* l = Array.ptr;
-        double* u = Array.ptr + Array.size;
-        for (; l < u; ++l) *l = std::clamp(*l + Scalar * (curand_uniform_double(&RNG) - 0.5f), LowerBound, UpperBound);
-    }
-}
-#endif
-
-template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void bcuda::rand::RandomizeArrayWFlips(Span<_T> Array, uint32_t FlipProb, _TRNG& RNG) {
-    if constexpr (std::same_as<_T, uint8_t>) {
-        if constexpr (_MemoryOnHost) {
-            uint64_t* l64 = (uint64_t*)Array.ptr;
-            uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
-            for (; l64 < u64; ++l64) *l64 = RandomizeWFlips(*l64, FlipProb, RNG);
-
-            uint64_t endV;
-            size_t r = Array.size & 7;
-            memcpy(&endV, u64, r);
-            if (r > 4) endV = RandomizeWFlips(endV, FlipProb, RNG);
-            else if (r > 2) endV = (uint64_t)RandomizeWFlips((uint32_t)endV, FlipProb, RNG);
-            else if (r > 1) endV = (uint64_t)RandomizeWFlips((uint16_t)endV, FlipProb, RNG);
-            else endV = (uint64_t)RandomizeWFlips((uint8_t)endV, FlipProb, RNG);
-            memcpy(u64, &endV, r & 7);
-        }
-        else {
-            std::uniform_int_distribution<uint64_t> dis64(0);
-            details::RandomizeArrayWFlips_CallKernel(Span<uint32_t>((uint32_t*)Array.ptr, Array.size >> 2), FlipProb, dis64(RNG));
-
-            uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
-
-            uint64_t endV;
-            size_t r = Array.size & 7;
-            cudaMemcpy(&endV, u64, r, cudaMemcpyDefault);
-            if (r > 4) endV = RandomizeWFlips(endV, FlipProb, RNG);
-            else if (r > 2) endV = (uint64_t)RandomizeWFlips((uint32_t)endV, FlipProb, RNG);
-            else if (r > 1) endV = (uint64_t)RandomizeWFlips((uint16_t)endV, FlipProb, RNG);
-            else endV = (uint64_t)RandomizeWFlips((uint8_t)endV, FlipProb, RNG);
-            cudaMemcpy(u64, &endV, r, cudaMemcpyDefault);
-        }
-    }
-    else {
-        RandomizeArrayWFlips<_MemoryOnHost, uint8_t, _TRNG>(Span<uint8_t>((uint8_t*)Array.ptr, Array.size * sizeof(_T)), FlipProb, RNG);
-    }
-}
-#ifdef __CUDACC__
-template <std::integral _T, bcuda::KernelCurandState _TRNG>
-__device__ __forceinline void bcuda::rand::RandomizeArrayWFlips(Span<_T> Array, uint32_t FlipProb, _TRNG& RNG) {
-    if constexpr (std::same_as<_T, uint8_t>) {
-        uint64_t* l64 = (uint64_t*)Array.ptr;
-        uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
-        for (; l64 < u64; ++l64) *l64 = RandomizeWFlips(*l64, FlipProb, RNG);
-
-        uint64_t endV;
-        size_t r = Array.size & 7;
-        memcpy(&endV, u64, r);
-        if (r > 4) endV = RandomizeWFlips(endV, FlipProb, RNG);
-        else if (r > 2) endV = (uint64_t)RandomizeWFlips((uint32_t)endV, FlipProb, RNG);
-        else if (r > 1) endV = (uint64_t)RandomizeWFlips((uint16_t)endV, FlipProb, RNG);
-        else endV = (uint64_t)RandomizeWFlips((uint8_t)endV, FlipProb, RNG);
-        memcpy(u64, &endV, r);
-    }
-    else {
-        RandomizeArrayWFlips<uint8_t>(Span<uint8_t>((uint8_t*)Array.ptr, Array.size * sizeof(_T)), FlipProb, RNG);
-    }
-}
-#endif
-template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void bcuda::rand::RandomizeArrayWTargets(Span<_T> Array, uint32_t EachFlipProb, _TRNG& RNG) {
-    if constexpr (std::same_as<_T, uint8_t>) {
-        if constexpr (_MemoryOnHost) {
-            uint64_t* l64 = (uint64_t*)Array.ptr;
-            uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
-            for (; l64 < u64; ++l64) *l64 = RandomizeWTargets(*l64, EachFlipProb, RNG);
-
-            uint64_t endV;
-            size_t r = Array.size & 7;
-            memcpy(&endV, u64, r);
-            if (r > 4) endV = RandomizeWTargets(endV, EachFlipProb, RNG);
-            else if (r > 2) endV = (uint64_t)RandomizeWTargets((uint32_t)endV, EachFlipProb, RNG);
-            else if (r > 1) endV = (uint64_t)RandomizeWTargets((uint16_t)endV, EachFlipProb, RNG);
-            else endV = (uint64_t)RandomizeWTargets((uint8_t)endV, EachFlipProb, RNG);
-            memcpy(u64, &endV, r);
-        }
-        else {
-            std::uniform_int_distribution<uint64_t> dis64(0);
-            details::RandomizeArrayWTargets_CallKernel(Span<uint32_t>((uint32_t*)Array.ptr, Array.size >> 2), EachFlipProb, dis64(RNG));
-
-            uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
-
-            uint64_t endV;
-            size_t r = Array.size & 7;
-            cudaMemcpy(&endV, u64, r, cudaMemcpyDefault);
-            if (r > 4) endV = RandomizeWTargets(endV, EachFlipProb, RNG);
-            else if (r > 2) endV = (uint64_t)RandomizeWTargets((uint32_t)endV, EachFlipProb, RNG);
-            else if (r > 1) endV = (uint64_t)RandomizeWTargets((uint16_t)endV, EachFlipProb, RNG);
-            else endV = (uint64_t)RandomizeWTargets((uint8_t)endV, EachFlipProb, RNG);
-            cudaMemcpy(u64, &endV, r, cudaMemcpyDefault);
-        }
-    }
-    else {
-        RandomizeArrayWTargets<_MemoryOnHost, uint8_t, _TRNG>(Span<uint8_t>((uint8_t*)Array.ptr, Array.size * sizeof(_T)), EachFlipProb, RNG);
-    }
-}
-#ifdef __CUDACC__
-template <std::integral _T, bcuda::KernelCurandState _TRNG>
-__device__ __forceinline void bcuda::rand::RandomizeArrayWTargets(Span<_T> Array, uint32_t EachFlipProb, _TRNG& RNG) {
-    if constexpr (std::same_as<_T, uint8_t>) {
-        uint64_t* l64 = (uint64_t*)Array.ptr;
-        uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
-        for (; l64 < u64; ++l64) *l64 = RandomizeWTargets(*l64, EachFlipProb, RNG);
-
-        uint64_t endV;
-        size_t r = Array.size & 7;
-        memcpy(&endV, u64, r);
-        if (r > 4) endV = RandomizeWTargets(endV, EachFlipProb, RNG);
-        else if (r > 2) endV = (uint64_t)RandomizeWTargets((uint32_t)endV, EachFlipProb, RNG);
-        else if (r > 1) endV = (uint64_t)RandomizeWTargets((uint16_t)endV, EachFlipProb, RNG);
-        else endV = (uint64_t)RandomizeWTargets((uint8_t)endV, EachFlipProb, RNG);
-        memcpy(u64, &endV, r);
-    }
-    else {
-        RandomizeArrayWTargets<uint8_t>(Span<uint8_t>((uint8_t*)Array.ptr, Array.size * sizeof(_T)), EachFlipProb, RNG);
-    }
-}
-#endif
-template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void bcuda::rand::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, _TRNG& RNG) {
-    if constexpr (std::same_as<_T, uint8_t>) {
-        if constexpr (_MemoryOnHost) {
-            uint64_t* l64 = (uint64_t*)Array.ptr;
-            uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
-            for (; l64 < u64; ++l64) *l64 = RandomizeWMutations(*l64, MutationProb, RNG);
-
-            uint64_t endV;
-            size_t r = Array.size & 7;
-            memcpy(&endV, u64, r);
-            if (r > 4) endV = RandomizeWMutations(endV, MutationProb, RNG);
-            else if (r > 2) endV = (uint64_t)RandomizeWMutations((uint32_t)endV, MutationProb, RNG);
-            else if (r > 1) endV = (uint64_t)RandomizeWMutations((uint16_t)endV, MutationProb, RNG);
-            else endV = (uint64_t)RandomizeWMutations((uint8_t)endV, MutationProb, RNG);
-            memcpy(u64, &endV, r);
-        }
-        else {
-            std::uniform_int_distribution<uint64_t> dis64(0);
-            details::RandomizeArrayWMutations_CallKernel(Span<uint32_t>((uint32_t*)Array.ptr, Array.size >> 2), MutationProb, dis64(RNG));
-
-            uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
-
-            uint64_t endV;
-            size_t r = Array.size & 7;
-            cudaMemcpy(&endV, u64, r, cudaMemcpyDefault);
-            if (r > 4) endV = RandomizeWMutations(endV, MutationProb, RNG);
-            else if (r > 2) endV = (uint64_t)RandomizeWMutations((uint32_t)endV, MutationProb, RNG);
-            else if (r > 1) endV = (uint64_t)RandomizeWMutations((uint16_t)endV, MutationProb, RNG);
-            else endV = (uint64_t)RandomizeWMutations((uint8_t)endV, MutationProb, RNG);
-            cudaMemcpy(u64, &endV, r, cudaMemcpyDefault);
-        }
-    }
-    else {
-        RandomizeArrayWMutations<_MemoryOnHost, uint8_t, _TRNG>(Span<uint8_t>((uint8_t*)Array.ptr, Array.size * sizeof(_T)), MutationProb, RNG);
-    }
-}
-#ifdef __CUDACC__
-template <std::integral _T, bcuda::KernelCurandState _TRNG>
-__device__ __forceinline void bcuda::rand::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, _TRNG& RNG) {
-    if constexpr (std::same_as<_T, uint8_t>) {
-        uint64_t* l64 = (uint64_t*)Array.ptr;
-        uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
-        for (; l64 < u64; ++l64) *l64 = RandomizeWMutations(*l64, MutationProb, RNG);
-
-        uint64_t endV;
-        size_t r = Array.size & 7;
-        memcpy(&endV, u64, r);
-        if (r > 4) endV = RandomizeWMutations(endV, MutationProb, RNG);
-        else if (r > 2) endV = (uint64_t)RandomizeWMutations((uint32_t)endV, MutationProb, RNG);
-        else if (r > 1) endV = (uint64_t)RandomizeWMutations((uint16_t)endV, MutationProb, RNG);
-        else endV = (uint64_t)RandomizeWMutations((uint8_t)endV, MutationProb, RNG);
-        memcpy(u64, &endV, r);
-    }
-    else {
-        RandomizeArrayWMutations<uint8_t>(Span<uint8_t>((uint8_t*)Array.ptr, Array.size * sizeof(_T)), MutationProb, RNG);
-    }
-}
-#endif
-template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void bcuda::rand::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, _TRNG& RNG) {
-    if constexpr (std::same_as<_T, uint8_t>) {
-        if constexpr (_MemoryOnHost) {
-            uint64_t* l64 = (uint64_t*)Array.ptr;
-            uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
-            for (; l64 < u64; ++l64) *l64 = RandomizeWMutations(*l64, MutationProb, ProbabilityOf1, RNG);
-
-            uint64_t endV;
-            size_t r = Array.size & 7;
-            memcpy(&endV, u64, r);
-            if (r > 4) endV = RandomizeWMutations(endV, MutationProb, ProbabilityOf1, RNG);
-            else if (r > 2) endV = (uint64_t)RandomizeWMutations((uint32_t)endV, MutationProb, ProbabilityOf1, RNG);
-            else if (r > 1) endV = (uint64_t)RandomizeWMutations((uint16_t)endV, MutationProb, ProbabilityOf1, RNG);
-            else endV = (uint64_t)RandomizeWMutations((uint8_t)endV, MutationProb, ProbabilityOf1, RNG);
-            memcpy(u64, &endV, r);
-        }
-        else {
-            std::uniform_int_distribution<uint64_t> dis64(0);
-            details::RandomizeArrayWMutations_CallKernel(Span<uint32_t>((uint32_t*)Array.ptr, Array.size >> 2), MutationProb, ProbabilityOf1, dis64(RNG));
-
-            uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
-
-            uint64_t endV;
-            size_t r = Array.size & 7;
-            cudaMemcpy(&endV, u64, r, cudaMemcpyDefault);
-            if (r > 4) endV = RandomizeWMutations(endV, MutationProb, ProbabilityOf1, RNG);
-            else if (r > 2) endV = (uint64_t)RandomizeWMutations((uint32_t)endV, MutationProb, ProbabilityOf1, RNG);
-            else if (r > 1) endV = (uint64_t)RandomizeWMutations((uint16_t)endV, MutationProb, ProbabilityOf1, RNG);
-            else endV = (uint64_t)RandomizeWMutations((uint8_t)endV, MutationProb, ProbabilityOf1, RNG);
-            cudaMemcpy(u64, &endV, r, cudaMemcpyDefault);
-        }
-    }
-    else {
-        RandomizeArrayWMutations<_MemoryOnHost, uint8_t, _TRNG>(Span<uint8_t>((uint8_t*)Array.ptr, Array.size * sizeof(_T)), MutationProb, ProbabilityOf1, RNG);
-    }
-}
-#ifdef __CUDACC__
-template <std::integral _T, bcuda::KernelCurandState _TRNG>
-__device__ __forceinline void bcuda::rand::RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, _TRNG& RNG) {
-    if constexpr (std::same_as<_T, uint8_t>) {
-        uint64_t* l64 = (uint64_t*)Array.ptr;
-        uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
-        for (; l64 < u64; ++l64) *l64 = RandomizeWMutations(*l64, MutationProb, ProbabilityOf1, RNG);
-
-        uint64_t endV;
-        size_t r = Array.size & 7;
-        memcpy(&endV, u64, r);
-        if (r > 4) endV = RandomizeWMutations(endV, MutationProb, ProbabilityOf1, RNG);
-        else if (r > 2) endV = (uint64_t)RandomizeWMutations((uint32_t)endV, MutationProb, ProbabilityOf1, RNG);
-        else if (r > 1) endV = (uint64_t)RandomizeWMutations((uint16_t)endV, MutationProb, ProbabilityOf1, RNG);
-        else endV = (uint64_t)RandomizeWMutations((uint8_t)endV, MutationProb, ProbabilityOf1, RNG);
-        memcpy(u64, &endV, r);
-    }
-    else {
-        RandomizeArrayWMutations<uint8_t>(Span<uint8_t>((uint8_t*)Array.ptr, Array.size * sizeof(_T)), MutationProb, ProbabilityOf1, RNG);
-    }
-}
-#endif
-
-template <bool _MemoryOnHost, typename _T, std::uniform_random_bit_generator _TRNG>
-    requires std::is_arithmetic_v<_T>
-__host__ __forceinline void bcuda::rand::InitRandomArray(Span<_T> Array, _TRNG& RNG) {
-    if constexpr (std::floating_point<_T>) {
-        if constexpr (_MemoryOnHost) {
-            std::uniform_real_distribution<_T> dis(-1., 1.);
-            _T* l = Array.ptr;
-            _T* u = Array.ptr + Array.size;
-            for (; l < u; ++l) *l = dis(RNG);
-        }
-        else {
-            std::uniform_int_distribution<uint64_t> dis64(0);
-            details::InitArray_CallKernel(Array, dis64(RNG));
-        }
-    }
-    else if (std::same_as<_T, uint8_t>) {
-        if constexpr (_MemoryOnHost) {
-            std::uniform_int_distribution<uint64_t> dis64(0);
-            uint64_t* l64 = (uint64_t*)Array.ptr;
-            uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
-            for (; l64 < u64; ++l64) *l64 = dis64(RNG);
-
-            uint64_t endV;
-            size_t r = Array.size & 7;
-            memcpy(&endV, u64, r);
-            endV = dis64(RNG);
-            memcpy(u64, &endV, r);
-        }
-        else {
-            std::uniform_int_distribution<uint64_t> dis64(0);
-            details::InitArray_CallKernel(Span<uint32_t>((uint32_t*)Array.ptr, Array.size >> 2), dis64(RNG));
-
-            uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
-
-            uint64_t endV;
-            size_t r = Array.size & 7;
-            cudaMemcpy(&endV, u64, r, cudaMemcpyDefault);
-            endV = dis64(RNG);
-            cudaMemcpy(u64, &endV, r, cudaMemcpyDefault);
-        }
-    }
-    else {
-        InitRandomArray<_MemoryOnHost, uint8_t, _TRNG>(Span<uint8_t>((uint8_t*)Array.ptr, Array.size * sizeof(_T)), RNG);
-    }
-}
-#ifdef __CUDACC__
-template <typename _T, bcuda::KernelCurandState _TRNG>
-    requires std::is_arithmetic_v<_T>
-__device__ __forceinline void bcuda::rand::InitRandomArray(Span<_T> Array, _TRNG& RNG) {
-    if constexpr (std::same_as<_T, float>) {
-        float* l = Array.ptr;
-        float* u = Array.ptr + Array.size;
-        for (; l < u; ++l) *l = curand_uniform(&RNG);
-    }
-    else if constexpr (std::same_as<_T, double>) {
-        double* l = Array.ptr;
-        double* u = Array.ptr + Array.size;
-        for (; l < u; ++l) *l = curand_uniform_double(&RNG);
-    }
-    else {
-        static_assert(std::integral<_T>, "Type _T has not yet been implemented.");
-        uint32_t* l32 = (uint32_t*)Array.ptr;
-        uint32_t* u32 = ((uint32_t*)Array.ptr) + (Array.size >> 2);
-        for (; l32 < u32; ++l32) *l32 = curand(&RNG);
-
-        uint32_t endV;
-        size_t r = Array.size & 3;
-        memcpy(&endV, u32, r);
-        endV = curand(&RNG);
-        memcpy(u32, &endV, r);
-    }
-}
-
-#endif
-template <bool _MemoryOnHost, std::floating_point _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void bcuda::rand::InitRandomArray(Span<_T> Array, _T LowerBound, _T UpperBound, _TRNG& RNG) {
-    if constexpr (_MemoryOnHost) {
-        std::uniform_real_distribution<_T> dis(LowerBound, UpperBound);
-        _T* l = Array.ptr;
-        _T* u = Array.ptr + Array.size;
-        for (; l < u; ++l) *l = dis(RNG);
-    }
-    else {
-        std::uniform_int_distribution<uint64_t> dis64(0);
-        details::InitArray_CallKernel(Array, LowerBound, UpperBound, dis64(RNG));
-    }
-}
-#ifdef __CUDACC__
-template <std::floating_point _T, bcuda::KernelCurandState _TRNG>
-__device__ __forceinline void bcuda::rand::InitRandomArray(Span<_T> Array, _T LowerBound, _T UpperBound, _TRNG& RNG) {
-    if constexpr (std::same_as<_T, float>) {
-        float range = UpperBound - LowerBound;
-        float* l = Array.ptr;
-        float* u = Array.ptr + Array.size;
-        for (; l < u; ++l) *l = curand_uniform(&RNG) * range + LowerBound;
-    }
-    else {
-        double range = UpperBound - LowerBound;
-        double* l = Array.ptr;
-        double* u = Array.ptr + Array.size;
-        for (; l < u; ++l) *l = curand_uniform_double(&RNG) * range + LowerBound;
-    }
-}
-#endif
-
-template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-__host__ __forceinline void bcuda::rand::InitRandomArray(Span<_T> Array, uint32_t ProbabilityOf1, _TRNG& RNG) {
-    if constexpr (std::same_as<_T, uint8_t>) {
-        if constexpr (_MemoryOnHost) {
-            uint64_t* l64 = (uint64_t*)Array.ptr;
-            uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
-            for (; l64 < u64; ++l64) *l64 = Get64Bits(ProbabilityOf1, RNG);
-
-            uint64_t endV;
-            size_t r = Array.size & 7;
-            memcpy(&endV, u64, r);
-            endV = Get64Bits(ProbabilityOf1, RNG);
-            memcpy(u64, &endV, r);
-        }
-        else {
-            std::uniform_int_distribution<uint64_t> dis64(0);
-            details::InitArray_CallKernel(Span<uint32_t>((uint32_t*)Array.ptr, Array.size >> 2), ProbabilityOf1, dis64(RNG));
-
-            uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
-
-            uint64_t endV;
-            size_t r = Array.size & 7;
-            cudaMemcpy(&endV, u64, r, cudaMemcpyDefault);
-            endV = Get64Bits(ProbabilityOf1, RNG);
-            cudaMemcpy(u64, &endV, r, cudaMemcpyDefault);
-        }
-    }
-    else {
-        InitRandomArray<_MemoryOnHost, uint8_t, _TRNG>(Span<uint8_t>((uint8_t*)Array.ptr, Array.size * sizeof(_T)), ProbabilityOf1, RNG);
-    }
-}
-#ifdef __CUDACC__
-template <std::integral _T, bcuda::KernelCurandState _TRNG>
-__device__ __forceinline void bcuda::rand::InitRandomArray(Span<_T> Array, uint32_t ProbabilityOf1, _TRNG& RNG) {
-    if constexpr (std::same_as<_T, uint8_t>) {
-        uint32_t* l32 = (uint32_t*)Array.ptr;
-        uint32_t* u32 = ((uint32_t*)Array.ptr) + (Array.size >> 2);
-        for (; l32 < u32; ++l32) *l32 = Get32Bits(ProbabilityOf1, RNG);
-
-        uint32_t endV;
-        size_t r = Array.size & 3;
-        memcpy(&endV, u32, r);
-        endV = Get32Bits(ProbabilityOf1, RNG);
-        memcpy(u32, &endV, r);
-    }
-    else {
-        InitRandomArray<uint8_t>(Span<uint8_t>((uint8_t*)Array.ptr, Array.size * sizeof(_T)), ProbabilityOf1, RNG);
-    }
-}
-#endif
-
-template <bool _MemoryOnHost, typename _T>
-    requires std::is_arithmetic_v<_T>
-__host__ __forceinline void bcuda::rand::ClearArray(Span<_T> Array) {
-    if constexpr (std::floating_point<_T>) {
-        if constexpr (_MemoryOnHost) {
-            _T* l = Array.ptr;
-            _T* u = Array.ptr + Array.size;
-            for (; l < u; ++l) *l = (_T)0;
-        }
-        else {
-            std::uniform_int_distribution<uint64_t> dis64(0);
-            details::ClearArray_CallKernel(Array);
-        }
-    }
-    else if constexpr (std::same_as<_T, uint8_t>) {
-        if constexpr (_MemoryOnHost) {
-            uint64_t* l64 = (uint64_t*)Array.ptr;
-            uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
-            for (; l64 < u64; ++l64) *l64 = 0;
-
-            uint64_t endV = 0;
-            size_t r = Array.size & 7;
-            memcpy(u64, &endV, r);
-        }
-        else {
-            std::uniform_int_distribution<uint64_t> dis64(0);
-            details::ClearArray_CallKernel(Span<uint64_t>((uint64_t*)Array.ptr, Array.size >> 3));
-
-            uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
-
-            uint64_t endV = 0;
-            size_t r = Array.size & 7;
-            cudaMemcpy(u64, &endV, r, cudaMemcpyDefault);
-        }
-    }
-    else {
-        ClearArray<_MemoryOnHost, uint8_t>(Span<uint8_t>((uint8_t*)Array.ptr, Array.size * sizeof(_T)));
-    }
-}
-#ifdef __CUDACC__
-template <typename _T>
-    requires std::is_arithmetic_v<_T>
-__device__ __forceinline void bcuda::rand::ClearArray(Span<_T> Array) {
-    if constexpr (std::floating_point<_T>) {
-        _T* l = Array.ptr;
-        _T* u = Array.ptr + Array.size;
-        for (; l < u; ++l) *l = (_T)0;
-    }
-    else if constexpr (std::same_as<_T, uint8_t>) {
-        uint64_t* l64 = (uint64_t*)Array.ptr;
-        uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
-        for (; l64 < u64; ++l64) *l64 = 0;
-
-        uint64_t endV = 0;
-        size_t r = Array.size & 7;
-        memcpy(u64, &endV, r);
-    }
-    else {
-        ClearArray<uint8_t>(Span<uint8_t>((uint8_t*)Array.ptr, Array.size * sizeof(_T)));
-    }
-}
-#endif

--- a/rand_randomizer.h
+++ b/rand_randomizer.h
@@ -48,19 +48,19 @@ namespace bcuda {
     }
     namespace rand {
         template <std::integral _T, std::uniform_random_bit_generator _TRNG>
-        __host__ inline _T RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
+        __host__ static inline _T RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
             if constexpr (sizeof(_T) > 4) return Value ^ (_T)Get64Bits(FlipProbability, RNG);
             else return Value ^ (_T)Get32Bits(FlipProbability, RNG);
-    }
+        }
 #ifdef __CUDACC__
         template <std::integral _T, bcuda::KernelCurandState _TRNG>
-        __device__ inline _T RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
+        __device__ static inline _T RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
             if constexpr (sizeof(_T) > 4) return Value ^ (_T)Get64Bits(FlipProbability, RNG);
             else return Value ^ (_T)Get32Bits(FlipProbability, RNG);
-}
+        }
 #endif
         template <std::integral _T, std::uniform_random_bit_generator _TRNG>
-        __host__ inline _T RandomizeWTargets(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
+        __host__ static inline _T RandomizeWTargets(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
             constexpr uint32_t shiftMask = (sizeof(_T) << 3) - 1;
 
             std::uniform_int_distribution<uint32_t> dis32(0);
@@ -83,11 +83,11 @@ namespace bcuda {
                 return Value ^
                     details::RandomizeWTargets_GetEditsOf1s(Value, bc, FlipProbability, dis32(RNG), dis32(RNG)) ^
                     details::RandomizeWTargets_GetEditsOf1s(~Value, 64 - bc, FlipProbability, dis32(RNG), dis32(RNG));
-                }
+            }
         }
 #ifdef __CUDACC__
         template <std::integral _T, bcuda::KernelCurandState _TRNG>
-        __device__ inline _T RandomizeWTargets(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
+        __device__ static inline _T RandomizeWTargets(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
             constexpr uint32_t shiftMask = (sizeof(_T) << 3) - 1;
 
             if (!Value) {
@@ -109,13 +109,14 @@ namespace bcuda {
                     details::RandomizeWTargets_GetEditsOf1s(Value, bc, FlipProbability, curand(&RNG), curand(&RNG)) ^
                     details::RandomizeWTargets_GetEditsOf1s(~Value, 64 - bc, FlipProbability, curand(&RNG), curand(&RNG));
             }
-            }
+        }
 #endif
         template <std::integral _T, std::uniform_random_bit_generator _TRNG>
-        __host__ inline _T RandomizeWMutations(_T Value, uint32_t MutationProbability, _TRNG& RNG) {
+        __host__ static inline _T RandomizeWMutations(_T Value, uint32_t MutationProbability, _TRNG& RNG) {
             std::uniform_int_distribution<uint32_t> dis32(0);
             if (dis32(RNG) < MutationProbability) {
-                if constexpr (sizeof(_T) == 4) return (_T)dis32(RNG);
+                if constexpr (sizeof(_T) == 4)
+                    return (_T)dis32(RNG);
                 else if constexpr (sizeof(_T) > 4) {
                     std::uniform_int_distribution<_T> disT(std::numeric_limits<_T>::min(), std::numeric_limits<_T>::max());
                     return disT(RNG);
@@ -129,7 +130,7 @@ namespace bcuda {
         }
 #ifdef __CUDACC__
         template <std::integral _T, bcuda::KernelCurandState _TRNG>
-        __device__ inline _T RandomizeWMutations(_T Value, uint32_t MutationProbability, _TRNG& RNG) {
+        __device__ static inline _T RandomizeWMutations(_T Value, uint32_t MutationProbability, _TRNG& RNG) {
             if (curand(&RNG) < MutationProbability) {
                 if constexpr (sizeof(_T) > 4) return (_T)(((uint64_t)curand(&RNG) << 32) | curand(&RNG));
                 else return (_T)curand(&RNG);
@@ -138,17 +139,17 @@ namespace bcuda {
         }
 #endif
         template <std::integral _T, std::uniform_random_bit_generator _TRNG>
-        __host__ inline _T RandomizeWMutations(_T Value, uint32_t MutationProbability, uint32_t ProbabilityOf1, _TRNG& RNG) {
+        __host__ static inline _T RandomizeWMutations(_T Value, uint32_t MutationProbability, uint32_t ProbabilityOf1, _TRNG& RNG) {
             std::uniform_int_distribution<uint32_t> dis32(0);
             if (dis32(RNG) < MutationProbability) {
                 if constexpr (sizeof(_T) > 4) return (_T)Get64Bits(ProbabilityOf1, RNG);
                 else return (_T)Get32Bits(ProbabilityOf1, RNG);
-        }
+            }
             return Value;
         }
 #ifdef __CUDACC__
         template <std::integral _T, bcuda::KernelCurandState _TRNG>
-        __device__ inline _T RandomizeWMutations(_T Value, uint32_t MutationProbability, uint32_t ProbabilityOf1, _TRNG& RNG) {
+        __device__ static inline _T RandomizeWMutations(_T Value, uint32_t MutationProbability, uint32_t ProbabilityOf1, _TRNG& RNG) {
             if (curand(&RNG) < MutationProbability) {
                 if constexpr (sizeof(_T) > 4) return (_T)Get64Bits(ProbabilityOf1, RNG);
                 else return (_T)Get32Bits(ProbabilityOf1, RNG);
@@ -157,48 +158,48 @@ namespace bcuda {
         }
 #endif
         template <std::uniform_random_bit_generator _TRNG>
-        __host__ inline float Randomize(float Value, float Scalar, _TRNG& RNG) {
+        __host__ static inline float Randomize(float Value, float Scalar, _TRNG& RNG) {
             std::uniform_real_distribution<float> dis(-Scalar, Scalar);
             return Value + dis(RNG);
         }
         template <std::uniform_random_bit_generator _TRNG>
-        __host__ inline double Randomize(double Value, double Scalar, _TRNG& RNG) {
+        __host__ static inline double Randomize(double Value, double Scalar, _TRNG& RNG) {
             std::uniform_real_distribution<double> dis(-Scalar, Scalar);
             return Value + dis(RNG);
         }
 #ifdef __CUDACC__
         template <bcuda::KernelCurandState _TRNG>
-        __device__ inline float Randomize(float Value, float Scalar, _TRNG& RNG) {
+        __device__ static inline float Randomize(float Value, float Scalar, _TRNG& RNG) {
             return Value + Scalar * 2.f * (curand_uniform(&RNG) - 0.5f);
         }
         template <bcuda::KernelCurandState _TRNG>
-        __device__ inline double Randomize(double Value, double Scalar, _TRNG& RNG) {
+        __device__ static inline double Randomize(double Value, double Scalar, _TRNG& RNG) {
             return Value + Scalar * 2. * (curand_uniform_double(&RNG) - 0.5);
         }
 #endif
         template <std::uniform_random_bit_generator _TRNG>
-        __host__ inline float Randomize(float Value, float Scalar, float LowerBound, float UpperBound, _TRNG& RNG) {
+        __host__ static inline float Randomize(float Value, float Scalar, float LowerBound, float UpperBound, _TRNG& RNG) {
             std::uniform_real_distribution<float> dis(-Scalar, Scalar);
             return std::clamp(Value + dis(RNG), LowerBound, UpperBound);
         }
         template <std::uniform_random_bit_generator _TRNG>
-        __host__ inline double Randomize(double Value, double Scalar, double LowerBound, double UpperBound, _TRNG& RNG) {
+        __host__ static inline double Randomize(double Value, double Scalar, double LowerBound, double UpperBound, _TRNG& RNG) {
             std::uniform_real_distribution<double> dis(-Scalar, Scalar);
             return std::clamp(Value + dis(RNG), LowerBound, UpperBound);
         }
 #ifdef __CUDACC__
         template <bcuda::KernelCurandState _TRNG>
-        __device__ inline float Randomize(float Value, float Scalar, float LowerBound, float UpperBound, _TRNG& RNG) {
+        __device__ static inline float Randomize(float Value, float Scalar, float LowerBound, float UpperBound, _TRNG& RNG) {
             return std::clamp(Value + Scalar * 2.f * (curand_uniform(&RNG) - 0.5f), LowerBound, UpperBound);
         }
         template <bcuda::KernelCurandState _TRNG>
-        __device__ inline double Randomize(double Value, double Scalar, double LowerBound, double UpperBound, _TRNG& RNG) {
+        __device__ static inline double Randomize(double Value, double Scalar, double LowerBound, double UpperBound, _TRNG& RNG) {
             return std::clamp(Value + Scalar * 2. * (curand_uniform_double(&RNG) - 0.5), LowerBound, UpperBound);
         }
 #endif
 
         template <bool _MemoryOnHost, std::floating_point _T, std::uniform_random_bit_generator _TRNG>
-        __host__ inline void RandomizeArray(Span<_T> Array, _T Scalar, _TRNG& RNG) {
+        __host__ static inline void RandomizeArray(Span<_T> Array, _T Scalar, _TRNG& RNG) {
             if constexpr (_MemoryOnHost) {
                 Scalar *= 2.f;
                 std::uniform_real_distribution<_T> dis(-Scalar, Scalar);
@@ -213,7 +214,7 @@ namespace bcuda {
         }
 #ifdef __CUDACC__
         template <std::floating_point _T, bcuda::KernelCurandState _TRNG>
-        __device__ inline void RandomizeArray(Span<_T> Array, _T Scalar, _TRNG& RNG) {
+        __device__ static inline void RandomizeArray(Span<_T> Array, _T Scalar, _TRNG& RNG) {
             if constexpr (std::same_as<_T, float>) {
                 Scalar *= 2.f;
                 float* l = Array.ptr;
@@ -229,7 +230,7 @@ namespace bcuda {
         }
 #endif
         template <bool _MemoryOnHost, std::floating_point _T, std::uniform_random_bit_generator _TRNG>
-        __host__ inline void RandomizeArray(Span<_T> Array, _T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+        __host__ static inline void RandomizeArray(Span<_T> Array, _T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
             if constexpr (_MemoryOnHost) {
                 Scalar *= 2.f;
                 std::uniform_real_distribution<_T> dis(-Scalar, Scalar);
@@ -244,7 +245,7 @@ namespace bcuda {
         }
 #ifdef __CUDACC__
         template <std::floating_point _T, bcuda::KernelCurandState _TRNG>
-        __device__ inline void RandomizeArray(Span<_T> Array, _T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+        __device__ static inline void RandomizeArray(Span<_T> Array, _T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
             if constexpr (std::same_as<_T, float>) {
                 Scalar *= 2.f;
                 float* l = Array.ptr;
@@ -261,7 +262,7 @@ namespace bcuda {
 #endif
 
         template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-        __host__ inline void RandomizeArrayWFlips(Span<_T> Array, uint32_t FlipProb, _TRNG& RNG) {
+        __host__ static void RandomizeArrayWFlips(Span<_T> Array, uint32_t FlipProb, _TRNG& RNG) {
             if constexpr (std::same_as<_T, uint8_t>) {
                 if constexpr (_MemoryOnHost) {
                     uint64_t* l64 = (uint64_t*)Array.ptr;
@@ -299,7 +300,7 @@ namespace bcuda {
         }
 #ifdef __CUDACC__
         template <std::integral _T, bcuda::KernelCurandState _TRNG>
-        __device__ inline void RandomizeArrayWFlips(Span<_T> Array, uint32_t FlipProb, _TRNG& RNG) {
+        __device__ static inline void RandomizeArrayWFlips(Span<_T> Array, uint32_t FlipProb, _TRNG& RNG) {
             if constexpr (std::same_as<_T, uint8_t>) {
                 uint64_t* l64 = (uint64_t*)Array.ptr;
                 uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
@@ -320,7 +321,7 @@ namespace bcuda {
         }
 #endif
         template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-        __host__ inline void RandomizeArrayWTargets(Span<_T> Array, uint32_t EachFlipProb, _TRNG& RNG) {
+        __host__ static void RandomizeArrayWTargets(Span<_T> Array, uint32_t EachFlipProb, _TRNG& RNG) {
             if constexpr (std::same_as<_T, uint8_t>) {
                 if constexpr (_MemoryOnHost) {
                     uint64_t* l64 = (uint64_t*)Array.ptr;
@@ -358,7 +359,7 @@ namespace bcuda {
         }
 #ifdef __CUDACC__
         template <std::integral _T, bcuda::KernelCurandState _TRNG>
-        __device__ inline void RandomizeArrayWTargets(Span<_T> Array, uint32_t EachFlipProb, _TRNG& RNG) {
+        __device__ static inline void RandomizeArrayWTargets(Span<_T> Array, uint32_t EachFlipProb, _TRNG& RNG) {
             if constexpr (std::same_as<_T, uint8_t>) {
                 uint64_t* l64 = (uint64_t*)Array.ptr;
                 uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
@@ -379,7 +380,7 @@ namespace bcuda {
         }
 #endif
         template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-        __host__ inline void RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, _TRNG& RNG) {
+        __host__ static void RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, _TRNG& RNG) {
             if constexpr (std::same_as<_T, uint8_t>) {
                 if constexpr (_MemoryOnHost) {
                     uint64_t* l64 = (uint64_t*)Array.ptr;
@@ -417,7 +418,7 @@ namespace bcuda {
         }
 #ifdef __CUDACC__
         template <std::integral _T, bcuda::KernelCurandState _TRNG>
-        __device__ inline void RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, _TRNG& RNG) {
+        __device__ static inline void RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, _TRNG& RNG) {
             if constexpr (std::same_as<_T, uint8_t>) {
                 uint64_t* l64 = (uint64_t*)Array.ptr;
                 uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
@@ -438,7 +439,7 @@ namespace bcuda {
         }
 #endif
         template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-        __host__ inline void RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, _TRNG& RNG) {
+        __host__ static void RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, _TRNG& RNG) {
             if constexpr (std::same_as<_T, uint8_t>) {
                 if constexpr (_MemoryOnHost) {
                     uint64_t* l64 = (uint64_t*)Array.ptr;
@@ -476,7 +477,7 @@ namespace bcuda {
         }
 #ifdef __CUDACC__
         template <std::integral _T, bcuda::KernelCurandState _TRNG>
-        __device__ inline void RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, _TRNG& RNG) {
+        __device__ static inline void RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, _TRNG& RNG) {
             if constexpr (std::same_as<_T, uint8_t>) {
                 uint64_t* l64 = (uint64_t*)Array.ptr;
                 uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
@@ -499,7 +500,7 @@ namespace bcuda {
 
         template <bool _MemoryOnHost, typename _T, std::uniform_random_bit_generator _TRNG>
             requires std::is_arithmetic_v<_T>
-        __host__ inline void InitRandomArray(Span<_T> Array, _TRNG& RNG) {
+        __host__ static void InitRandomArray(Span<_T> Array, _TRNG& RNG) {
             if constexpr (std::floating_point<_T>) {
                 if constexpr (_MemoryOnHost) {
                     std::uniform_real_distribution<_T> dis(-1., 1.);
@@ -545,7 +546,7 @@ namespace bcuda {
 #ifdef __CUDACC__
         template <typename _T, bcuda::KernelCurandState _TRNG>
             requires std::is_arithmetic_v<_T>
-        __device__ inline void InitRandomArray(Span<_T> Array, _TRNG& RNG) {
+        __device__ static inline void InitRandomArray(Span<_T> Array, _TRNG& RNG) {
             if constexpr (std::same_as<_T, float>) {
                 float* l = Array.ptr;
                 float* u = Array.ptr + Array.size;
@@ -572,7 +573,7 @@ namespace bcuda {
 
 #endif
         template <bool _MemoryOnHost, std::floating_point _T, std::uniform_random_bit_generator _TRNG>
-        __host__ inline void InitRandomArray(Span<_T> Array, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+        __host__ static inline void InitRandomArray(Span<_T> Array, _T LowerBound, _T UpperBound, _TRNG& RNG) {
             if constexpr (_MemoryOnHost) {
                 std::uniform_real_distribution<_T> dis(LowerBound, UpperBound);
                 _T* l = Array.ptr;
@@ -586,7 +587,7 @@ namespace bcuda {
         }
 #ifdef __CUDACC__
         template <std::floating_point _T, bcuda::KernelCurandState _TRNG>
-        __device__ inline void InitRandomArray(Span<_T> Array, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+        __device__ static inline void InitRandomArray(Span<_T> Array, _T LowerBound, _T UpperBound, _TRNG& RNG) {
             if constexpr (std::same_as<_T, float>) {
                 float range = UpperBound - LowerBound;
                 float* l = Array.ptr;
@@ -603,7 +604,7 @@ namespace bcuda {
 #endif
 
         template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-        __host__ inline void InitRandomArray(Span<_T> Array, uint32_t ProbabilityOf1, _TRNG& RNG) {
+        __host__ static void InitRandomArray(Span<_T> Array, uint32_t ProbabilityOf1, _TRNG& RNG) {
             if constexpr (std::same_as<_T, uint8_t>) {
                 if constexpr (_MemoryOnHost) {
                     uint64_t* l64 = (uint64_t*)Array.ptr;
@@ -635,7 +636,7 @@ namespace bcuda {
         }
 #ifdef __CUDACC__
         template <std::integral _T, bcuda::KernelCurandState _TRNG>
-        __device__ inline void InitRandomArray(Span<_T> Array, uint32_t ProbabilityOf1, _TRNG& RNG) {
+        __device__ static inline void InitRandomArray(Span<_T> Array, uint32_t ProbabilityOf1, _TRNG& RNG) {
             if constexpr (std::same_as<_T, uint8_t>) {
                 uint32_t* l32 = (uint32_t*)Array.ptr;
                 uint32_t* u32 = ((uint32_t*)Array.ptr) + (Array.size >> 2);
@@ -655,7 +656,7 @@ namespace bcuda {
 
         template <bool _MemoryOnHost, typename _T>
             requires std::is_arithmetic_v<_T>
-        __host__ inline void ClearArray(Span<_T> Array) {
+        __host__ static inline void ClearArray(Span<_T> Array) {
             if constexpr (std::floating_point<_T>) {
                 if constexpr (_MemoryOnHost) {
                     _T* l = Array.ptr;
@@ -695,7 +696,7 @@ namespace bcuda {
 #ifdef __CUDACC__
         template <typename _T>
             requires std::is_arithmetic_v<_T>
-        __device__ inline void ClearArray(Span<_T> Array) {
+        __device__ static inline void ClearArray(Span<_T> Array) {
             if constexpr (std::floating_point<_T>) {
                 _T* l = Array.ptr;
                 _T* u = Array.ptr + Array.size;

--- a/rand_randomizer.h
+++ b/rand_randomizer.h
@@ -12,7 +12,7 @@
 namespace bcuda {
     namespace details {
         template <std::integral _T>
-        __host__ __device__ static __forceinline _T RandomizeWTargets_GetEditsOf1s(_T Value, uint32_t CountOf1s, uint32_t FlipProb, uint32_t RN1, uint32_t RN2) {
+        __host__ __device__ static inline _T RandomizeWTargets_GetEditsOf1s(_T Value, uint32_t CountOf1s, uint32_t FlipProb, uint32_t RN1, uint32_t RN2) {
             if (RN1 < FlipProb) {
                 uint32_t mrn = RN2 % CountOf1s;
 
@@ -48,19 +48,19 @@ namespace bcuda {
     }
     namespace rand {
         template <std::integral _T, std::uniform_random_bit_generator _TRNG>
-        __host__ __forceinline _T RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
+        __host__ inline _T RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
             if constexpr (sizeof(_T) > 4) return Value ^ (_T)Get64Bits(FlipProbability, RNG);
             else return Value ^ (_T)Get32Bits(FlipProbability, RNG);
     }
 #ifdef __CUDACC__
         template <std::integral _T, bcuda::KernelCurandState _TRNG>
-        __device__ __forceinline _T RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
+        __device__ inline _T RandomizeWFlips(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
             if constexpr (sizeof(_T) > 4) return Value ^ (_T)Get64Bits(FlipProbability, RNG);
             else return Value ^ (_T)Get32Bits(FlipProbability, RNG);
 }
 #endif
         template <std::integral _T, std::uniform_random_bit_generator _TRNG>
-        __host__ __forceinline _T RandomizeWTargets(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
+        __host__ inline _T RandomizeWTargets(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
             constexpr uint32_t shiftMask = (sizeof(_T) << 3) - 1;
 
             std::uniform_int_distribution<uint32_t> dis32(0);
@@ -87,7 +87,7 @@ namespace bcuda {
         }
 #ifdef __CUDACC__
         template <std::integral _T, bcuda::KernelCurandState _TRNG>
-        __device__ __forceinline _T RandomizeWTargets(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
+        __device__ inline _T RandomizeWTargets(_T Value, uint32_t FlipProbability, _TRNG& RNG) {
             constexpr uint32_t shiftMask = (sizeof(_T) << 3) - 1;
 
             if (!Value) {
@@ -112,7 +112,7 @@ namespace bcuda {
             }
 #endif
         template <std::integral _T, std::uniform_random_bit_generator _TRNG>
-        __host__ __forceinline _T RandomizeWMutations(_T Value, uint32_t MutationProbability, _TRNG& RNG) {
+        __host__ inline _T RandomizeWMutations(_T Value, uint32_t MutationProbability, _TRNG& RNG) {
             std::uniform_int_distribution<uint32_t> dis32(0);
             if (dis32(RNG) < MutationProbability) {
                 if constexpr (sizeof(_T) == 4) return (_T)dis32(RNG);
@@ -129,7 +129,7 @@ namespace bcuda {
         }
 #ifdef __CUDACC__
         template <std::integral _T, bcuda::KernelCurandState _TRNG>
-        __device__ __forceinline _T RandomizeWMutations(_T Value, uint32_t MutationProbability, _TRNG& RNG) {
+        __device__ inline _T RandomizeWMutations(_T Value, uint32_t MutationProbability, _TRNG& RNG) {
             if (curand(&RNG) < MutationProbability) {
                 if constexpr (sizeof(_T) > 4) return (_T)(((uint64_t)curand(&RNG) << 32) | curand(&RNG));
                 else return (_T)curand(&RNG);
@@ -138,7 +138,7 @@ namespace bcuda {
         }
 #endif
         template <std::integral _T, std::uniform_random_bit_generator _TRNG>
-        __host__ __forceinline _T RandomizeWMutations(_T Value, uint32_t MutationProbability, uint32_t ProbabilityOf1, _TRNG& RNG) {
+        __host__ inline _T RandomizeWMutations(_T Value, uint32_t MutationProbability, uint32_t ProbabilityOf1, _TRNG& RNG) {
             std::uniform_int_distribution<uint32_t> dis32(0);
             if (dis32(RNG) < MutationProbability) {
                 if constexpr (sizeof(_T) > 4) return (_T)Get64Bits(ProbabilityOf1, RNG);
@@ -148,7 +148,7 @@ namespace bcuda {
         }
 #ifdef __CUDACC__
         template <std::integral _T, bcuda::KernelCurandState _TRNG>
-        __device__ __forceinline _T RandomizeWMutations(_T Value, uint32_t MutationProbability, uint32_t ProbabilityOf1, _TRNG& RNG) {
+        __device__ inline _T RandomizeWMutations(_T Value, uint32_t MutationProbability, uint32_t ProbabilityOf1, _TRNG& RNG) {
             if (curand(&RNG) < MutationProbability) {
                 if constexpr (sizeof(_T) > 4) return (_T)Get64Bits(ProbabilityOf1, RNG);
                 else return (_T)Get32Bits(ProbabilityOf1, RNG);
@@ -157,48 +157,48 @@ namespace bcuda {
         }
 #endif
         template <std::uniform_random_bit_generator _TRNG>
-        __host__ __forceinline float Randomize(float Value, float Scalar, _TRNG& RNG) {
+        __host__ inline float Randomize(float Value, float Scalar, _TRNG& RNG) {
             std::uniform_real_distribution<float> dis(-Scalar, Scalar);
             return Value + dis(RNG);
         }
         template <std::uniform_random_bit_generator _TRNG>
-        __host__ __forceinline double Randomize(double Value, double Scalar, _TRNG& RNG) {
+        __host__ inline double Randomize(double Value, double Scalar, _TRNG& RNG) {
             std::uniform_real_distribution<double> dis(-Scalar, Scalar);
             return Value + dis(RNG);
         }
 #ifdef __CUDACC__
         template <bcuda::KernelCurandState _TRNG>
-        __device__ __forceinline float Randomize(float Value, float Scalar, _TRNG& RNG) {
+        __device__ inline float Randomize(float Value, float Scalar, _TRNG& RNG) {
             return Value + Scalar * 2.f * (curand_uniform(&RNG) - 0.5f);
         }
         template <bcuda::KernelCurandState _TRNG>
-        __device__ __forceinline double Randomize(double Value, double Scalar, _TRNG& RNG) {
+        __device__ inline double Randomize(double Value, double Scalar, _TRNG& RNG) {
             return Value + Scalar * 2. * (curand_uniform_double(&RNG) - 0.5);
         }
 #endif
         template <std::uniform_random_bit_generator _TRNG>
-        __host__ __forceinline float Randomize(float Value, float Scalar, float LowerBound, float UpperBound, _TRNG& RNG) {
+        __host__ inline float Randomize(float Value, float Scalar, float LowerBound, float UpperBound, _TRNG& RNG) {
             std::uniform_real_distribution<float> dis(-Scalar, Scalar);
             return std::clamp(Value + dis(RNG), LowerBound, UpperBound);
         }
         template <std::uniform_random_bit_generator _TRNG>
-        __host__ __forceinline double Randomize(double Value, double Scalar, double LowerBound, double UpperBound, _TRNG& RNG) {
+        __host__ inline double Randomize(double Value, double Scalar, double LowerBound, double UpperBound, _TRNG& RNG) {
             std::uniform_real_distribution<double> dis(-Scalar, Scalar);
             return std::clamp(Value + dis(RNG), LowerBound, UpperBound);
         }
 #ifdef __CUDACC__
         template <bcuda::KernelCurandState _TRNG>
-        __device__ __forceinline float Randomize(float Value, float Scalar, float LowerBound, float UpperBound, _TRNG& RNG) {
+        __device__ inline float Randomize(float Value, float Scalar, float LowerBound, float UpperBound, _TRNG& RNG) {
             return std::clamp(Value + Scalar * 2.f * (curand_uniform(&RNG) - 0.5f), LowerBound, UpperBound);
         }
         template <bcuda::KernelCurandState _TRNG>
-        __device__ __forceinline double Randomize(double Value, double Scalar, double LowerBound, double UpperBound, _TRNG& RNG) {
+        __device__ inline double Randomize(double Value, double Scalar, double LowerBound, double UpperBound, _TRNG& RNG) {
             return std::clamp(Value + Scalar * 2. * (curand_uniform_double(&RNG) - 0.5), LowerBound, UpperBound);
         }
 #endif
 
         template <bool _MemoryOnHost, std::floating_point _T, std::uniform_random_bit_generator _TRNG>
-        __host__ __forceinline void RandomizeArray(Span<_T> Array, _T Scalar, _TRNG& RNG) {
+        __host__ inline void RandomizeArray(Span<_T> Array, _T Scalar, _TRNG& RNG) {
             if constexpr (_MemoryOnHost) {
                 Scalar *= 2.f;
                 std::uniform_real_distribution<_T> dis(-Scalar, Scalar);
@@ -213,7 +213,7 @@ namespace bcuda {
         }
 #ifdef __CUDACC__
         template <std::floating_point _T, bcuda::KernelCurandState _TRNG>
-        __device__ __forceinline void RandomizeArray(Span<_T> Array, _T Scalar, _TRNG& RNG) {
+        __device__ inline void RandomizeArray(Span<_T> Array, _T Scalar, _TRNG& RNG) {
             if constexpr (std::same_as<_T, float>) {
                 Scalar *= 2.f;
                 float* l = Array.ptr;
@@ -229,7 +229,7 @@ namespace bcuda {
         }
 #endif
         template <bool _MemoryOnHost, std::floating_point _T, std::uniform_random_bit_generator _TRNG>
-        __host__ __forceinline void RandomizeArray(Span<_T> Array, _T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+        __host__ inline void RandomizeArray(Span<_T> Array, _T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
             if constexpr (_MemoryOnHost) {
                 Scalar *= 2.f;
                 std::uniform_real_distribution<_T> dis(-Scalar, Scalar);
@@ -244,7 +244,7 @@ namespace bcuda {
         }
 #ifdef __CUDACC__
         template <std::floating_point _T, bcuda::KernelCurandState _TRNG>
-        __device__ __forceinline void RandomizeArray(Span<_T> Array, _T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+        __device__ inline void RandomizeArray(Span<_T> Array, _T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
             if constexpr (std::same_as<_T, float>) {
                 Scalar *= 2.f;
                 float* l = Array.ptr;
@@ -261,7 +261,7 @@ namespace bcuda {
 #endif
 
         template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-        __host__ __forceinline void RandomizeArrayWFlips(Span<_T> Array, uint32_t FlipProb, _TRNG& RNG) {
+        __host__ inline void RandomizeArrayWFlips(Span<_T> Array, uint32_t FlipProb, _TRNG& RNG) {
             if constexpr (std::same_as<_T, uint8_t>) {
                 if constexpr (_MemoryOnHost) {
                     uint64_t* l64 = (uint64_t*)Array.ptr;
@@ -299,7 +299,7 @@ namespace bcuda {
         }
 #ifdef __CUDACC__
         template <std::integral _T, bcuda::KernelCurandState _TRNG>
-        __device__ __forceinline void RandomizeArrayWFlips(Span<_T> Array, uint32_t FlipProb, _TRNG& RNG) {
+        __device__ inline void RandomizeArrayWFlips(Span<_T> Array, uint32_t FlipProb, _TRNG& RNG) {
             if constexpr (std::same_as<_T, uint8_t>) {
                 uint64_t* l64 = (uint64_t*)Array.ptr;
                 uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
@@ -320,7 +320,7 @@ namespace bcuda {
         }
 #endif
         template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-        __host__ __forceinline void RandomizeArrayWTargets(Span<_T> Array, uint32_t EachFlipProb, _TRNG& RNG) {
+        __host__ inline void RandomizeArrayWTargets(Span<_T> Array, uint32_t EachFlipProb, _TRNG& RNG) {
             if constexpr (std::same_as<_T, uint8_t>) {
                 if constexpr (_MemoryOnHost) {
                     uint64_t* l64 = (uint64_t*)Array.ptr;
@@ -358,7 +358,7 @@ namespace bcuda {
         }
 #ifdef __CUDACC__
         template <std::integral _T, bcuda::KernelCurandState _TRNG>
-        __device__ __forceinline void RandomizeArrayWTargets(Span<_T> Array, uint32_t EachFlipProb, _TRNG& RNG) {
+        __device__ inline void RandomizeArrayWTargets(Span<_T> Array, uint32_t EachFlipProb, _TRNG& RNG) {
             if constexpr (std::same_as<_T, uint8_t>) {
                 uint64_t* l64 = (uint64_t*)Array.ptr;
                 uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
@@ -379,7 +379,7 @@ namespace bcuda {
         }
 #endif
         template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-        __host__ __forceinline void RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, _TRNG& RNG) {
+        __host__ inline void RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, _TRNG& RNG) {
             if constexpr (std::same_as<_T, uint8_t>) {
                 if constexpr (_MemoryOnHost) {
                     uint64_t* l64 = (uint64_t*)Array.ptr;
@@ -417,7 +417,7 @@ namespace bcuda {
         }
 #ifdef __CUDACC__
         template <std::integral _T, bcuda::KernelCurandState _TRNG>
-        __device__ __forceinline void RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, _TRNG& RNG) {
+        __device__ inline void RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, _TRNG& RNG) {
             if constexpr (std::same_as<_T, uint8_t>) {
                 uint64_t* l64 = (uint64_t*)Array.ptr;
                 uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
@@ -438,7 +438,7 @@ namespace bcuda {
         }
 #endif
         template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-        __host__ __forceinline void RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, _TRNG& RNG) {
+        __host__ inline void RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, _TRNG& RNG) {
             if constexpr (std::same_as<_T, uint8_t>) {
                 if constexpr (_MemoryOnHost) {
                     uint64_t* l64 = (uint64_t*)Array.ptr;
@@ -476,7 +476,7 @@ namespace bcuda {
         }
 #ifdef __CUDACC__
         template <std::integral _T, bcuda::KernelCurandState _TRNG>
-        __device__ __forceinline void RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, _TRNG& RNG) {
+        __device__ inline void RandomizeArrayWMutations(Span<_T> Array, uint32_t MutationProb, uint32_t ProbabilityOf1, _TRNG& RNG) {
             if constexpr (std::same_as<_T, uint8_t>) {
                 uint64_t* l64 = (uint64_t*)Array.ptr;
                 uint64_t* u64 = ((uint64_t*)Array.ptr) + (Array.size >> 3);
@@ -499,7 +499,7 @@ namespace bcuda {
 
         template <bool _MemoryOnHost, typename _T, std::uniform_random_bit_generator _TRNG>
             requires std::is_arithmetic_v<_T>
-        __host__ __forceinline void InitRandomArray(Span<_T> Array, _TRNG& RNG) {
+        __host__ inline void InitRandomArray(Span<_T> Array, _TRNG& RNG) {
             if constexpr (std::floating_point<_T>) {
                 if constexpr (_MemoryOnHost) {
                     std::uniform_real_distribution<_T> dis(-1., 1.);
@@ -545,7 +545,7 @@ namespace bcuda {
 #ifdef __CUDACC__
         template <typename _T, bcuda::KernelCurandState _TRNG>
             requires std::is_arithmetic_v<_T>
-        __device__ __forceinline void InitRandomArray(Span<_T> Array, _TRNG& RNG) {
+        __device__ inline void InitRandomArray(Span<_T> Array, _TRNG& RNG) {
             if constexpr (std::same_as<_T, float>) {
                 float* l = Array.ptr;
                 float* u = Array.ptr + Array.size;
@@ -572,7 +572,7 @@ namespace bcuda {
 
 #endif
         template <bool _MemoryOnHost, std::floating_point _T, std::uniform_random_bit_generator _TRNG>
-        __host__ __forceinline void InitRandomArray(Span<_T> Array, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+        __host__ inline void InitRandomArray(Span<_T> Array, _T LowerBound, _T UpperBound, _TRNG& RNG) {
             if constexpr (_MemoryOnHost) {
                 std::uniform_real_distribution<_T> dis(LowerBound, UpperBound);
                 _T* l = Array.ptr;
@@ -586,7 +586,7 @@ namespace bcuda {
         }
 #ifdef __CUDACC__
         template <std::floating_point _T, bcuda::KernelCurandState _TRNG>
-        __device__ __forceinline void InitRandomArray(Span<_T> Array, _T LowerBound, _T UpperBound, _TRNG& RNG) {
+        __device__ inline void InitRandomArray(Span<_T> Array, _T LowerBound, _T UpperBound, _TRNG& RNG) {
             if constexpr (std::same_as<_T, float>) {
                 float range = UpperBound - LowerBound;
                 float* l = Array.ptr;
@@ -603,7 +603,7 @@ namespace bcuda {
 #endif
 
         template <bool _MemoryOnHost, std::integral _T, std::uniform_random_bit_generator _TRNG>
-        __host__ __forceinline void InitRandomArray(Span<_T> Array, uint32_t ProbabilityOf1, _TRNG& RNG) {
+        __host__ inline void InitRandomArray(Span<_T> Array, uint32_t ProbabilityOf1, _TRNG& RNG) {
             if constexpr (std::same_as<_T, uint8_t>) {
                 if constexpr (_MemoryOnHost) {
                     uint64_t* l64 = (uint64_t*)Array.ptr;
@@ -635,7 +635,7 @@ namespace bcuda {
         }
 #ifdef __CUDACC__
         template <std::integral _T, bcuda::KernelCurandState _TRNG>
-        __device__ __forceinline void InitRandomArray(Span<_T> Array, uint32_t ProbabilityOf1, _TRNG& RNG) {
+        __device__ inline void InitRandomArray(Span<_T> Array, uint32_t ProbabilityOf1, _TRNG& RNG) {
             if constexpr (std::same_as<_T, uint8_t>) {
                 uint32_t* l32 = (uint32_t*)Array.ptr;
                 uint32_t* u32 = ((uint32_t*)Array.ptr) + (Array.size >> 2);
@@ -655,7 +655,7 @@ namespace bcuda {
 
         template <bool _MemoryOnHost, typename _T>
             requires std::is_arithmetic_v<_T>
-        __host__ __forceinline void ClearArray(Span<_T> Array) {
+        __host__ inline void ClearArray(Span<_T> Array) {
             if constexpr (std::floating_point<_T>) {
                 if constexpr (_MemoryOnHost) {
                     _T* l = Array.ptr;
@@ -695,7 +695,7 @@ namespace bcuda {
 #ifdef __CUDACC__
         template <typename _T>
             requires std::is_arithmetic_v<_T>
-        __device__ __forceinline void ClearArray(Span<_T> Array) {
+        __device__ inline void ClearArray(Span<_T> Array) {
             if constexpr (std::floating_point<_T>) {
                 _T* l = Array.ptr;
                 _T* u = Array.ptr + Array.size;

--- a/threadid.h
+++ b/threadid.h
@@ -6,13 +6,13 @@
 
 namespace bcuda {
 #ifdef __CUDACC__
-    __device__ inline uint64_t GetThreadID1() {
+    __device__ static inline uint64_t GetThreadID1() {
         uint64_t t = 0;
         t = t * gridDim.x + blockIdx.x;
         t = t * blockDim.x + threadIdx.x;
         return t;
     }
-    __device__ inline uint64_t GetThreadID2() {
+    __device__ static inline uint64_t GetThreadID2() {
         uint64_t t = 0;
         t = t * gridDim.y + blockIdx.y;
         t = t * blockDim.y + threadIdx.y;
@@ -20,7 +20,7 @@ namespace bcuda {
         t = t * blockDim.x + threadIdx.x;
         return t;
     }
-    __device__ inline uint64_t GetThreadID3() {
+    __device__ static inline uint64_t GetThreadID3() {
         uint64_t t = 0;
         t = t * gridDim.z + blockIdx.z;
         t = t * blockDim.z + threadIdx.z;

--- a/threadid.h
+++ b/threadid.h
@@ -6,35 +6,29 @@
 
 namespace bcuda {
 #ifdef __CUDACC__
-    __device__ __forceinline uint64_t GetThreadID1();
-    __device__ __forceinline uint64_t GetThreadID2();
-    __device__ __forceinline uint64_t GetThreadID3();
+    __device__ __forceinline uint64_t GetThreadID1() {
+        uint64_t t = 0;
+        t = t * gridDim.x + blockIdx.x;
+        t = t * blockDim.x + threadIdx.x;
+        return t;
+    }
+    __device__ __forceinline uint64_t GetThreadID2() {
+        uint64_t t = 0;
+        t = t * gridDim.y + blockIdx.y;
+        t = t * blockDim.y + threadIdx.y;
+        t = t * gridDim.x + blockIdx.x;
+        t = t * blockDim.x + threadIdx.x;
+        return t;
+    }
+    __device__ __forceinline uint64_t GetThreadID3() {
+        uint64_t t = 0;
+        t = t * gridDim.z + blockIdx.z;
+        t = t * blockDim.z + threadIdx.z;
+        t = t * gridDim.y + blockIdx.y;
+        t = t * blockDim.y + threadIdx.y;
+        t = t * gridDim.x + blockIdx.x;
+        t = t * blockDim.x + threadIdx.x;
+        return t;
+    }
 #endif
 }
-
-#ifdef __CUDACC__
-__device__ __forceinline uint64_t bcuda::GetThreadID1() {
-    uint64_t t = 0;
-    t = t * gridDim.x + blockIdx.x;
-    t = t * blockDim.x + threadIdx.x;
-    return t;
-}
-__device__ __forceinline uint64_t bcuda::GetThreadID2() {
-    uint64_t t = 0;
-    t = t * gridDim.y + blockIdx.y;
-    t = t * blockDim.y + threadIdx.y;
-    t = t * gridDim.x + blockIdx.x;
-    t = t * blockDim.x + threadIdx.x;
-    return t;
-}
-__device__ __forceinline uint64_t bcuda::GetThreadID3() {
-    uint64_t t = 0;
-    t = t * gridDim.z + blockIdx.z;
-    t = t * blockDim.z + threadIdx.z;
-    t = t * gridDim.y + blockIdx.y;
-    t = t * blockDim.y + threadIdx.y;
-    t = t * gridDim.x + blockIdx.x;
-    t = t * blockDim.x + threadIdx.x;
-    return t;
-}
-#endif

--- a/threadid.h
+++ b/threadid.h
@@ -6,13 +6,13 @@
 
 namespace bcuda {
 #ifdef __CUDACC__
-    __device__ __forceinline uint64_t GetThreadID1() {
+    __device__ inline uint64_t GetThreadID1() {
         uint64_t t = 0;
         t = t * gridDim.x + blockIdx.x;
         t = t * blockDim.x + threadIdx.x;
         return t;
     }
-    __device__ __forceinline uint64_t GetThreadID2() {
+    __device__ inline uint64_t GetThreadID2() {
         uint64_t t = 0;
         t = t * gridDim.y + blockIdx.y;
         t = t * blockDim.y + threadIdx.y;
@@ -20,7 +20,7 @@ namespace bcuda {
         t = t * blockDim.x + threadIdx.x;
         return t;
     }
-    __device__ __forceinline uint64_t GetThreadID3() {
+    __device__ inline uint64_t GetThreadID3() {
         uint64_t t = 0;
         t = t * gridDim.z + blockIdx.z;
         t = t * blockDim.z + threadIdx.z;


### PR DESCRIPTION
Refactored the entire project to support the following conventions:

* Replaced the nonstandard `__forceinline` keyword with the much more portable `inline` keyword.
* Previously, functions both declared and defined in the header sometimes still had their definitions separated from their declarations. This has now been resolved. All functions defined in the header are now defined in the same place as they are declared, unless this is impossible (such as in the case of circular references).
* Previously, some functions had their parameters spread horizontally for readability. This is no longer the case.
* In source files, namespace-qualified function names have been entirely replaced with placing said functions in the namespace corresponding to their own.
* Fixed usage of `static` keyword in multiple places.
* Added and removed `inline` keywords (including where that `inline` used to be a `__forceinline`).

There may also be some more minor changes, but those are the big ones.