### PR TITLE
Fixing disposal of `bcuda::fields` objects

### DIFF
--- a/details_dfieldbase.h
+++ b/details_dfieldbase.h
@@ -71,6 +71,8 @@ namespace bcuda {
                 ThrowIfBad(cudaFree(darrF));
                 ThrowIfBad(cudaFree(darrB));
 #endif
+                darrF = 0;
+                darrB = 0;
             }
 
 #pragma region CpyAll

--- a/details_fieldbase.h
+++ b/details_fieldbase.h
@@ -211,6 +211,7 @@ namespace bcuda {
 #else
                 ThrowIfBad(cudaFree(darr));
 #endif
+                darr = 0;
             }
 
             __host__ __device__ inline _T* Data() const {

--- a/details_mfieldbase.h
+++ b/details_mfieldbase.h
@@ -128,12 +128,14 @@ namespace bcuda {
 #pragma endregion
 
             __host__ __device__ inline void Dispose() {
-                for (size_t i = 0; i < sizeof...(_Ts); ++i)
+                for (size_t i = 0; i < sizeof...(_Ts); ++i) {
 #ifdef __CUDA_ARCH__
                     free(darrs[i]);
 #else
                     ThrowIfBad(cudaFree(darrs[i]));
 #endif
+                    darrs[i] = 0;
+                }
             }
 
             __host__ __device__ inline this_t Clone() const {


### PR DESCRIPTION
Previously, pointers in field, dfield, or mfield objects retained their values after disposal, meaning that disposing of fields, dfields, or mfield objects more than once could cause a double free. This has now been resolved. Disposing of any `Field`, `DField`, or `MField` object is now completely safe.