### PR TITLE
Adding compile-time `Run` functions to `FixedMLP` and `FixedMLPB`

### DIFF
--- a/ai.h
+++ b/ai.h
@@ -10,6 +10,10 @@ namespace bcuda {
     namespace ai {
         template <typename _T>
         using activationFunction_t = _T(*)(_T Value);
+        template <auto _Func, typename _TVal>
+        concept IsActivationFunction = requires (_TVal Val) {
+            { _Func(Val) } -> std::same_as<_TVal>;
+        };
 
         template <typename _T>
         __host__ __device__ inline static constexpr _T ReLU(_T Value) {

--- a/ai_mlp_fixedmlp.h
+++ b/ai_mlp_fixedmlp.h
@@ -186,6 +186,16 @@ namespace bcuda {
                         }
                     }
                 }
+                __host__ __device__ consteval std::array<_T, _OutputCount> Run(const _T(&Input)[_InputCount]) {
+                    std::array<_T, _OutputCount> output;
+                    for (size_t j = 0; j < _OutputCount; ++j) {
+                        _T v = bias[j];
+                        for (size_t i = 0; i < _InputCount; ++i)
+                            v += weights[i][j] * Input[i];
+                        output[j] = _ActivationFunction(v);
+                    }
+                    return output;
+                }
 
                 inline size_t SerializedSize() const {
                     return sizeof(this_t);
@@ -308,6 +318,10 @@ namespace bcuda {
                     if (!Intermediate1) delete[] i1;
                     if (!Intermediate2) delete[] i2;
                 }
+                __host__ __device__ consteval std::array<_T, OutputCount()> Run(const _T(&Input)[_InputCount]) {
+                    auto firstOutput = layer.Run(Input);
+                    return nextLayers.Run(firstOutput);
+                }
 
                 inline size_t SerializedSize() const {
                     return sizeof(this_t);
@@ -406,6 +420,9 @@ namespace bcuda {
                 }
                 __host__ __device__ inline void Run(const _T* Input, _T* Intermediate1, _T* Intermediate2, _T* Output) const {
                     layer.Run(Input, Output);
+                }
+                __host__ __device__ consteval std::array<_T, _OutputCount> Run(const _T(&Input)[_InputCount]) {
+                    return layer.Run(Input);
                 }
 
                 inline size_t SerializedSize() const {

--- a/ai_mlp_fixedmlp.h
+++ b/ai_mlp_fixedmlp.h
@@ -170,20 +170,18 @@ namespace bcuda {
                     if (Input == Output) {
                         _T* secondOutput = new _T[_OutputCount];
                         for (size_t j = 0; j < _OutputCount; ++j) {
-                            float v = bias[j];
-                            for (size_t i = 0; i < _InputCount; ++i) {
+                            _T v = bias[j];
+                            for (size_t i = 0; i < _InputCount; ++i)
                                 v += weights[i][j] * Input[i];
-                            }
                             secondOutput[j] = _ActivationFunction(v);
                         }
                         memcpy(Output, secondOutput, sizeof(_T) * _OutputCount);
                     }
                     else {
                         for (size_t j = 0; j < _OutputCount; ++j) {
-                            float v = bias[j];
-                            for (size_t i = 0; i < _InputCount; ++i) {
+                            _T v = bias[j];
+                            for (size_t i = 0; i < _InputCount; ++i)
                                 v += weights[i][j] * Input[i];
-                            }
                             Output[j] = _ActivationFunction(v);
                         }
                     }
@@ -266,19 +264,7 @@ namespace bcuda {
                     nextLayers.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
                 }
 #endif
-                __host__ __device__ inline void Run(const _T* Input, _T* Output) const {
-                    Run(Input, 0, 0, Output);
-                }
-                __host__ __device__ inline void Run(const _T* Input, _T* Intermediate1, _T* Intermediate2, _T* Output) const {
-                    _T* i1 = Intermediate1 ? Intermediate1 : new _T[Intermediate0Count()];
-                    _T* i2 = Intermediate2 ? Intermediate2 : new _T[Intermediate1Count()];
 
-                    layer.Run(Input, i1);
-                    nextLayers.Run(i1, i2, i1, Output);
-
-                    if (!Intermediate1) delete[] i1;
-                    if (!Intermediate2) delete[] i2;
-                }
                 template <size_t _Index>
                 __host__ __device__ inline layerType_t<_Index>& Layer() {
                     if constexpr (_Index) {
@@ -307,6 +293,20 @@ namespace bcuda {
                 }
                 static constexpr size_t LayerCount() {
                     return sizeof...(_ContinuedOutputCounts) + 2;
+                }
+
+                __host__ __device__ inline void Run(const _T* Input, _T* Output) const {
+                    Run(Input, 0, 0, Output);
+                }
+                __host__ __device__ inline void Run(const _T* Input, _T* Intermediate1, _T* Intermediate2, _T* Output) const {
+                    _T* i1 = Intermediate1 ? Intermediate1 : new _T[Intermediate0Count()];
+                    _T* i2 = Intermediate2 ? Intermediate2 : new _T[Intermediate1Count()];
+
+                    layer.Run(Input, i1);
+                    nextLayers.Run(i1, i2, i1, Output);
+
+                    if (!Intermediate1) delete[] i1;
+                    if (!Intermediate2) delete[] i2;
                 }
 
                 inline size_t SerializedSize() const {
@@ -375,12 +375,6 @@ namespace bcuda {
                     layer.ChangeWithRandom(Scalar, LowerBound, UpperBound, RNG);
                 }
 #endif
-                __host__ __device__ inline void Run(const _T* Input, _T* Output) const {
-                    layer.Run(Input, Output);
-                }
-                __host__ __device__ inline void Run(const _T* Input, _T* Intermediate1, _T* Intermediate2, _T* Output) const {
-                    layer.Run(Input, Output);
-                }
                 template <size_t _Index>
                 __host__ __device__ inline layerType_t<_Index>& Layer() {
                     static_assert(!_Index, "_Index is out of bounds (too large).");
@@ -405,6 +399,13 @@ namespace bcuda {
                 }
                 static constexpr size_t LayerCount() {
                     return 1;
+                }
+
+                __host__ __device__ inline void Run(const _T* Input, _T* Output) const {
+                    layer.Run(Input, Output);
+                }
+                __host__ __device__ inline void Run(const _T* Input, _T* Intermediate1, _T* Intermediate2, _T* Output) const {
+                    layer.Run(Input, Output);
                 }
 
                 inline size_t SerializedSize() const {

--- a/ai_mlp_fixedmlp.h
+++ b/ai_mlp_fixedmlp.h
@@ -15,28 +15,29 @@
 namespace bcuda {
     namespace ai {
         namespace mlp {
-            template <std::floating_point _T, activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+            template <std::floating_point _T, auto _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+                requires ai::IsActivationFunction<_ActivationFunction, _T>
             struct FixedMLPL;
         }
     }
     namespace details {
-        template <size_t _Index, std::floating_point _T, ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _ContinuedOutputCounts>
+        template <size_t _Index, std::floating_point _T, auto _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _ContinuedOutputCounts>
         struct MLPLayerType;
-        template <size_t _Index, std::floating_point _T, ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+        template <size_t _Index, std::floating_point _T, auto _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
         struct MLPLayerType<_Index, _T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...> {
             using type = typename MLPLayerType<_Index - 1, _T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::type;
         };
-        template <std::floating_point _T, ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+        template <std::floating_point _T, auto _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
         struct MLPLayerType<0, _T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...> {
             using type = ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _Output1Count>;
         };
-        template <size_t _Index, std::floating_point _T, ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+        template <size_t _Index, std::floating_point _T, auto _ActivationFunction, size_t _InputCount, size_t _Output1Count>
         struct MLPLayerType<_Index, _T, _ActivationFunction, _InputCount, _Output1Count> {
             static_assert(!_Index, "_Index is out of bounds.");
             using type = ai::mlp::FixedMLPL<_T, _ActivationFunction, _InputCount, _Output1Count>;
         };
 
-        template <size_t _Index, std::floating_point _T, ai::activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _ContinuedOutputCounts>
+        template <size_t _Index, std::floating_point _T, auto _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _ContinuedOutputCounts>
         using mlpLayerType_t = MLPLayerType<_Index, _T, _ActivationFunction, _InputCount, _Output1Count, _ContinuedOutputCounts...>;
 
         template <uintmax_t _Idx, size_t... _Ints>
@@ -52,7 +53,8 @@ namespace bcuda {
     }
     namespace ai {
         namespace mlp {
-            template <std::floating_point _T, activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+            template <std::floating_point _T, auto _ActivationFunction, size_t _InputCount, size_t _OutputCount>
+                requires ai::IsActivationFunction<_ActivationFunction, _T>
             struct FixedMLPL {
                 static_assert(_InputCount, "_InputCount must be greater than 0.");
                 static_assert(_OutputCount, "_OutputCount must be greater than 0.");
@@ -60,7 +62,7 @@ namespace bcuda {
                 using this_t = FixedMLPL<_T, _ActivationFunction, _InputCount, _OutputCount>;
             public:
                 using element_t = _T;
-                static constexpr activationFunction_t<_T> activationFunction = _ActivationFunction;
+                static constexpr auto activationFunction = _ActivationFunction;
                 static constexpr size_t inputCount = _InputCount;
                 static constexpr size_t outputCount = _OutputCount;
 
@@ -205,15 +207,17 @@ namespace bcuda {
                     BSerializer::DeserializeArray(Data, obj.bias, _OutputCount);
                 }
             };
-            template <std::floating_point _T, activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+            template <std::floating_point _T, auto _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t... _LayerCounts>
+                requires ai::IsActivationFunction<_ActivationFunction, _T>
             struct FixedMLP;
-            template <std::floating_point _T, activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+            template <std::floating_point _T, auto _ActivationFunction, size_t _InputCount, size_t _Output1Count, size_t _Output2Count, size_t... _ContinuedOutputCounts>
+                requires ai::IsActivationFunction<_ActivationFunction, _T>
             struct FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...> {
             private:
                 using this_t = FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>;
             public:
                 using element_t = _T;
-                static constexpr activationFunction_t<_T> activationFunction = _ActivationFunction;
+                static constexpr auto activationFunction = _ActivationFunction;
                 template <size_t _Index>
                 static constexpr size_t widthAt = details::getIntsByIndex<_Index, _InputCount, _Output1Count, _Output2Count, _ContinuedOutputCounts...>::value;
                 template <size_t _Index>
@@ -323,13 +327,14 @@ namespace bcuda {
                     BSerializer::Deserialize<FixedMLP<_T, _ActivationFunction, _Output1Count, _Output2Count, _ContinuedOutputCounts...>>(Data, &obj.nextLayers);
                 }
             };
-            template <std::floating_point _T, activationFunction_t<_T> _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+            template <std::floating_point _T, auto _ActivationFunction, size_t _InputCount, size_t _Output1Count>
+                requires ai::IsActivationFunction<_ActivationFunction, _T>
             struct FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count> {
             private:
                 using this_t = FixedMLP<_T, _ActivationFunction, _InputCount, _Output1Count>;
             public:
                 using element_t = _T;
-                static constexpr activationFunction_t<_T> activationFunction = _ActivationFunction;
+                static constexpr auto activationFunction = _ActivationFunction;
                 template <size_t _Index>
                 static constexpr size_t widthAt = details::getIntsByIndex<_Index, _InputCount, _Output1Count>::value;
                 template <size_t _Index>

--- a/ai_mlpb_fixedmlpb.h
+++ b/ai_mlpb_fixedmlpb.h
@@ -112,13 +112,13 @@ namespace bcuda {
                     bias = bcuda::rand::RandomizeWMutations(bias, BiasProbOf1, RNG);
                 }
 #endif
-                __host__ __device__ inline _TOutput Run(_TInput Input) const {
+                __host__ __device__ inline constexpr _TOutput Run(_TInput Input) const {
                     _TOutput o = bias;
                     for (size_t i = 0; i < details::bitCount<_TOutput>; ++i)
                         if (Input & weights[i]) o |= ((_TOutput)1) << i;
                     return o;
                 }
-                __host__ __device__ inline uint64_t RunG(uint64_t Input) const {
+                __host__ __device__ inline constexpr uint64_t RunG(uint64_t Input) const {
                     return (uint64_t)Run((_TInput)Input);
                 }
 
@@ -205,10 +205,10 @@ namespace bcuda {
                 template <KernelCurandState _TRNG>
                 __device__ inline void RandomizeWMutations(uint32_t WeightsMutationProb, uint32_t WeightsProbOf1, uint32_t BiasMutationProb, uint32_t BiasProbOf1, _TRNG& RNG);
 #endif
-                __host__ __device__ inline output_t Run(_TInput Input) const {
+                __host__ __device__ inline constexpr output_t Run(_TInput Input) const {
                     return (output_t)RunG((uint64_t)Input);
                 }
-                __host__ __device__ inline uint64_t RunG(uint64_t Input) const {
+                __host__ __device__ inline constexpr uint64_t RunG(uint64_t Input) const {
                     Input = layer.RunG(Input);
                     Input = nextLayers.RunG(Input);
                     return Input;
@@ -301,10 +301,10 @@ namespace bcuda {
                     layer.RandomizeWMutations(WeightsMutationProb, WeightsProbOf1, BiasMutationProb, BiasProbOf1, RNG);
                 }
 #endif
-                __host__ __device__ inline output_t Run(_TInput Input) const {
+                __host__ __device__ inline constexpr output_t Run(_TInput Input) const {
                     return (output_t)RunG((uint64_t)Input);
                 }
-                __host__ __device__ inline uint64_t RunG(uint64_t Input) const {
+                __host__ __device__ inline constexpr uint64_t RunG(uint64_t Input) const {
                     Input = layer.RunG(Input);
                     return Input;
                 }


### PR DESCRIPTION
Adding compile-time functions or functionality to structs `bcuda::ai::mlp::FixedMLP` and `bcuda::ai::mlpb::FixedMLPB`. As part of this, the activation function for `bcuda::ai::mlp::FixedMLP` had to be expanded for more complex functions, such as `constexpr` ones.