### PR TITLE
Adding compile-time constraints to `RunKernelMLPOverDFieldProxy`

### DIFF
--- a/fields_mlpkernel.h
+++ b/fields_mlpkernel.h
@@ -28,6 +28,8 @@ namespace bcuda {
 
         template <std::floating_point _TFloat, typename _TFieldVal, size_t _DimensionCount, ai::mlp::IsFixedMLP _TMLP>
         void RunKernelMLPOverDFieldProxy(fields::DFieldProxy<_TFieldVal, _DimensionCount> DField, _TMLP* KernelMLP, ptrdiff_t InputThisDiff, size_t InputThisCount, ptrdiff_t InputSharedDiff, size_t InputSharedCount, ptrdiff_t OutputDiff, size_t OutputCount) {
+            static_assert(std::same_as<typename _TMLP::element_t, _TFloat>, "_TMLP is incompatible.");
+            
             constexpr size_t areaCountByDim = details::AreaCountByDimension(_DimensionCount);
             size_t inputCount = InputThisCount + (areaCountByDim - 1) * InputSharedCount;
 


### PR DESCRIPTION
Added compile-time constraints to `RunKernelMLPOverDFieldProxy`. Specifically, just one: a `static_assert` requiring the elements of `_TMLP` to be the same as `_TFloat`.