### PR TITLE
Changed inputs format of MLP kernel runner

### DIFF
--- a/fields_mlpkernel.h
+++ b/fields_mlpkernel.h
@@ -23,15 +23,15 @@ namespace bcuda {
             }
 
             template <std::floating_point _TFloat>
-            void RunKernelMLPOverDField(Span<const size_t> Dimensions, _TFloat* FieldFData, _TFloat* FieldBData, size_t FieldElementSize, _TFloat* KernelMLP, Span<const size_t> HiddenWidths, ai::activationFunction_t<_TFloat> ActivationFunc, ptrdiff_t InputThisDiff, size_t InputThisCount, ptrdiff_t InputSharedDiff, size_t InputSharedCount, ptrdiff_t OutputDiff, size_t OutputCount);
+            void RunKernelMLPOverDField(Span<const size_t> Dimensions, _TFloat* FieldFData, _TFloat* FieldBData, size_t FieldElementSize, _TFloat* KernelMLP, Span<const size_t> HiddenWidths, ai::activationFunction_t<_TFloat> ActivationFunc, ptrdiff_t InputPrivateDiff, size_t InputPrivateCount, ptrdiff_t InputSharedDiff, size_t InputSharedCount, ptrdiff_t OutputDiff, size_t OutputCount);
         }
 
         template <std::floating_point _TFloat, typename _TFieldVal, size_t _DimensionCount, ai::mlp::IsFixedMLP _TMLP>
-        void RunKernelMLPOverDFieldProxy(fields::DFieldProxy<_TFieldVal, _DimensionCount> DField, _TMLP* KernelMLP, ptrdiff_t InputThisDiff, size_t InputThisCount, ptrdiff_t InputSharedDiff, size_t InputSharedCount, ptrdiff_t OutputDiff, size_t OutputCount) {
+        void RunKernelMLPOverDFieldProxy(fields::DFieldProxy<_TFieldVal, _DimensionCount> DField, _TMLP* KernelMLP, ptrdiff_t InputPrivateDiff, size_t InputPrivateCount, ptrdiff_t InputSharedDiff, size_t InputSharedCount, ptrdiff_t OutputDiff, size_t OutputCount) {
             static_assert(std::same_as<typename _TMLP::element_t, _TFloat>, "_TMLP is incompatible.");
             
             constexpr size_t areaCountByDim = details::AreaCountByDimension(_DimensionCount);
-            size_t inputCount = InputThisCount + (areaCountByDim - 1) * InputSharedCount;
+            size_t inputCount = InputPrivateCount + areaCountByDim * InputSharedCount;
 
             if (_TMLP::InputCount() == inputCount) throw std::exception("_TMLP must have an input count of InputThisDiff + (3 ** _DimensionCount - 1) * InputSharedDiff!");
             if (_TMLP::OutputCount() == OutputCount) throw std::exception("_TMLP must have an output count of OutputCount!");
@@ -43,11 +43,11 @@ namespace bcuda {
             details::WriteHiddenWidthsToArray<_TMLP>(hiddenWidths);
             Span<const size_t> hiddenWidthsSpan(hiddenWidths, _TMLP::LayerCount());
 
-            details::RunKernelMLPOverDField<_TFloat>(dimensionsSpan, (_TFloat*)DField.FData(), (_TFloat*)DField.BData(), sizeof(_TFieldVal), (_TFloat*)KernelMLP, hiddenWidthsSpan, _TMLP::activationFunction, InputThisDiff, InputThisCount, InputSharedDiff, InputSharedCount, OutputDiff, OutputCount);
+            details::RunKernelMLPOverDField<_TFloat>(dimensionsSpan, (_TFloat*)DField.FData(), (_TFloat*)DField.BData(), sizeof(_TFieldVal), (_TFloat*)KernelMLP, hiddenWidthsSpan, _TMLP::activationFunction, InputPrivateDiff, InputPrivateCount, InputSharedDiff, InputSharedCount, OutputDiff, OutputCount);
         }
         template <std::floating_point _TFloat, typename _TFieldVal, size_t _DimensionCount, ai::mlp::IsFixedMLP _TMLP>
-        void RunKernelMLPOverDField(fields::DField<_TFieldVal, _DimensionCount>& DField, _TMLP* KernelMLP, ptrdiff_t InputThisDiff, size_t InputThisCount, ptrdiff_t InputSharedDiff, size_t InputSharedCount, ptrdiff_t OutputDiff, size_t OutputCount) {
-            RunKernelMLPOverDFieldProxy<_TFloat, _TFieldVal, _DimensionCount, _TMLP>(DField, KernelMLP, InputThisDiff, InputThisCount, InputSharedDiff, InputSharedCount, OutputDiff, OutputCount);
+        void RunKernelMLPOverDField(fields::DField<_TFieldVal, _DimensionCount>& DField, _TMLP* KernelMLP, ptrdiff_t InputPrivateDiff, size_t InputPrivateCount, ptrdiff_t InputSharedDiff, size_t InputSharedCount, ptrdiff_t OutputDiff, size_t OutputCount) {
+            RunKernelMLPOverDFieldProxy<_TFloat, _TFieldVal, _DimensionCount, _TMLP>(DField, KernelMLP, InputPrivateDiff, InputPrivateCount, InputSharedDiff, InputSharedCount, OutputDiff, OutputCount);
             DField.Reverse();
         }
     }


### PR DESCRIPTION
Renamed parameters `InputThisDiff` and `InputThisCount` to `InputPrivateDiff` and `InputPrivateCount`, respectively. However, they now refer to different things. To illustrate:
```
           InputThis          
┌──────────────┴─────────────┐
┌──────────────┬─────────────┐
│ InputPrivate │ InputShared │
└──────────────┴─────────────┘
```
This will decrease parameters' dependence on each other.