### PR TITLE
Fixed bugs in headers

### DIFF
--- a/ai_evol_eval_output_impl_uniquevalues.h
+++ b/ai_evol_eval_output_impl_uniquevalues.h
@@ -15,7 +15,7 @@ namespace bcuda {
                         bool individual;
                         void* sd_ci;
                         inline constexpr Evaluate_UniqueValues_SD()
-                            : InstanceFunctions(), iterationCount(0), outputCount(0), individual(0), sd_ci(0) { }
+                            : instanceFunctions(), iterationCount(0), outputCount(0), individual(0), sd_ci(0) { }
                     };
 
                     template <typename _T>

--- a/ai_genetics_genefixedmlp.h
+++ b/ai_genetics_genefixedmlp.h
@@ -79,25 +79,25 @@ namespace bcuda {
                 }
                 template <std::uniform_random_bit_generator _TRNG>
                 inline this_t Reproduce(_T Scalar, _TRNG& RNG) {
-                    this_t n = Clone();
+                    this_t n = *this;
                     n.Randomize(Scalar, RNG);
                     return n;
                 }
                 template <std::uniform_random_bit_generator _TRNG>
                 inline this_t Reproduce(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
-                    this_t n = Clone();
+                    this_t n = *this;
                     n.Randomize(Scalar, LowerBound, UpperBound, RNG);
                     return n;
                 }
                 template <std::uniform_random_bit_generator _TRNG>
                 inline this_t Reproduce(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
-                    this_t n = Clone();
+                    this_t n = *this;
                     n.Randomize(Scalar_Base, Scalar_MLP, RNG);
                     return n;
                 }
                 template <std::uniform_random_bit_generator _TRNG>
                 inline this_t Reproduce(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
-                    this_t n = Clone();
+                    this_t n = *this;
                     n.Randomize(Scalar_Base, Scalar_MLP, LowerBound, UpperBound, RNG);
                     return n;
                 }
@@ -124,25 +124,25 @@ namespace bcuda {
                 }
                 template <KernelCurandState _TRNG>
                 __device__ inline this_t Reproduce(_T Scalar, _TRNG& RNG) {
-                    this_t n = Clone();
+                    this_t n = *this;
                     n.Randomize(Scalar, RNG);
                     return n;
                 }
                 template <KernelCurandState _TRNG>
                 __device__ inline this_t Reproduce(_T Scalar, _T LowerBound, _T UpperBound, _TRNG& RNG) {
-                    this_t n = Clone();
+                    this_t n = *this;
                     n.Randomize(Scalar, LowerBound, UpperBound, RNG);
                     return n;
                 }
                 template <KernelCurandState _TRNG>
                 __device__ inline this_t Reproduce(_T Scalar_Base, _T Scalar_MLP, _TRNG& RNG) {
-                    this_t n = Clone();
+                    this_t n = *this;
                     n.Randomize(Scalar_Base, Scalar_MLP, RNG);
                     return n;
                 }
                 template <KernelCurandState _TRNG>
                 __device__ inline this_t Reproduce(_T Scalar_Base, _T Scalar_MLP, _T LowerBound, _T UpperBound, _TRNG& RNG) {
-                    this_t n = Clone();
+                    this_t n = *this;
                     n.Randomize(Scalar_Base, Scalar_MLP, LowerBound, UpperBound, RNG);
                     return n;
                 }

--- a/ai_mlp_fixedmlp.h
+++ b/ai_mlp_fixedmlp.h
@@ -588,7 +588,7 @@ namespace bcuda {
             using element_t = typename _TFixedMLP::element_t;
 
             if constexpr (_TFixedMLP::LayerCount() == 1) {
-                FixedMLPL_Run<decltype(Mlp->layer), false, false>(&Mlp->layer, Inputs, Outputs);
+                ai::mlp::FixedMLPL_Run<decltype(Mlp->layer), false, false>(&Mlp->layer, Inputs, Outputs);
             }
             else {
                 ai::mlp::FixedMLPL_Run<decltype(Mlp->layer), false, false>(&Mlp->layer, Inputs, Intermediate0);

--- a/ai_mlp_fixedmlp.h
+++ b/ai_mlp_fixedmlp.h
@@ -429,17 +429,7 @@ namespace bcuda {
     }
     namespace details {
         template <ai::mlp::IsFixedMLP _TFixedMLP>
-        inline static void FixedMLP_Run(const _TFixedMLP* Mlp, const typename _TFixedMLP::element_t* Inputs, typename _TFixedMLP::element_t* Intermediate0, typename _TFixedMLP::element_t* Intermediate1, typename _TFixedMLP::element_t* Outputs) {
-            using element_t = typename _TFixedMLP::element_t;
-
-            if constexpr (_TFixedMLP::LayerCount() == 1) {
-                FixedMLPL_Run<decltype(Mlp->layer), false, false>(&Mlp->layer, Inputs, Outputs);
-            }
-            else {
-                ai::mlp::FixedMLPL_Run<decltype(Mlp->layer), false, false>(&Mlp->layer, Inputs, Intermediate0);
-                FixedMLP_Run(&Mlp->nextLayers, Intermediate0, Intermediate1, Intermediate0, Outputs);
-            }
-        }
+        inline static void FixedMLP_Run(const _TFixedMLP* Mlp, const typename _TFixedMLP::element_t* Inputs, typename _TFixedMLP::element_t* Intermediate0, typename _TFixedMLP::element_t* Intermediate1, typename _TFixedMLP::element_t* Outputs);
     }
     namespace ai {
         namespace mlp {
@@ -589,6 +579,20 @@ namespace bcuda {
                 using element_t = typename _TFixedMLP::element_t;
 
                 rand::RandomizeArray<false, element_t, _TRNG>(FixedMLP_GetElementSpan(MLP), Scalar, LowerBound, UpperBound, RNG);
+            }
+        }
+    }
+    namespace details {
+        template <ai::mlp::IsFixedMLP _TFixedMLP>
+        inline static void FixedMLP_Run(const _TFixedMLP* Mlp, const typename _TFixedMLP::element_t* Inputs, typename _TFixedMLP::element_t* Intermediate0, typename _TFixedMLP::element_t* Intermediate1, typename _TFixedMLP::element_t* Outputs) {
+            using element_t = typename _TFixedMLP::element_t;
+
+            if constexpr (_TFixedMLP::LayerCount() == 1) {
+                FixedMLPL_Run<decltype(Mlp->layer), false, false>(&Mlp->layer, Inputs, Outputs);
+            }
+            else {
+                ai::mlp::FixedMLPL_Run<decltype(Mlp->layer), false, false>(&Mlp->layer, Inputs, Intermediate0);
+                FixedMLP_Run(&Mlp->nextLayers, Intermediate0, Intermediate1, Intermediate0, Outputs);
             }
         }
     }

--- a/details_fieldbase.h
+++ b/details_fieldbase.h
@@ -73,6 +73,7 @@ namespace bcuda {
 #pragma endregion
 
 #pragma region OperatorInvoke
+#ifdef __CUDACC__
             __device__ inline _T& operator()(uint64_t Idx) const {
                 return *IdxToPtr(Idx);
             }
@@ -84,6 +85,7 @@ namespace bcuda {
             __device__ inline _T& operator()(_Ts... Coords) const {
                 return *CoordsToPtr(typename this_t::vector_t(Coords...));
             }
+#endif
 #pragma endregion
 
 #pragma region CpyAll

--- a/details_fieldbase.h
+++ b/details_fieldbase.h
@@ -259,7 +259,7 @@ namespace bcuda {
                     field.CpyValIn(i, BSerializer::Deserialize<_T>(Data));
                 return field;
             }
-            static inline void Deserialize(const void*& Data, void* Value) requires BSerializer::Serializable<_T> requires BSerializer::Serializable<_T> {
+            static inline void Deserialize(const void*& Data, void* Value) requires BSerializer::Serializable<_T> {
                 new (Value) FieldBase<_T, _DimensionCount>(Deserialize(Data));
             }
         };

--- a/details_fieldbase.h
+++ b/details_fieldbase.h
@@ -20,6 +20,8 @@ namespace bcuda {
         class FieldBase : public DimensionedBase<_DimensionCount> {
             using this_t = FieldBase<_T, _DimensionCount>;
             using basedb_t = DimensionedBase<_DimensionCount>;
+
+            _T* darr;
         public:
 #pragma region Constructors
             __host__ __device__ inline FieldBase(const typename this_t::vector_t& Dimensions)
@@ -260,8 +262,6 @@ namespace bcuda {
             static inline void Deserialize(const void*& Data, void* Value) requires BSerializer::Serializable<_T> requires BSerializer::Serializable<_T> {
                 new (Value) FieldBase<_T, _DimensionCount>(Deserialize(Data));
             }
-        private:
-            _T* darr;
         };
     }
 }

--- a/dimensionedbase.h
+++ b/dimensionedbase.h
@@ -11,6 +11,8 @@ namespace bcuda {
         static_assert(_DimensionCount, "_DimensionCount may not be zero.");
     protected:
         using vector_t = FixedVector<uint32_t, _DimensionCount>;
+    private:
+        vector_t dims;
     public:
         __host__ __device__ inline DimensionedBase(vector_t Dimensions) {
             for (size_t i = 0; i < _DimensionCount; ++i)
@@ -67,7 +69,5 @@ namespace bcuda {
         __host__ __device__ inline uint64_t CoordsToIdx(_Ts... Coords) const {
             return CoordsToIdx(vector_t(Coords...));
         }
-    private:
-        vector_t dims;
     };
 }

--- a/dimensionedbase.h
+++ b/dimensionedbase.h
@@ -59,7 +59,7 @@ namespace bcuda {
         }
 
         __host__ __device__ inline vector_t IdxToCoords(uint64_t Index) const {
-            return bcuda::IndexToCoordinates<uint64_t, uint32_t, _DimensionCount, true>(Dimensions(), Idx);
+            return bcuda::IndexToCoordinates<uint64_t, uint32_t, _DimensionCount, true>(Dimensions(), Index);
         }
         __host__ __device__ inline uint64_t CoordsToIdx(vector_t Coords) const {
             return bcuda::CoordinatesToIndex<uint64_t, uint32_t, _DimensionCount, true>(Dimensions(), Coords);

--- a/fields_field.h
+++ b/fields_field.h
@@ -73,9 +73,11 @@ namespace bcuda {
             __host__ __device__ inline _T* IdxToPtr(uint64_t Idx) {
                 return basefb_t::IdxToPtr(Idx);
             }
+#ifdef __CUDACC__
             __device__ inline _T& IdxToRef(uint64_t Idx) {
                 return basefb_t::IdxToRef(Idx);
             }
+#endif
             __host__ inline thrust::device_reference<_T> IdxToDRef(uint64_t Idx) {
                 return basefb_t::IdxToDRef(Idx);
             }
@@ -87,17 +89,21 @@ namespace bcuda {
             __host__ __device__ inline _T* CoordsToPtr(_Ts... Coords) {
                 return basefb_t::CoordsToPtr(vector_t(Coords...));
             }
+#ifdef __CUDACC__
             __device__ inline _T& CoordsToRef(const vector_t& Coords) {
                 return basefb_t::CoordsToRef(Coords);
             }
+#endif
             __host__ inline thrust::device_reference<_T> CoordsToDRef(const vector_t& Coords) {
                 return basefb_t::CoordsToDRef(Coords);
             }
+#ifdef __CUDACC__
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
             __device__ inline _T& CoordsToRef(_Ts... Coords) {
                 return basefb_t::CoordsToRef(vector_t(Coords...));
             }
+#endif
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
             __host__ inline thrust::device_reference<_T> CoordsToDRef(_Ts... Coords) {
@@ -106,9 +112,11 @@ namespace bcuda {
             __host__ __device__ inline const _T* IdxToPtr(uint64_t Idx) const {
                 return basefb_t::IdxToPtr(Idx);
             }
+#ifdef __CUDACC__
             __device__ inline const _T& IdxToRef(uint64_t Idx) const {
                 return basefb_t::IdxToRef(Idx);
             }
+#endif
             __host__ inline thrust::device_reference<const _T> IdxToDRef(uint64_t Idx) const {
                 return basefb_t::IdxToDRef(Idx);
             }
@@ -120,17 +128,21 @@ namespace bcuda {
             __host__ __device__ inline const _T* CoordsToPtr(_Ts... Coords) const {
                 return basefb_t::CoordsToPtr(vector_t(Coords...));
             }
+#ifdef __CUDACC__
             __device__ inline const _T& CoordsToRef(const vector_t& Coords) const {
                 return basefb_t::CoordsToRef(Coords);
             }
+#endif
             __host__ inline thrust::device_reference<const _T> CoordsToDRef(const vector_t& Coords) const {
                 return basefb_t::CoordsToDRef(Coords);
             }
+#ifdef __CUDACC__
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
             __device__ inline const _T& CoordsToRef(_Ts... Coords) const {
                 return basefb_t::CoordsToRef(vector_t(Coords...));
             }
+#endif
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
             __host__ inline thrust::device_reference<const _T> CoordsToDRef(_Ts... Coords) const {
@@ -142,15 +154,19 @@ namespace bcuda {
             __host__ __device__ inline vector_t PtrToCoords(const _T* Ptr) const {
                 return basefb_t::PtrToCoords(Ptr);
             }
+#ifdef __CUDACC__
             __device__ inline const _T& PtrToRef(const _T* Ptr) const {
                 return basefb_t::PtrToRef(Ptr);
             }
+#endif
             __host__ inline thrust::device_reference<const _T> PtrToDRef(const _T* Ptr) const {
                 return basefb_t::PtrToDRef(Ptr);
             }
+#ifdef __CUDACC__
             __device__ inline _T& PtrToRef(const _T* Ptr) {
                 return basefb_t::PtrToRef(Ptr);
             }
+#endif
             __host__ inline thrust::device_reference<_T> PtrToDRef(const _T* Ptr) {
                 return basefb_t::PtrToDRef(Ptr);
             }
@@ -197,7 +213,6 @@ namespace bcuda {
             __device__ inline _T* RefToPtr(const _T& Ref) {
                 return basefb_t::RefToPtr(Ref);
             }
-#endif
             __device__ inline const _T& operator()(uint64_t Idx) const {
                 return IdxToRef(Idx);
             }
@@ -220,6 +235,7 @@ namespace bcuda {
             __device__ inline _T& operator()(_Ts... Coords) {
                 return CoordsToRef(vector_t(Coords...));
             }
+#endif
             template <bool _CopyFromHost>
             __host__ inline void CpyAllIn(const _T* All) {
                 basefb_t::template CpyAllIn<_CopyFromHost>(All);
@@ -448,17 +464,21 @@ namespace bcuda {
             __host__ __device__ inline _T* CoordsToPtr(_Ts... Coords) const {
                 return basefb_t::CoordsToPtr(vector_t(Coords...));
             }
+#ifdef __CUDACC__
             __device__ inline _T& CoordsToRef(const vector_t& Coords) const {
                 return basefb_t::CoordsToRef(Coords);
             }
+#endif
             __host__ inline thrust::device_reference<_T> CoordsToDRef(const vector_t& Coords) const {
                 return basefb_t::CoordsToDRef(Coords);
             }
+#ifdef __CUDACC__
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
             __device__ inline _T& CoordsToRef(_Ts... Coords) const {
                 return basefb_t::CoordsToRef(vector_t(Coords...));
             }
+#endif
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
             __host__ inline thrust::device_reference<_T> CoordsToDRef(_Ts... Coords) const {
@@ -470,9 +490,11 @@ namespace bcuda {
             __host__ __device__ inline vector_t PtrToCoords(const _T* Ptr) const {
                 return basefb_t::PtrToCoords(Ptr);
             }
+#ifdef __CUDACC__
             __device__ inline _T& PtrToRef(const _T* Ptr) const {
                 return basefb_t::PtrToRef(Ptr);
             }
+#endif
             __host__ inline thrust::device_reference<_T> PtrToDRef(const _T* Ptr) const {
                 return basefb_t::PtrToDRef(Ptr);
             }
@@ -508,7 +530,6 @@ namespace bcuda {
             __device__ inline _T* RefToPtr(const _T& Ref) const {
                 return basefb_t::RefToPtr(Ref);
             }
-#endif
             __device__ inline _T& operator()(uint64_t Idx) const {
                 return IdxToRef(Idx);
             }
@@ -520,6 +541,7 @@ namespace bcuda {
             __device__ inline _T& operator()(_Ts... Coords) const {
                 return CoordsToRef(vector_t(Coords...));
             }
+#endif
             template <bool _CopyFromHost>
             __host__ inline void CpyAllIn(const _T* All) const {
                 basefb_t::template CpyAllIn<_CopyFromHost>(All);
@@ -699,9 +721,11 @@ namespace bcuda {
             __host__ __device__ inline const _T* IdxToPtr(uint64_t Idx) const {
                 return basefb_t::IdxToPtr(Idx);
             }
+#ifdef __CUDACC__
             __device__ inline const _T& IdxToRef(uint64_t Idx) const {
                 return basefb_t::IdxToRef(Idx);
             }
+#endif
             __host__ inline thrust::device_reference<const _T> IdxToDRef(uint64_t Idx) const {
                 return basefb_t::IdxToDRef(Idx);
             }
@@ -713,17 +737,21 @@ namespace bcuda {
             __host__ __device__ inline const _T* CoordsToPtr(_Ts... Coords) const {
                 return basefb_t::CoordsToPtr(vector_t(Coords...));
             }
+#ifdef __CUDACC__
             __device__ inline const _T& CoordsToRef(const vector_t& Coords) const {
                 return basefb_t::CoordsToRef(Coords);
             }
+#endif
             __host__ inline thrust::device_reference<const _T> CoordsToDRef(const vector_t& Coords) const {
                 return basefb_t::CoordsToDRef(Coords);
             }
+#ifdef __CUDACC__
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
             __device__ inline const _T& CoordsToRef(_Ts... Coords) const {
                 return basefb_t::CoordsToRef(vector_t(Coords...));
             }
+#endif
             template <std::convertible_to<uint32_t>... _Ts>
                 requires (sizeof...(_Ts) == _DimensionCount)
             __host__ inline thrust::device_reference<const _T> CoordsToDRef(_Ts... Coords) const {
@@ -735,9 +763,11 @@ namespace bcuda {
             __host__ __device__ inline vector_t PtrToCoords(const _T* Ptr) const {
                 return basefb_t::PtrToCoords(Ptr);
             }
+#ifdef __CUDACC__
             __device__ inline const _T& PtrToRef(const _T* Ptr) const {
                 return basefb_t::PtrToRef(Ptr);
             }
+#endif
             __host__ inline thrust::device_reference<const _T> PtrToDRef(const _T* Ptr) const {
                 return basefb_t::PtrToDRef(Ptr);
             }
@@ -773,7 +803,6 @@ namespace bcuda {
             __device__ inline const  _T* RefToPtr(const _T& Ref) const {
                 return basefb_t::RefToPtr(Ref);
             }
-#endif
             __device__ inline const _T& operator()(uint64_t Idx) const {
                 return IdxToRef(Idx);
             }
@@ -785,6 +814,7 @@ namespace bcuda {
             __device__ inline const _T& operator()(_Ts... Coords) const {
                 return CoordsToRef(vector_t(Coords...));
             }
+#endif
             template <bool _CopyToHost>
             __host__ inline _T* CpyAllOut() const {
                 return basefb_t::template CpyAllOut<_CopyToHost>();

--- a/fields_instance.h
+++ b/fields_instance.h
@@ -45,7 +45,7 @@ namespace bcuda {
             ArrayV<size_t>& il = rv.inputs;
             ArrayV<size_t>& ol = rv.outputs;
 
-            std::uniform_int_distribution<uint32_t> dis(0, f.ValueCount());
+            std::uniform_int_distribution<uint32_t> dis(0, rv.dfield.ValueCount());
 
             for (uint32_t i = 0; i < settings.inputCount; ++i) {
             ContinueInputs:

--- a/fields_mdfield.h
+++ b/fields_mdfield.h
@@ -169,10 +169,10 @@ namespace bcuda {
                 details::MFieldBase<_DimensionCount, _Ts..., _Ts...>(Data, Value);
             }
 
-            inline inline MDField(const this_t&) = default;
-            inline inline MDField(this_t&&) = default;
-            inline inline this_t& operator=(const this_t&) = default;
-            inline inline this_t& operator=(this_t&&) = default;
+            inline MDField(const this_t&) = default;
+            inline MDField(this_t&&) = default;
+            inline this_t& operator=(const this_t&) = default;
+            inline this_t& operator=(this_t&&) = default;
 
             __host__ __device__ inline MDFieldProxy<_DimensionCount, _Ts...> MakeProxy() {
                 return MDFieldProxy<_DimensionCount, _Ts...>(*this);

--- a/packs.h
+++ b/packs.h
@@ -77,14 +77,12 @@ namespace bcuda {
         using bringOutInsideBatch_t = typename details::bringOutBatch<_T>::type_t;
 
         namespace details {
-            template <typename _T>
-            struct isPackSatisfyingAll : std::false_type { };
             template <template <typename> typename _TPredicate, typename... _Ts>
             struct isPackSatisfyingAll : std::bool_constant<_TPredicate<_Ts>::value && ...> { };
         }
 
         template <typename _T, template <typename> typename _TPredicate>
-        concept IsPackAndElementsSatisfy = details::isPackSatisfyingAll<_T>::value;
+        concept IsPackAndElementsSatisfy = details::isPackSatisfyingAll<_TPredicate, _T>::value;
 
         namespace details {
             template <typename... _Ts>

--- a/packs.h
+++ b/packs.h
@@ -67,7 +67,7 @@ namespace bcuda {
             struct bringOutBatch;
             template <typename... _Ts>
             struct bringOutBatch<Pack<_Ts...>> {
-                using type_t = Pack<bringOut<_Ts>, ...>;
+                using type_t = Pack<bringOut<_Ts>...>;
             };
         }
 

--- a/packs.h
+++ b/packs.h
@@ -127,7 +127,7 @@ namespace bcuda {
 
             template <typename _T1, typename _T2, typename... _Ts>
             struct addPacks<_T1, _T2, _Ts...> {
-                using type_t = typename addPacks<addPacks<_T1, _T2>::type_t, _Ts...>::type_t;
+                using type_t = typename addPacks<typename addPacks<_T1, _T2>::type_t, _Ts...>::type_t;
             };
         }
 

--- a/packs.h
+++ b/packs.h
@@ -78,7 +78,7 @@ namespace bcuda {
 
         namespace details {
             template <template <typename> typename _TPredicate, typename... _Ts>
-            struct isPackSatisfyingAll : std::bool_constant<_TPredicate<_Ts>::value && ...> { };
+            struct isPackSatisfyingAll : std::bool_constant<(_TPredicate<_Ts>::value && ...)> { };
         }
 
         template <typename _T, template <typename> typename _TPredicate>
@@ -142,6 +142,6 @@ namespace bcuda {
         }
 
         template <template <typename...> typename _T, IsPack _TPack>
-        using appliedPack_t = typename details::applyPack<_T, _Pack>::type_t;
+        using appliedPack_t = typename details::applyPack<_T, _TPack>::type_t;
     }
 }


### PR DESCRIPTION
Fixed errors and many warnings in headers, including (but possibly not limited to):

* Functions being defined before other functions they call. (This is a result of #30.)
* Modifiers being specified multiple times on the same function.
* `__device__` functions in non-`.cuh` headers not wrapped in `#ifdef __CUDACC__`s.
* One instance of a duplicate `requires` clause. (What?)
* References to other things declared later in the file.
* Missing `typename` keywords and incorrect syntax for variadic templates.