### PR TITLE
Adding missing file `uniqueid.h` to `allheaders.h`

### DIFF
--- a/allheaders.h
+++ b/allheaders.h
@@ -40,3 +40,4 @@
 #include "rand_bits.h"
 #include "rand_randomizer.h"
 #include "threadid.h"
+#include "uniqueid.h"


### PR DESCRIPTION
Previously, file `allheaders.h` did not contain a reference to the file `uniqueid.h`. This is likely a consequence of its very recent creation in #29. Now, however, this has been resolved.